### PR TITLE
Forgotten append to channel

### DIFF
--- a/modules/ibm/feed.py
+++ b/modules/ibm/feed.py
@@ -47,6 +47,8 @@ def query(MAX=settings.ENTRIES):
                     description = description[:396] + ' ...'
                 content += '(' + link + ')'
                 content += '\n>'+ description +'\n'
+            for channel in settings.CHANNELS:
+                items.append([channel, content])
             count += 1
         except IndexError:
             return items # No more items


### PR DESCRIPTION
Removed the item.append when fixing the external reference [here](https://github.com/uforia/MatterBot/pull/90/commits/20007d7ae4aac16a222615bfddeff611947dc389#diff-641e7292e4bd3c4a4876999d32e85944e4f22c9bba2eb0ce2e829022306b0ec7L48-L49). No articles were posted by the IBM X-Force module in the meantime. This has now been put back in place. Added missing articles via manual bulk insert.