### PR TITLE
Switch translation method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+argostranslate
 azure-search-documents
 azure-storage-blob
 beautifulsoup4


### PR DESCRIPTION
Removed asynchronous google translate api. Current translation model (https://github.com/argosopent ech/argos-translate) uses an open source neural machine translation system. Installation is therefore quite hefty and has linear scaling depending on the local system config.