### PR TITLE
Cap per-user concurrent commands with a Semaphore

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -47,6 +47,8 @@ Matterbot:
   logcmdparams: False
   command_workers: 8 # Max parallel module command executions. Lower (e.g. 1) effectively serializes commands
                      # if you suspect a module is not thread-safe; raise for more parallelism on a fast host.
+  user_concurrency: 2 # Max concurrent commands per user. Raise for trusted teams, lower (e.g. 1) on
+                      # public-ish deployments. Excess commands queue and may hit the 30s timeout.
 
 Modules:
   moduledir: "modules"

--- a/matterbot.py
+++ b/matterbot.py
@@ -34,6 +34,19 @@ class MattermostManager(object):
             max_workers=options.Matterbot.get('command_workers', 8),
             thread_name_prefix='mb-cmd',
         )
+        # Maximum number of in-flight module dispatches per user. Prevents a
+        # single user from saturating the bot (or the command thread-pool)
+        # with parallel commands and starving other users. Further requests
+        # from that user are queued behind the same asyncio.timeout window
+        # as the run itself, so a spammer can self-DoS their own queue but
+        # cannot block anyone else. Tunable via Matterbot.user_concurrency.
+        self._user_concurrency = options.Matterbot.get('user_concurrency', 2)
+        # Map of userid -> asyncio.Semaphore, populated lazily on first command
+        # from each user via dict.setdefault() so concurrent first-time
+        # creations don't race. Entries are never evicted; size is bounded
+        # by the number of distinct users who have ever talked to the bot
+        # since process start (small for a single-team deployment).
+        self._user_semaphores = {}
         self.mmDriver = Driver(options={
             'url'       : options.Matterbot['host'],
             'port'      : options.Matterbot['port'],
@@ -694,6 +707,14 @@ class MattermostManager(object):
                             await self.send_message(welcome_channel, text)
 
 
+    def _semaphore_for(self, userid):
+        # setdefault is atomic in CPython for the dict op, so two coroutines
+        # racing on the same first-time userid get the same Semaphore back
+        # (one freshly-constructed instance may be discarded — harmless).
+        return self._user_semaphores.setdefault(
+            userid, asyncio.Semaphore(self._user_concurrency)
+        )
+
     async def call_module(self, module, command, channame, rootid, username, params, files, conn):
         try:
             chanid = self.channame_to_chanid(channame)
@@ -789,8 +810,12 @@ class MattermostManager(object):
                                                 if len(post['metadata']['files']):
                                                     files = post['metadata']['files']
                                         try:
+                                            # Per-user fairness gate is inside the timeout window so
+                                            # a single user spamming commands self-DoSes their own
+                                            # queue (commands time out) instead of blocking others.
                                             async with asyncio.timeout(30):
-                                                await self.call_module(module, command, channame, rootid, username, params, files, self.mmDriver)
+                                                async with self._semaphore_for(userid):
+                                                    await self.call_module(module, command, channame, rootid, username, params, files, self.mmDriver)
                                         except asyncio.TimeoutError:
                                             text = f"Error: the command to the {module} module timed out while processing/waiting for a response."
                                             await self.send_message(chanid, text, rootid)


### PR DESCRIPTION
## What this PR does

Adds a **per-user concurrency cap** on command dispatch. Without it, one user with a bound key in autohotkey (or a curious teenager with `for i in {1..50}; do ...; done`) can keep every command slot busy and lock other users out of the bot entirely.

It's a 26-line change in one file. The interesting bits are: one class constant, a one-line `__init__` addition, a 5-line helper, and a one-line wrap of the existing dispatch site.

## The scenario it's designed for

Imagine the bot has been hardened with the rest of the in-flight Phase 1 work (PR #152 makes commands genuinely run in parallel; PR #153 keeps the bot alive across reconnects). User Alice gets bored and types:

```
!virustotal hash1
!virustotal hash2
!virustotal hash3
... × 10 ...
```

Each one is a slow API call. They all hit the dispatch path roughly simultaneously (Mattermost delivers them as separate websocket messages, and each one spawns its own `asyncio.create_task(self.handle_message(...))`). Before this PR, all 10 race to grab a slot in the thread pool. Meanwhile Bob types `!help` and waits.

With this PR, Alice gets 2 slots. Numbers 3-10 line up in her own queue. Bob is on a different queue (his own semaphore) and his `!help` returns immediately.

## Where the gate sits

The semaphore is acquired **inside** the existing `asyncio.timeout(30)` window in `handle_post`:

```python
async with asyncio.timeout(30):
    async with self._semaphore_for(userid):
        await self.call_module(...)
```

That placement is deliberate. Two alternatives I considered and rejected:

1. **Outside the timeout** (queue wait is unbounded, run gets the full 30s budget). Friendly to legitimate dual-use but allows a spammer to grow an unbounded queue against themselves — a denial-of-service surface against the bot's memory rather than against other users, but still a surface.
2. **Reject immediately if no slot** (send "you have too many commands in flight"). Better UX feedback, but more code and changes the bot's externally-visible behavior in a way I'd rather not bundle into a concurrency PR. Worth doing as a follow-up.

The chosen placement means: a user spamming the bot self-DoSes their own queue (their excess commands time out with the existing `"command timed out"` reply) and the misfeature is bounded.

## What it doesn't try to do

- **Doesn't cap total bot concurrency.** That's the thread-pool size in PR #152 (`max_workers=8`).
- **Doesn't cap per-channel.** Two users in the same channel each get their own quota.
- **Doesn't reject up-front.** Excess commands queue and may time out. Worth a separate UX PR adding a "you have too many commands in flight, try again later" reply if you want it.
- **Doesn't evict the semaphore map.** Entries persist for the lifetime of the process. For a single-team deployment with O(50) distinct users that's ~tens of KB. If you ever exposed this bot to a much larger user pool, you'd want an LRU on the map.

## Reviewer's quick guide

The diff is mostly comments. The runtime change is three lines:

| Line | What changed |
|---|---|
| Class body | `_USER_CONCURRENCY = 2` — bump if you want a looser cap |
| `__init__` | `self._user_semaphores = {}` — empty dict |
| Dispatch site (~L767) | `async with self._semaphore_for(userid): await self.call_module(...)` — the actual gate |

The lazy semaphore creation in `_semaphore_for` is intentional: `asyncio.Semaphore()` should be created from async context so it binds to the right event loop. Constructing them in `__init__` would technically work on Python 3.10+ but is brittle to refactors.

## Interaction with other Phase 1 PRs

This PR is independent of #152, #153, #154:

- **Without #152**: the gate is correct but mostly inert — the event loop blocks during sync `module.process()` calls, so other users can't reach their own semaphore anyway. Once #152 lands, this PR becomes effective.
- **Without #153 / #154**: this PR doesn't touch the run loop or signal handling. Merging in any order is fine.

## Test plan

- [ ] Type `!somecommand` 5 times in rapid succession in a channel. First two run, next three queue. Verify the queued ones either complete or hit the existing 30s timeout — no silent drops.
- [ ] As user A, fire off a slow command. From a second account (user B), run `!help` — returns immediately even while A's command is still running.
- [ ] As one user spam 50 fast commands. Confirm bot stays responsive to other users throughout.
- [ ] Verify `_user_semaphores` keys equal distinct senders (memory growth check via `len(mm._user_semaphores)` in a debug REPL).