### PR TITLE
Log a warning when a command hits the 30s timeout

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -750,6 +750,10 @@ class MattermostManager(object):
                                             async with asyncio.timeout(30):
                                                 await self.call_module(module, command, channame, rootid, username, params, files, self.mmDriver)
                                         except asyncio.TimeoutError:
+                                            log.warning(
+                                                f"Command timed out: module={module} command={command} "
+                                                f"user={username} channel={channame}"
+                                            )
                                             text = f"Error: the command to the {module} module timed out while processing/waiting for a response."
                                             await self.send_message(chanid, text, rootid)
 


### PR DESCRIPTION
## Summary

The `asyncio.TimeoutError` branch in `handle_post` was silently sending only the user-facing `"command timed out"` reply with no operator-visible signal. Add a WARNING-level log line with module, command, user, and channel so operators can see which commands are hitting the 30s cap and which users are triggering them.

4-line change in one file.

## Why now

This is the observability companion to PR #152 (executor for `module.process`). Before #152 the `asyncio.timeout(30)` wrapper silently no-op'd because no `await` ever yielded inside it — the timeout could never fire and so this log line would never trigger. After #152 lands, the timeout actually fires, and this log line gives operators a real signal that the path is engaged.

Useful on its own even without #152 — but most valuable in combination.

## Out of scope

- Counting / rate-limiting noisy timeout offenders. Operators can grep the log if needed.
- Surfacing to a metrics endpoint. The bot has no metrics layer currently.

## Test plan

- [ ] With #152 merged, run a command that takes >30s. Verify channel reply *and* a `WARNING - MatterBot - ... - Command timed out: module=... command=... user=... channel=...` line in `matterfeed.log`.
- [ ] Verify the line contains all four fields (module, command, user, channel) and is shaped suitably for `grep`/`awk`.