### PR TITLE
Add websocket reconnect loop with exponential backoff

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -11,6 +11,7 @@ import os
 import pathlib
 import re
 import sys
+import time
 import traceback
 import configargparse
 from mattermostdriver import Driver
@@ -98,8 +99,32 @@ class MattermostManager(object):
                 self.commands[module_name]['process'] = getattr(module, 'process')
                 self.commands[module_name]['help'] = HELP
         self.binds = sorted(list(set(self.binds)))
-        # Start the websocket
-        self.mmDriver.init_websocket(self.handle_raw_message)
+
+    def run_forever(self):
+        """Drive the Mattermost websocket, reconnecting on disconnect with
+        exponential backoff. Without this loop, any websocket termination
+        (network blip, MM restart, idle timeout) causes init_websocket to
+        return and the process to exit silently."""
+        backoff = 1.0
+        max_backoff = 60.0
+        healthy_after = 60.0  # a connection that lasted this long resets backoff
+        while True:
+            connected_at = time.monotonic()
+            try:
+                log.info("Connecting Mattermost websocket")
+                self.mmDriver.init_websocket(self.handle_raw_message)
+                log.warning("Websocket loop returned (server closed connection?)")
+            except KeyboardInterrupt:
+                log.info("Interrupted — exiting")
+                raise
+            except Exception:
+                log.exception("Websocket loop crashed")
+            if time.monotonic() - connected_at >= healthy_after:
+                backoff = 1.0
+            else:
+                backoff = min(backoff * 2, max_backoff)
+            log.info(f"Reconnecting websocket in {backoff:.1f}s")
+            time.sleep(backoff)
 
     def load_bindmap(self):
         try:
@@ -774,3 +799,4 @@ if __name__ == '__main__' :
     log = logging.getLogger('MatterBot')
     log.info('Starting MatterBot')
     mm = MattermostManager()
+    mm.run_forever()


### PR DESCRIPTION
## Summary

`init_websocket(self.handle_raw_message)` was called once at the end of `__init__` and blocked there. On any websocket termination — network blip, Mattermost server restart, idle disconnect — the call simply returned, `__init__` finished, and the process exited silently. The bot had no resilience to transient disconnects.

This PR extracts the websocket call into a new `run_forever()` method with an exponential-backoff reconnect loop, and updates `__main__` to call it.

- Backoff: 1s → 60s cap, doubling on each failure.
- Connections that survive ≥60s are considered healthy and reset the backoff.
- `KeyboardInterrupt` still propagates so `Ctrl-C` exits cleanly.
- Other exceptions are logged via `log.exception()` (full traceback) and retried.

## Diff shape

32 lines, single file. `__init__` no longer blocks on the websocket — the loop lives in `run_forever()`. The driver, login, channel map, feed map, and module loading remain in `__init__` unchanged.

## Compatibility

The entry point in `__main__` is updated to call `mm.run_forever()` after construction. Anyone embedding `MattermostManager` directly will need to call `run_forever()` themselves — previously the websocket started implicitly.

## Out of scope (follow-ups)

- Refreshing `self.channels` / `self.feedmap` after long disconnects (REST caches go stale).
- `SIGTERM` handler for graceful drain.
- Admin alert after N consecutive fast failures (currently logs only).
- Re-login if the driver's session token becomes invalid (rare with PATs).

## Test plan

- [ ] Start the bot, confirm websocket connects, fast commands respond as before.
- [ ] `docker restart mattermost` (or kill the WS at the network layer) — bot logs the disconnect, sleeps, reconnects, resumes processing without operator intervention.
- [ ] Force repeated fast failures (e.g. point to a bad host) — backoff doubles up to 60s cap; logs are clear.
- [ ] `Ctrl-C` during run — process exits cleanly without retry-spam.
- [ ] Soak overnight with intermittent network — bot is still alive in the morning.