### PR TITLE
Handle SIGTERM with a graceful drain

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -10,6 +10,7 @@ import logging
 import os
 import pathlib
 import re
+import signal
 import sys
 import time
 import traceback
@@ -99,6 +100,15 @@ class MattermostManager(object):
                 self.commands[module_name]['process'] = getattr(module, 'process')
                 self.commands[module_name]['help'] = HELP
         self.binds = sorted(list(set(self.binds)))
+        # Translate SIGTERM (docker stop, systemctl stop, k8s pod termination)
+        # into a KeyboardInterrupt in the main thread, so the existing
+        # interrupt path in run_forever drains in-flight work and exits cleanly
+        # instead of being SIGKILL'd 10s later.
+        signal.signal(signal.SIGTERM, self._on_terminate)
+
+    def _on_terminate(self, signum, frame):
+        log.info(f"Received {signal.Signals(signum).name} — initiating graceful drain")
+        raise KeyboardInterrupt
 
     def run_forever(self):
         """Drive the Mattermost websocket, reconnecting on disconnect with
@@ -108,23 +118,35 @@ class MattermostManager(object):
         backoff = 1.0
         max_backoff = 60.0
         healthy_after = 60.0  # a connection that lasted this long resets backoff
-        while True:
-            connected_at = time.monotonic()
-            try:
-                log.info("Connecting Mattermost websocket")
-                self.mmDriver.init_websocket(self.handle_raw_message)
-                log.warning("Websocket loop returned (server closed connection?)")
-            except KeyboardInterrupt:
-                log.info("Interrupted — exiting")
-                raise
-            except Exception:
-                log.exception("Websocket loop crashed")
-            if time.monotonic() - connected_at >= healthy_after:
-                backoff = 1.0
-            else:
-                backoff = min(backoff * 2, max_backoff)
-            log.info(f"Reconnecting websocket in {backoff:.1f}s")
-            time.sleep(backoff)
+        try:
+            while True:
+                connected_at = time.monotonic()
+                try:
+                    log.info("Connecting Mattermost websocket")
+                    self.mmDriver.init_websocket(self.handle_raw_message)
+                    log.warning("Websocket loop returned (server closed connection?)")
+                except KeyboardInterrupt:
+                    raise
+                except Exception:
+                    log.exception("Websocket loop crashed")
+                if time.monotonic() - connected_at >= healthy_after:
+                    backoff = 1.0
+                else:
+                    backoff = min(backoff * 2, max_backoff)
+                log.info(f"Reconnecting websocket in {backoff:.1f}s")
+                time.sleep(backoff)
+        except KeyboardInterrupt:
+            log.info("Interrupt received — draining in-flight work")
+        finally:
+            # Drain the command thread pool (added by the call_module executor
+            # PR) so any in-flight module handlers can complete instead of
+            # being abandoned mid-write. The outer asyncio.timeout(30) bounds
+            # each task, so total drain is capped near 30s.
+            executor = getattr(self, '_command_executor', None)
+            if executor is not None:
+                log.info("Waiting for command executor to drain")
+                executor.shutdown(wait=True, cancel_futures=True)
+            log.info("Exit")
 
     def load_bindmap(self):
         try:


### PR DESCRIPTION
**Stacked on #153** (`fix/websocket-reconnect`). Merge #153 first; review here only the new commit.

## Summary

SIGTERM — the signal sent by `docker stop`, `systemctl stop`, and Kubernetes pod termination — was handled by Python's default: instant process kill. In-flight module handlers were abandoned mid-write, shelve state could be left half-flushed, and the user got no response to commands that were one HTTP call away from returning.

This PR installs a SIGTERM handler that raises `KeyboardInterrupt` in the main thread, piggy-backing on the interrupt path #153 just added. `run_forever()`'s main loop is wrapped in `try/finally` so the cleanup path runs on any exit (SIGINT, SIGTERM, or unexpected exception).

In the `finally`, the command thread pool (added by #152) is drained: queued-but-not-started tasks are cancelled, in-flight tasks are awaited to completion.

- The outer `asyncio.timeout(30)` from `handle_post` bounds each task, so total drain time is capped near ~30s.
- The executor lookup uses `getattr(self, '_command_executor', None)`, so this PR works whether #152 is merged or not.

## Operator note

If your `docker stop -t <N>` grace window is < ~35s, you may want to bump it. Otherwise Docker SIGKILLs the process before the drain completes and you're back to the old behaviour for any in-flight long command.

## Out of scope (follow-ups)

- Flushing shelve / feedmap state explicitly (currently relies on module-side cleanup which is best-effort).
- Admin alert on drain (currently log-only).
- Pre-init signals: signals arriving before construction finishes still hit Python's default and may be swallowed by pre-existing bare `except:` clauses. Cleaning up the bare-excepts is tracked separately in the production readiness report.

## Test plan

- [ ] Start the bot, `kill -TERM <pid>` from another shell — bot logs `Received SIGTERM`, drains, exits 0. Verify no stack traces.
- [ ] Start bot, run a slow command (~25s), immediately `docker stop` — slow command's response still posts to channel before exit.
- [ ] Start bot, run 30 commands fast, `docker stop` — the 8 in-flight finish; the 22 queued are cancelled; exit time ~30s max.
- [ ] `Ctrl-C` still exits cleanly (same path).
- [ ] Bot under load + `kill -TERM` repeatedly under restart-loop simulation — no zombie threads.