### PR TITLE
Add timeout=(10, 30) to every requests.* callsite

### DIFF
--- a/commands/abuseipdb/command.py
+++ b/commands/abuseipdb/command.py
@@ -65,7 +65,7 @@ def process(command, channel, username, params, files, conn):
                         querystring[querytype] = ip
                     if maxAge:
                         querystring['maxAgeInDays'] = maxAge
-                    with requests.get(url,headers=headers,params=querystring) as response:
+                    with requests.get(url,headers=headers,params=querystring, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if 'data' in json_response:
                             reportCategories = {

--- a/commands/alienvault/command.py
+++ b/commands/alienvault/command.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import concurrent.futures
 import re
 import requests
 import traceback
@@ -76,14 +77,14 @@ def process(command, channel, username, params, files, conn):
                     endpoints = ('file/'+query+'/analysis',)
                 if querytype in ('url'):
                     endpoints = ('url/'+query+'/url_list',)
-                for endpoint in endpoints:
+                def _fetch_endpoint(endpoint):
                     APIENDPOINT = settings.APIURL['alienvault']['url']+endpoint+'?limit=10'
                     with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                         message = ''
                         try:
                             json_response = response.json()
                         except:
-                            continue
+                            return None
                         geofields = {
                             'asn': 'ASN',
                             'city': 'City',
@@ -170,7 +171,17 @@ def process(command, channel, username, params, files, conn):
                                                         message += '\n| **Families** | `%s` |' % '`, `'.join(sorted(families))
                         if len(message):
                             table = '| **AlienVault OTX** | **'+query+'** |\n| -: | :- |'+message+'\n\n'
-                            messages.append({'text': table})
+                            return {'text': table}
+                        return None
+                with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(endpoints), 6)) as pool:
+                    futures = [pool.submit(_fetch_endpoint, endpoint) for endpoint in endpoints]
+                    for fut in concurrent.futures.as_completed(futures):
+                        try:
+                            result = fut.result()
+                        except Exception:
+                            continue
+                        if result:
+                            messages.append(result)
     except Exception as e:
         messages.append({'text': 'A Python error occurred searching AlienVault OTX:%s\n%s' % (str(e), traceback.format_exc())})
     finally:

--- a/commands/alienvault/command.py
+++ b/commands/alienvault/command.py
@@ -78,7 +78,7 @@ def process(command, channel, username, params, files, conn):
                     endpoints = ('url/'+query+'/url_list',)
                 for endpoint in endpoints:
                     APIENDPOINT = settings.APIURL['alienvault']['url']+endpoint+'?limit=10'
-                    with requests.get(APIENDPOINT, headers=headers) as response:
+                    with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                         message = ''
                         try:
                             json_response = response.json()

--- a/commands/argostrans/command.py
+++ b/commands/argostrans/command.py
@@ -44,7 +44,7 @@ def process(command, channel, username, params, files, conn):
                 url = settings.PACKAGES
 
                 # Request data from the API
-                response = requests.get(url)
+                response = requests.get(url, timeout=(10, 30))
                 response.raise_for_status()
 
                 json_response = response.json()

--- a/commands/asnwhois/command.py
+++ b/commands/asnwhois/command.py
@@ -42,7 +42,7 @@ def process(command, channel, username, params, files, conn):
                     'User-Agent': 'MatterBot integration for ASNWHOIS v0.1'
                 }
                 url = settings.APIURL['asnwhois']['url']+f"{data}"
-                with requests.get(settings.APIURL['asnwhois']['url']+f"{data}", headers=headers) as response:
+                with requests.get(settings.APIURL['asnwhois']['url']+f"{data}", headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     message = 'ASN WHOIS lookup for `%s`: ' % (data,)
                     if 'data' in json_response:
@@ -60,7 +60,7 @@ def process(command, channel, username, params, files, conn):
                             lat = str(jsondata['latitude'])
                             long = str(jsondata['longitude'])
                             gpsurl = settings.APIURL['osmdata']['url']+f"lat={lat}&lon={long}&format=json"
-                            with requests.get(gpsurl, headers=headers) as response:
+                            with requests.get(gpsurl, headers=headers, timeout=(10, 30)) as response:
                                 json_response = response.json()
                                 if 'display_name' in json_response:
                                     address = json_response['display_name']

--- a/commands/attackmatrix/command.py
+++ b/commands/attackmatrix/command.py
@@ -56,7 +56,7 @@ def process(command, channel, username, params, files, conn):
                 }
                 if querytype in ('matrices', 'config'):
                     APIENDPOINT = settings.APIURL['attackmatrix']['url']+'/explore/'
-                    with requests.get(APIENDPOINT, headers=headers) as response:
+                    with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if len(json_response):
                             table = 'ATT&CK Matrix API endpoint currently has ' + str(len(json_response['Metadata']['matrices'])) + ' databases loaded:'
@@ -72,7 +72,7 @@ def process(command, channel, username, params, files, conn):
                 if querytype == 'search':
                     searchterms = '&params='.join([urllib.parse.quote(_) for _ in keywords])
                     APIENDPOINT = settings.APIURL['attackmatrix']['url']+'/search?params='+searchterms
-                    with requests.get(APIENDPOINT, headers=headers) as response:
+                    with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if json_response != 'null':
                             if 'count' in json_response:
@@ -105,7 +105,7 @@ def process(command, channel, username, params, files, conn):
                     mitreid = keywords[0].upper().strip()
                     for category in categories:
                         APIENDPOINT = settings.APIURL['attackmatrix']['url']+'/explore/'+category+'/'+mitreid
-                        with requests.get(APIENDPOINT, headers=headers) as response:
+                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                             json_response = response.json()
                             result = False
                             if len(json_response)>0:
@@ -146,7 +146,7 @@ def process(command, channel, username, params, files, conn):
                     if re.search(r"[\w\s,.\+\-]+", searchterms):
                         text = None
                         APIENDPOINT = settings.APIURL['attackmatrix']['url']+'/actoroverlap?actors='+searchterms
-                        with requests.get(APIENDPOINT, headers=headers) as response:
+                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if len(json_response)>0:
                                 if 'error' in json_response:
@@ -180,7 +180,7 @@ def process(command, channel, username, params, files, conn):
                                     for actor in keywords:
                                         actorttps[actor] = {}
                                         APIENDPOINT = settings.APIURL['attackmatrix']['url']+'/explore/Actors/'+actor
-                                        with requests.get(APIENDPOINT, headers=headers) as response:
+                                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                                             json_response = response.json()
                                             for commonttpcategory in commonttps:
                                                 if commonttpcategory in commonttps:
@@ -265,7 +265,7 @@ def process(command, channel, username, params, files, conn):
                     if re.search(r"[\w\s,.\+\-]+", searchterms):
                         text = None
                         APIENDPOINT = settings.APIURL['attackmatrix']['url']+'/ttpoverlap?ttps='+searchterms
-                        with requests.get(APIENDPOINT, headers=headers) as response:
+                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if len(json_response)>0:
                                 count = len(json_response)
@@ -416,7 +416,7 @@ def process(command, channel, username, params, files, conn):
                     if len(keywords)>2:
                         if re.search(r"[\w\s,.\+\-]+", searchterms):
                             APIENDPOINT = settings.APIURL['attackmatrix']['url']+'/findactor?ttps='+searchterms
-                            with requests.get(APIENDPOINT, headers=headers) as response:
+                            with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                                 json_response = response.json()
                                 if len(json_response)>0:
                                     count = json_response['count']

--- a/commands/bootloaders/command.py
+++ b/commands/bootloaders/command.py
@@ -41,7 +41,7 @@ def process(command, channel, username, params, files, conn):
             }
             query = params[0]
             if query == 'rebuildcache' or not Path(settings.CACHE).is_file():
-                with requests.get(settings.APIURL['bootloaders']['url'], headers=headers) as response:
+                with requests.get(settings.APIURL['bootloaders']['url'], headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         with open(settings.CACHE, mode='w') as f:
@@ -159,7 +159,7 @@ def process(command, channel, username, params, files, conn):
                                         type = Detection['type'].replace('_',' ').title()
                                         url = Detection['value']
                                         try:
-                                            with requests.get(url) as response:
+                                            with requests.get(url, timeout=(10, 30)) as response:
                                                 uploads.append({'filename': Path(url).name, 'bytes': b'xxxx'})
                                                 filenames.append(Path(url).name)
                                         except:

--- a/commands/botscout/command.py
+++ b/commands/botscout/command.py
@@ -43,7 +43,7 @@ def process(command, channel, username, params, files, conn):
             url = settings.APIURL['botscout']['url']+f"{query}"
             if settings.APIURL['botscout']['key']:
                 url += f"&key={settings.APIURL['botscout']['key']}"
-            with requests.get(url, headers=headers) as response:
+            with requests.get(url, headers=headers, timeout=(10, 30)) as response:
                 if response.status_code in (200,):
                     message = f"| BotScout results | `{query}` |\n"
                     message += "| :- | -: |\n"

--- a/commands/bssc/command.py
+++ b/commands/bssc/command.py
@@ -35,7 +35,7 @@ def getToken():
         'Content-Type': 'application/x-www-form-urlencoded',
     }
     try:
-        with requests.post(settings.APIURL['bssc']['token'], headers=auth) as response:
+        with requests.post(settings.APIURL['bssc']['token'], headers=auth, timeout=(10, 30)) as response:
             json_response = response.json()
             if 'access_token' in json_response and 'token_type' in json_response:
                 return json_response['access_token']
@@ -77,7 +77,7 @@ def process(command, channel, username, params, files, conn):
                         'Authorization': 'Bearer %s' % token,
                         'Content-Type': settings.CONTENTTYPE,
                     }
-                    with requests.get(endpoint, headers=headers) as response:
+                    with requests.get(endpoint, headers=headers, timeout=(10, 30)) as response:
                         data = ''
                         json_response = response.json()
                         for outputField in outputFields.keys():

--- a/commands/censys/command.py
+++ b/commands/censys/command.py
@@ -53,7 +53,7 @@ def process(command, channel, username, params, files, conn):
                 if re.search(r"^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\:[0-65535]*)?$", ip):
                     text = 'Censys `%s` search for `%s`: ' % (querytype, ip)
                     APIENDPOINT = settings.APIURL['censys']['url'] + '/hosts/%s' % (ip,)
-                    with requests.get(APIENDPOINT, auth=(settings.APIURL['censys']['key'], settings.APIURL['censys']['secret']), headers=headers) as response:
+                    with requests.get(APIENDPOINT, auth=(settings.APIURL['censys']['key'], settings.APIURL['censys']['secret']), headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if 'error' in json_response:
                             error = json_response['error']
@@ -133,7 +133,7 @@ def process(command, channel, username, params, files, conn):
                 if (re.search(r"^[A-Fa-f0-9]{64}$", sha256)):
                     text = '\nCensys SHA256 certificate fingerprint search for: `%s`' % (sha256,)
                     APIENDPOINT = settings.APIURL['censys']['url'] + '/certificates/' + sha256 + '/hosts'
-                    with requests.get(APIENDPOINT, auth=(settings.APIURL['censys']['key'], settings.APIURL['censys']['secret']), headers=headers) as response:
+                    with requests.get(APIENDPOINT, auth=(settings.APIURL['censys']['key'], settings.APIURL['censys']['secret']), headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if 'error' in json_response:
                             error = json_response['error']
@@ -176,7 +176,7 @@ def process(command, channel, username, params, files, conn):
                                                 page += 1
                                                 cursor = result['links']['next']
                                                 APIENDPOINT = settings.APIURL['censys']['url'] + '/certificates/' + sha256 + '/hosts&cursor=' + cursor
-                                                response = requests.get(APIENDPOINT, auth=(settings.APIURL['censys']['key'], settings.APIURL['censys']['secret']))
+                                                response = requests.get(APIENDPOINT, auth=(settings.APIURL['censys']['key'], settings.APIURL['censys']['secret']), timeout=(10, 30))
                                                 json_response = response.json()
                                                 if 'result' in json_response:
                                                     uploads.append({'filename': 'censys-'+querytype+'-page-'+str(page)+'-'+datetime.datetime.now().strftime('%Y%m%dT%H%M%S')+'.json', 'bytes': response.content})
@@ -194,7 +194,7 @@ def process(command, channel, username, params, files, conn):
                     messages.append({'text': 'Censys error: invalid SHA256 fingerprint `%s`' % (params,)})
             if querytype == 'credits' or querytype == 'account':
                 APIENDPOINT = settings.APIURL['censys']['url'].replace('/v2', '/v1') + '/account'
-                with requests.get(APIENDPOINT, auth=(settings.APIURL['censys']['key'], settings.APIURL['censys']['secret']), headers=headers) as response:
+                with requests.get(APIENDPOINT, auth=(settings.APIURL['censys']['key'], settings.APIURL['censys']['secret']), headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if 'error' in json_response:
                         error = json_response['error']

--- a/commands/chatgpt/command.py
+++ b/commands/chatgpt/command.py
@@ -40,7 +40,7 @@ def process(command, channel, username, params, files, conn):
             "max_tokens": settings.MAX_TOKENS,
             "prompt": params,
         }
-        with requests.post(settings.APIENDPOINT, json=data, headers=headers) as response:
+        with requests.post(settings.APIENDPOINT, json=data, headers=headers, timeout=(10, 30)) as response:
             answer = response.json()
             reply = None
             if 'error' in answer:

--- a/commands/crtsh/command.py
+++ b/commands/crtsh/command.py
@@ -49,7 +49,7 @@ def process(command, channel, username, params, files, conn):
             }
             api_url = f"{settings.APIURL['crtsh']['url']}{param}"
             # Request data from the API
-            response = requests.get(api_url, headers=headers)
+            response = requests.get(api_url, headers=headers, timeout=(10, 30))
             response.raise_for_status()  # Ensure we raise an error for bad status codes
             json_response = response.json()
             if len(json_response):

--- a/commands/cyberthreat/cyberthreat.py
+++ b/commands/cyberthreat/cyberthreat.py
@@ -34,11 +34,11 @@ def wget(url: str) -> dict:
                     "Authorization": f'Token {getapikey()}'}
 
         logging.debug(f"GET: {url}")
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=(10, 30))
         if response.status_code >= 500:
             logging.info("Error. Sleeping for 5 seconds.")
             sleep(5)
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=(10, 30))
 
     except requests.exceptions.Timeout:
         raise Exception('Timeout')

--- a/commands/dnsdumpster/command.py
+++ b/commands/dnsdumpster/command.py
@@ -60,7 +60,7 @@ def process(command, channel, username, params, files, conn):
         }
 
         # Request data from the API
-        response = requests.get(api_url, headers=headers)
+        response = requests.get(api_url, headers=headers, timeout=(10, 30))
         # Ensure we raise an error for bad status codes
         response.raise_for_status()
         # Assign response to variable

--- a/commands/docgen/command.py
+++ b/commands/docgen/command.py
@@ -150,7 +150,7 @@ def process(command, channel, username, params, files, conn):
                         }
                         """ % (pagecontent, description, editor, isPublished, isPrivate, locale, path, tags, title,)
                         query = json.dumps({'query': query.strip()})
-                        with requests.post(settings.APIURL['docgen']['url']+'/graphql', headers=headers, data=query) as response:
+                        with requests.post(settings.APIURL['docgen']['url']+'/graphql', headers=headers, data=query, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if 'data' in json_response:
                                 if 'pages' in json_response['data']:
@@ -215,7 +215,7 @@ def process(command, channel, username, params, files, conn):
                         }
                         """ % (pagecontent, description, editor, isPublished, isPrivate, locale, path, tags, title,)
                         query = json.dumps({'query': query.strip()})
-                        with requests.post(settings.APIURL['docgen']['url']+'/graphql', headers=headers, data=query) as response:
+                        with requests.post(settings.APIURL['docgen']['url']+'/graphql', headers=headers, data=query, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if 'data' in json_response:
                                 if 'pages' in json_response['data']:
@@ -230,25 +230,25 @@ def process(command, channel, username, params, files, conn):
                 else:
                     maxdepth = 4
                 query = '{"query":"query { pages { list (orderBy: PATH) { id path title }}}"}'
-                with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=query) as response:
+                with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=query, timeout=(10, 30)) as response:
                     pages = response.json()
                     if 'data' in pages:
                         for page in pages['data']['pages']['list']:
                             if page['title'].lower() == settings.TEMPLATECASES.lower():
                                 query = '{"query":"query { pages { single (id: %d) { content }}}"}' % (page['id'],)
-                                with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=query) as response:
+                                with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=query, timeout=(10, 30)) as response:
                                     pagecontent = response.json()
                                     if 'data' in pagecontent:
                                         template_cases_content = csv.DictReader(StringIO(pagecontent['data']['pages']['single']['content']))
                             if page['title'].lower() == settings.TEMPLATEIDCHAIN.lower():
                                 query = '{"query":"query { pages { single (id: %d) { content }}}"}' % (page['id'],)
-                                with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=query) as response:
+                                with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=query, timeout=(10, 30)) as response:
                                     pagecontent = response.json()
                                     if 'data' in pagecontent:
                                         template_idchain_content = csv.DictReader(StringIO(pagecontent['data']['pages']['single']['content']))
                             if page['title'].lower() == settings.TEMPLATECUSTOMERS.lower():
                                 query = '{"query":"query { pages { single (id: %d) { content }}}"}' % (page['id'],)
-                                with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=query) as response:
+                                with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=query, timeout=(10, 30)) as response:
                                     pagecontent = response.json()
                                     if 'data' in pagecontent:
                                         template_customers_content = csv.DictReader(StringIO(pagecontent['data']['pages']['single']['content']))
@@ -270,13 +270,13 @@ def process(command, channel, username, params, files, conn):
                     pagecount = 0
                     for pid in template_id_chain['ids'].split(' '):
                         pages = '{"query":"query { pages { list (orderBy: PATH) { id path title }}}"}'
-                        with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=pages) as response:
+                        with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=pages, timeout=(10, 30)) as response:
                             pages = response.json()
                         if 'data' in pages:
                             for page in pages['data']['pages']['list']:
                                 if pid.lower() == page['path'].lower().split('/').pop():
                                     pagecontent = '{"query":"query { pages { single (id: %d) { content }}}"}' % (page['id'],)
-                                    with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=pagecontent) as response:
+                                    with requests.post(settings.APIURL['docgen']['url'], headers=headers, data=pagecontent, timeout=(10, 30)) as response:
                                         pagecontent = response.json()
                                         if 'data' in pagecontent:
                                             langsplit = '<!---'+language+'--->'

--- a/commands/docspell/command.py
+++ b/commands/docspell/command.py
@@ -44,7 +44,7 @@ def getToken():
     }
     try:
         url = f"{settings.APIURL['docspell']['url']}/open/auth/login"
-        with requests.post(url, headers=headers, json=auth) as response:
+        with requests.post(url, headers=headers, json=auth, timeout=(10, 30)) as response:
             json_response = response.json()
             if 'token' in json_response and 'validMs' in json_response:
                 return json_response['token']
@@ -81,7 +81,7 @@ def process(command, channel, username, params, files, conn):
                     res = [ ''.join(esc_dict.get(chr, chr) for chr in sub) for sub in params]
                     query = f"content%3A%22{' '.join(res)}%22"
                     url = f"{settings.APIURL['docspell']['url']}/sec/item/search?q={query}&withDetails=True"
-                    with requests.get(url=url, headers=headers) as response:
+                    with requests.get(url=url, headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if "groups" in json_response:
                             if "name" in json_response['groups'][0]:
@@ -112,7 +112,7 @@ def process(command, channel, username, params, files, conn):
                                                         'User-Agent': 'MatterBot integration for Docspell v0.1',
                                                         'X-Docspell-Auth': f"{token}",
                                                     }
-                                                    with requests.get(url=url, headers=headers) as download:
+                                                    with requests.get(url=url, headers=headers, timeout=(10, 30)) as download:
                                                         entry = {'filename': name, 'bytes': download.content}
                                                         if not entry in files:
                                                             files.append(entry)
@@ -177,7 +177,7 @@ def process(command, channel, username, params, files, conn):
                                 mime_type = file['mime_type']
                                 filesize = file['size']
                                 contentfields = {'file': (filename, content, mime_type)}
-                                with requests.post(url=url, headers=headers, files=contentfields) as response:
+                                with requests.post(url=url, headers=headers, files=contentfields, timeout=(10, 30)) as response:
                                     if response.status_code in (200, 201):
                                         entries.append({
                                             'success': True,

--- a/commands/ewa/command.py
+++ b/commands/ewa/command.py
@@ -63,7 +63,7 @@ def process(command, channel, username, params, files, conn):
                         }
                     """
                     query = json.dumps({'query': query.strip()})
-                    with requests.post(settings.APIURL['ewa']['url']+'/graphql', headers=headers, data=query) as response:
+                    with requests.post(settings.APIURL['ewa']['url']+'/graphql', headers=headers, data=query, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if 'data' in json_response:
                             if 'pages' in json_response['data']:
@@ -83,7 +83,7 @@ def process(command, channel, username, params, files, conn):
                         """
                         query = json.dumps({'query': query.strip()})
                         try:
-                            with requests.post(settings.APIURL['ewa']['url']+'/graphql', headers=headers, data=query) as response:
+                            with requests.post(settings.APIURL['ewa']['url']+'/graphql', headers=headers, data=query, timeout=(10, 30)) as response:
                                 json_response = response.json()
                                 content = json_response['data']['pages']['single']['content']
                                 MODULEDIR = "commands/ewa/"
@@ -158,7 +158,7 @@ def process(command, channel, username, params, files, conn):
                 if command == 'create':
                     ### Download the CVE information
                     content = None
-                    with requests.get(settings.APIURL['nvd']['url']+cve) as response:
+                    with requests.get(settings.APIURL['nvd']['url']+cve, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if 'resultsPerPage' in json_response:
                             if json_response['resultsPerPage'] == 1:
@@ -296,7 +296,7 @@ def process(command, channel, username, params, files, conn):
                                 }
                                 """ % (content, description, editor, isPublished, isPrivate, locale, path, tags, title,)
                                 query = json.dumps({'query': query.strip()})
-                                with requests.post(settings.APIURL['ewa']['url']+'/graphql', headers=headers, data=query) as response:
+                                with requests.post(settings.APIURL['ewa']['url']+'/graphql', headers=headers, data=query, timeout=(10, 30)) as response:
                                     json_response = response.json()
                                     if 'data' in json_response:
                                         if 'pages' in json_response['data']:

--- a/commands/geolookup/command.py
+++ b/commands/geolookup/command.py
@@ -41,7 +41,7 @@ def process(command, channel, username, params, files, conn):
                 long = params[1]
                 if re.search(r"^[\-\.0-9]+$", lat) and re.search(r"^[\-\.0-9]+$", long):
                     # Close enough
-                    with requests.get(settings.APIURL['osmdata']['url']+'lat='+lat+'&lon='+long+'&format=json', headers=headers) as response:
+                    with requests.get(settings.APIURL['osmdata']['url']+'lat='+lat+'&lon='+long+'&format=json', headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         message = 'Geographical address lookup for latitude `%s`, longitude `%s`: ' % (lat, long)
                         if 'display_name' in json_response:

--- a/commands/grayhat/command.py
+++ b/commands/grayhat/command.py
@@ -49,7 +49,7 @@ def process(command, channel, username, params, files, conn,):
         }
 
         # Request data from the API
-        response = requests.get(api_url, headers=headers)
+        response = requests.get(api_url, headers=headers, timeout=(10, 30))
         # Ensure we raise an error for bad status codes
         response.raise_for_status()
         # Assign response to variable

--- a/commands/greynoise/command.py
+++ b/commands/greynoise/command.py
@@ -63,7 +63,7 @@ def process(command, channel, username, params, files, conn):
             }
             if querytype == 'ping':
                 APIENDPOINT += querytypes[querytype]
-                with requests.get(APIENDPOINT, headers=headers) as response:
+                with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if 'message' in json_response:
                         if json_response['message'] == 'pong':
@@ -88,7 +88,7 @@ def process(command, channel, username, params, files, conn):
                     if querytype == 'community':
                         query = query[0].strip()
                         APIENDPOINT += urllib.parse.quote(querytypes[querytype]+'%s' % (query,))
-                        with requests.get(APIENDPOINT, headers=headers) as response:
+                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if response.status_code in (200,404):
                                 message =  '\n| **GreyNoise** Lookup Type | `%s` |' % (querytype)
@@ -107,7 +107,7 @@ def process(command, channel, username, params, files, conn):
                     if querytype == 'ipcontext':
                         query = query[0].strip()
                         APIENDPOINT += urllib.parse.quote(querytypes[querytype]+'%s' % (query,))
-                        with requests.get(APIENDPOINT, headers=headers) as response:
+                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if response.status_code == 200:
                                 message =  '\n| **GreyNoise** Lookup Type | `%s` |' % (querytype)
@@ -211,7 +211,7 @@ def process(command, channel, username, params, files, conn):
                     if querytype == 'ipquick':
                         query = query[0].strip()
                         APIENDPOINT += urllib.parse.quote(querytypes[querytype]+'%s' % (query,))
-                        with requests.get(APIENDPOINT, headers=headers) as response:
+                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if response.status_code == 200:
                                 codemap = {
@@ -249,7 +249,7 @@ def process(command, channel, username, params, files, conn):
                     if querytype == 'riot':
                         query = query[0].strip()
                         APIENDPOINT += urllib.parse.quote(querytypes[querytype]+'%s' % (query,))
-                        with requests.get(APIENDPOINT, headers=headers) as response:
+                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if response.status_code in (200,404):
                                 message =  '\n| **GreyNoise** Lookup Type | `%s` |' % (querytype)
@@ -326,7 +326,7 @@ def process(command, channel, username, params, files, conn):
                                 APIENDPOINT += urllib.parse.quote('%s' % (filterdict[field],))
                                 APIENDPOINT += '&'
                             APIENDPOINT = APIENDPOINT.strip('&')
-                            with requests.get(APIENDPOINT, headers=headers) as response:
+                            with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                                 json_response = response.json()
                                 if 'message' in json_response:
                                     if json_response['message'] == 'Forbidden':
@@ -336,7 +336,7 @@ def process(command, channel, username, params, files, conn):
                     if querytype == 'similarity':
                         query = query[0].strip()
                         APIENDPOINT += urllib.parse.quote(querytypes[querytype]+'%s' % (query,))
-                        with requests.get(APIENDPOINT, headers=headers) as response:
+                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if 'message' in json_response:
                                 if json_response['message'] == 'Forbidden':

--- a/commands/gtfobins/command.py
+++ b/commands/gtfobins/command.py
@@ -41,7 +41,7 @@ def process(command, channel, username, params, files, conn):
             }
             query = params[0]
             if query == 'rebuildcache' or not Path(settings.CACHE).is_file():
-                with requests.get(settings.APIURL['gtfobins']['url'], headers=headers) as response:
+                with requests.get(settings.APIURL['gtfobins']['url'], headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         with open(settings.CACHE, mode='w') as f:

--- a/commands/haveibeenpwned/command.py
+++ b/commands/haveibeenpwned/command.py
@@ -60,7 +60,7 @@ def process(command, channel, username, params, files, conn):
         messages = []
 
         # Request data from the API
-        response = requests.get(api_url, headers=headers)
+        response = requests.get(api_url, headers=headers, timeout=(10, 30))
 
         response.raise_for_status()  # Ensure we raise an error for bad status codes
 

--- a/commands/hybridanalysis/command.py
+++ b/commands/hybridanalysis/command.py
@@ -101,7 +101,7 @@ def process(command, channel, username, params, files, conn):
                 for endpoint in endpoints:
                     data = {endpoint:query}
                     APIENDPOINT = settings.APIURL['hybridanalysis']['url']+endpoints[endpoint]
-                    with requests.post(APIENDPOINT, data=data, headers=headers) as response:
+                    with requests.post(APIENDPOINT, data=data, headers=headers, timeout=(10, 30)) as response:
                         message = ''
                         json_response = response.json()
                         if len(json_response):

--- a/commands/ipinfo/command.py
+++ b/commands/ipinfo/command.py
@@ -49,7 +49,7 @@ def process(command, channel, username, params, files, conn):
         }
 
         # Request data from the API
-        response = requests.get(api_url)
+        response = requests.get(api_url, timeout=(10, 30))
 
         #  Ensure we raise an error for bad status codes
         response.raise_for_status()

--- a/commands/iplocation/command.py
+++ b/commands/iplocation/command.py
@@ -38,7 +38,7 @@ def process(command, channel, username, params, files, conn):
                not re.search(r"^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))", ip):
                 return
             else:
-                with requests.get(settings.APIURL['iplocation']['url']+ip) as response:
+                with requests.get(settings.APIURL['iplocation']['url']+ip, timeout=(10, 30)) as response:
                     data = response.json()
                     message = f'**IPLocation lookup for {ip}**\n\n'
                     fieldmap = {

--- a/commands/ipwhois/command.py
+++ b/commands/ipwhois/command.py
@@ -36,7 +36,7 @@ def process(command, channel, username, params, files, conn):
             if re.search(r"^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\:[0-9]*)?$", params):
                 data = params.split(':')[0]
             if data:
-                with requests.get(settings.APIURL['ipwhois']['url'] + data) as response:
+                with requests.get(settings.APIURL['ipwhois']['url'] + data, timeout=(10, 30)) as response:
                     json_response = response.json()
                     message = 'IPWHOIS lookup for `%s`' % (data,)
                     if 'success' in json_response:

--- a/commands/koboldcpp/command.py
+++ b/commands/koboldcpp/command.py
@@ -73,7 +73,7 @@ def process(command, channel, username, params, files, conn):
             "quiet": True,
             "genkey": "KCPP{:03d}".format(randkey)
         }
-        with requests.post(settings.APIURL['koboldcpp']['url'], json=json.dumps(data), headers=headers) as response:
+        with requests.post(settings.APIURL['koboldcpp']['url'], json=json.dumps(data), headers=headers, timeout=(10, 30)) as response:
             answers = response.json()
             if 'results' in answers:
                 num = 1

--- a/commands/leakix/command.py
+++ b/commands/leakix/command.py
@@ -60,7 +60,7 @@ def process(command, channel, username, params, files, conn):
                 for endpoint in endpoints:
                     query = urllib.parse.quote_plus(query.encode())
                     APIENDPOINT = settings.APIURL['leakix']['url']+endpoint+query
-                    with requests.get(APIENDPOINT,headers=headers) as response:
+                    with requests.get(APIENDPOINT,headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         querytype = endpoint.strip('/')
                         if json_response:

--- a/commands/lolbas/command.py
+++ b/commands/lolbas/command.py
@@ -41,7 +41,7 @@ def process(command, channel, username, params, files, conn):
             }
             query = params[0]
             if query == 'rebuildcache' or not Path(settings.CACHE).is_file():
-                with requests.get(settings.APIURL['lolbas']['url'], headers=headers) as response:
+                with requests.get(settings.APIURL['lolbas']['url'], headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         with open(settings.CACHE, mode='w') as f:
@@ -105,7 +105,7 @@ def process(command, channel, username, params, files, conn):
                                         iocs.add(detection[type])
                             try:
                                 for url in urls:
-                                    with requests.get(url, headers=headers) as response:
+                                    with requests.get(url, headers=headers, timeout=(10, 30)) as response:
                                         uploads.append({'filename': Path(url).name, 'bytes': response.content})
                             except:
                                 pass

--- a/commands/loldrivers/command.py
+++ b/commands/loldrivers/command.py
@@ -41,7 +41,7 @@ def process(command, channel, username, params, files, conn):
             }
             query = params[0]
             if query == 'rebuildcache' or not Path(settings.CACHE).is_file():
-                with requests.get(settings.APIURL['loldrivers']['url'], headers=headers) as response:
+                with requests.get(settings.APIURL['loldrivers']['url'], headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         with open(settings.CACHE, mode='w') as f:
@@ -155,7 +155,7 @@ def process(command, channel, username, params, files, conn):
                                         type = Detection['type'].replace('_',' ').title()
                                         url = Detection['value']
                                         try:
-                                            with requests.get(url) as response:
+                                            with requests.get(url, timeout=(10, 30)) as response:
                                                 uploads.append({'filename': Path(url).name, 'bytes': b'xxxx'})
                                                 filenames.append(Path(url).name)
                                         except:

--- a/commands/lolrmm/command.py
+++ b/commands/lolrmm/command.py
@@ -42,7 +42,7 @@ def process(command, channel, username, params, files, conn):
             }
             query = params[0]
             if query == 'rebuildcache' or not Path(settings.CACHE).is_file():
-                with requests.get(settings.APIURL['lolrmm']['url'], headers=headers) as response:
+                with requests.get(settings.APIURL['lolrmm']['url'], headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         with open(settings.CACHE, mode='w') as f:

--- a/commands/loobins/command.py
+++ b/commands/loobins/command.py
@@ -42,7 +42,7 @@ def process(command, channel, username, params, files, conn):
             }
             query = params[0]
             if query == 'rebuildcache' or not Path(settings.CACHE).is_file():
-                with requests.get(settings.APIURL['loobins']['url'], headers=headers) as response:
+                with requests.get(settings.APIURL['loobins']['url'], headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         with open(settings.CACHE, mode='w') as f:

--- a/commands/macvendors/command.py
+++ b/commands/macvendors/command.py
@@ -53,7 +53,7 @@ def process(command, channel, username, params, files, conn):
         if not isMac(address):
             return messages.append({'text': f"`{address}` is not a valid address format"})
         api_url = f"{settings.APIURL['macvendors']['url']}{urllib.parse.quote(address)}"         # API URL for fetching data
-        response = requests.get(api_url)
+        response = requests.get(api_url, timeout=(10, 30))
         if response.status_code == 200:
             messages.append({'text': f"Vendor: `{response.text}`"})
         else:

--- a/commands/malpedia/command.py
+++ b/commands/malpedia/command.py
@@ -50,7 +50,7 @@ def process(command, channel, username, params, files, conn):
             if hash_algo:
                 apipath = 'get/sample/%s/zip' % (params,)
                 uploads = None
-                with requests.get(settings.APIURL['malpedia']['url'] + apipath, headers=headers) as response:
+                with requests.get(settings.APIURL['malpedia']['url'] + apipath, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if 'detail' in json_response:
                         # You don't have a registered account/API key to get samples!
@@ -68,10 +68,10 @@ def process(command, channel, username, params, files, conn):
                     messages.append({'text': text, 'uploads': uploads})
             if re.search(r"^[A-Za-z0-9]+$", params):
                 apipath = 'find/actor/%s' % (params,)
-                with requests.get(settings.APIURL['malpedia']['url'] + apipath, headers=headers) as response:
+                with requests.get(settings.APIURL['malpedia']['url'] + apipath, headers=headers, timeout=(10, 30)) as response:
                     actors = response.json()
                 apipath = 'find/family/%s' % (params,)
-                with requests.get(settings.APIURL['malpedia']['url'] + apipath, headers=headers) as response:
+                with requests.get(settings.APIURL['malpedia']['url'] + apipath, headers=headers, timeout=(10, 30)) as response:
                     families = response.json()
                 if actors:
                     items = {}
@@ -87,7 +87,7 @@ def process(command, channel, username, params, files, conn):
                         text += '\n**Actor names/synonyms**: `' + '`, `'.join(sorted(actornames, key=str.lower)) + '`'
                         for actorname in actornames:
                             if re.search(r"^G[0-9]{4}$", actorname):
-                                with requests.get(settings.APIURL['mitre']['url'] + 'Actors/' + actorname, headers=headers) as response:
+                                with requests.get(settings.APIURL['mitre']['url'] + 'Actors/' + actorname, headers=headers, timeout=(10, 30)) as response:
                                     mitre = response.json()
                                     if mitre:
                                         for subtree in subtrees:

--- a/commands/malwarebazaar/command.py
+++ b/commands/malwarebazaar/command.py
@@ -49,7 +49,7 @@ def process(command, channel, username, params, files, conn):
                     'query': 'get_info',
                     'hash': params,
                 }
-                with requests.post(settings.APIURL['malwarebazaar']['url'], data=data) as response:
+                with requests.post(settings.APIURL['malwarebazaar']['url'], data=data, timeout=(10, 30)) as response:
                     if response.status_code in (401,):
                         message = "Incorrect MalwareBazaar API key or not configured!"
                     else:

--- a/commands/misp/command.py
+++ b/commands/misp/command.py
@@ -53,7 +53,7 @@ def process(command, channel, username, params, files, conn):
                 "order": "Event.publish_timestamp desc",
                 "value": params,
             }
-            with requests.post(settings.APIENDPOINT, data=json.dumps(data), headers=headers) as response:
+            with requests.post(settings.APIENDPOINT, data=json.dumps(data), headers=headers, timeout=(10, 30)) as response:
                 answer = response.json()
                 if 'response' in answer:
                     results = answer['response']

--- a/commands/mwdb/command.py
+++ b/commands/mwdb/command.py
@@ -152,7 +152,7 @@ def getDownloads(ids):
     for id in ids:
         url = settings.APIURL['mwdb']['url']+f"file/{id}/download/zip"
         try:
-            with requests.get(url, headers=headers) as response:
+            with requests.get(url, headers=headers, timeout=(10, 30)) as response:
                 if response.status_code == 404:
                     return None
                 if response.status_code == 200:
@@ -224,7 +224,7 @@ def process(command, channel, username, params, files, conn):
                 if querytype == 'multi':
                     url = settings.APIURL['mwdb']['url']+f"blob?query=multi:{query}"
                     try:
-                        with requests.get(url, headers=headers) as response:
+                        with requests.get(url, headers=headers, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if 'blobs' in json_response:
                                 if len(json_response['blobs']):

--- a/commands/ollama/command.py
+++ b/commands/ollama/command.py
@@ -49,7 +49,7 @@ def process(command, channel, username, params, files, conn):
                 }
             }
             messages = []
-            with requests.post(settings.APIENDPOINT, json=data, headers=headers) as response:
+            with requests.post(settings.APIENDPOINT, json=data, headers=headers, timeout=(10, 30)) as response:
                 answer = response.json()
                 reply = None
                 if 'response' in answer:

--- a/commands/onionlookup/command.py
+++ b/commands/onionlookup/command.py
@@ -43,7 +43,7 @@ def process(command, channel, username, params, files, conn):
         try:
             messages = []
             if params.endswith('.onion'):
-                with requests.get(settings.APIURL['onionlookup']['url']+f"{params}", headers=headers) as response:
+                with requests.get(settings.APIURL['onionlookup']['url']+f"{params}", headers=headers, timeout=(10, 30)) as response:
                     if response.status_code in (400,401,402,403,):
                         messages.append({'text': "Failed Onion-Lookup, check address validity or try again later ..."})
                     if response.status_code in (200,):

--- a/commands/proxycheck/command.py
+++ b/commands/proxycheck/command.py
@@ -59,7 +59,7 @@ def process(command, channel, username, params, files, conn):
                 if 'key' in settings.APIURL['proxycheck']:
                     if settings.APIURL['proxycheck']['key']:
                         apiurl += f"?key={settings.APIURL['proxycheck']['key']}"
-                with requests.post(apiurl, headers=headers, data=postdata) as response:
+                with requests.post(apiurl, headers=headers, data=postdata, timeout=(10, 30)) as response:
                     if response.status_code in (400,401,402,403,):
                         messages.append({'text': "Failed ProxyCheck lookup, check address validity or try again later ..."})
                     if response.status_code in (200,):

--- a/commands/qualys/command.py
+++ b/commands/qualys/command.py
@@ -42,7 +42,7 @@ def getToken():
         username = urllib.parse.quote(settings.APIURL['qualys']['username'])
         password = urllib.parse.quote(settings.APIURL['qualys']['password'])
         data = 'username=%s&password=%s&token=true' % (username,password)
-        with requests.post(settings.APIURL['qualys']['jwt'], headers=headers, data=data) as response:
+        with requests.post(settings.APIURL['qualys']['jwt'], headers=headers, data=data, timeout=(10, 30)) as response:
             content = response.content.decode()
             if 'Authentication Failure' in content:
                 return None
@@ -153,7 +153,7 @@ def process(command, channel, username, params, files, conn):
                     if querytype == 'software':
                         completeAPIurl += '?includeFields=assetName,dnsName,address,software,tag'
                     jsonfilter = json.dumps(filtermap[querytype])
-                    with requests.post(completeAPIurl, headers=headers, data=jsonfilter) as response:
+                    with requests.post(completeAPIurl, headers=headers, data=jsonfilter, timeout=(10, 30)) as response:
                         try:
                             if len(response.content):
                                 json_response = json.loads(response.content)
@@ -185,7 +185,7 @@ def process(command, channel, username, params, files, conn):
                                                                 while hasMore == 1:
                                                                     lastSeenAssetId = json_response['lastSeenAssetId']
                                                                     paginationAPIurl = completeAPIurl + f"&lastSeenAssetId={lastSeenAssetId}"
-                                                                    with requests.post(paginationAPIurl, headers=headers, data=jsonfilter) as response:
+                                                                    with requests.post(paginationAPIurl, headers=headers, data=jsonfilter, timeout=(10, 30)) as response:
                                                                         json_response = json.loads(response.content)
                                                                         assets += json_response['assetListData']['asset']
                                                                         hasMore = int(json_response['hasMore'])

--- a/commands/ransomlook/command.py
+++ b/commands/ransomlook/command.py
@@ -75,7 +75,7 @@ def process(command, channel, username, params, files, conn):
             if querytype == 'group':
                 if query:
                     endpoint = settings.APIURL['ransomlook']['url']+'groups'
-                    with requests.get(url=endpoint, headers=headers) as response:
+                    with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if len(json_response):
                             candidates = []
@@ -87,7 +87,7 @@ def process(command, channel, username, params, files, conn):
                             messages.append({'text': message})
                         else:
                             endpoint = settings.APIURL['ransomlook']['url']+f"group/{candidates[0]}"
-                            with requests.get(url=endpoint, headers=headers) as response:
+                            with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                                 groupinfo = response.json()[0]
                                 if len(response.json())>1:
                                     posts = response.json()[1]
@@ -172,7 +172,7 @@ def process(command, channel, username, params, files, conn):
                     messages.append({'text': message})
             if querytype == 'groups':
                 endpoint = settings.APIURL['ransomlook']['url']+'groups'
-                with requests.get(url=endpoint, headers=headers) as response:
+                with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         count = 1
@@ -189,7 +189,7 @@ def process(command, channel, username, params, files, conn):
             if querytype == 'market':
                 if query:
                     endpoint = settings.APIURL['ransomlook']['url']+'markets'
-                    with requests.get(url=endpoint, headers=headers) as response:
+                    with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if len(json_response):
                             candidates = []
@@ -201,7 +201,7 @@ def process(command, channel, username, params, files, conn):
                             messages.append({'text': message})
                         else:
                             endpoint = settings.APIURL['ransomlook']['url']+f"market/{candidates[0]}"
-                            with requests.get(url=endpoint, headers=headers) as response:
+                            with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                                 marketinfo = response.json()[0]
                                 if len(response.json())>1:
                                     posts = response.json()[1]
@@ -286,7 +286,7 @@ def process(command, channel, username, params, files, conn):
                     messages.append({'text': message})
             if querytype == 'markets':
                 endpoint = settings.APIURL['ransomlook']['url']+'markets'
-                with requests.get(url=endpoint, headers=headers) as response:
+                with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         count = 1
@@ -305,7 +305,7 @@ def process(command, channel, username, params, files, conn):
                 filter = None
                 if query:
                     filter = query
-                with requests.get(url=endpoint, headers=headers) as response:
+                with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         count = 1
@@ -364,7 +364,7 @@ def process(command, channel, username, params, files, conn):
                             messages.append({'text': message})
             if querytype == 'tgchannels':
                 endpoint = settings.APIURL['ransomlook']['url']+'telegram/channels'
-                with requests.get(url=endpoint, headers=headers) as response:
+                with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         count = 1
@@ -391,7 +391,7 @@ def process(command, channel, username, params, files, conn):
                         searches.append(' '.join(query[:-1]))
                     else:
                         filter = None
-                    with requests.get(url=endpoint, headers=headers) as response:
+                    with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if len(json_response):
                             for tgchannel in json_response:
@@ -403,7 +403,7 @@ def process(command, channel, username, params, files, conn):
                             messages.append({'text': message})
                         if len(candidates):
                             endpoint = settings.APIURL['ransomlook']['url']+f"telegram/channel/{candidates[0]}"
-                            with requests.get(url=endpoint, headers=headers) as response:
+                            with requests.get(url=endpoint, headers=headers, timeout=(10, 30)) as response:
                                 json_response = response.json()
                                 if len(json_response):
                                     tgchannelinfo = json_response[0]
@@ -446,7 +446,7 @@ def process(command, channel, username, params, files, conn):
                                                     content = True
                                                     for image in images:
                                                         imageurl = settings.APIURL['ransomlook']['url']+f"telegram/channel/{candidates[0]}/image/%s" % (urllib.parse.quote_plus(image,))
-                                                        with requests.get(url=imageurl, headers=headers) as image:
+                                                        with requests.get(url=imageurl, headers=headers, timeout=(10, 30)) as image:
                                                             for header in image.headers:
                                                                 if header.lower() == 'content-disposition':
                                                                     filename = urllib.parse.unquote_plus(re.findall('filename=(.+)', image.headers[header], re.IGNORECASE)[0]).replace('?','-').replace('"','')

--- a/commands/reversinglabs/command.py
+++ b/commands/reversinglabs/command.py
@@ -95,7 +95,7 @@ def process(command, channel, username, params, files, conn):
         if querytype:
             if querytype == 'url':
                 a1kendpoint += f"?url={query}"
-                with requests.get(url=a1kendpoint, headers=a1kheaders) as response:
+                with requests.get(url=a1kendpoint, headers=a1kheaders, timeout=(10, 30)) as response:
                     if response.status_code in (200,):
                         results = response.json()
                         if 'analysis' in results:
@@ -153,7 +153,7 @@ def process(command, channel, username, params, files, conn):
                             messages.append({'text': message})
             if querytype == 'host':
                 a1kendpoint += f"{query}/"
-                with requests.get(url=a1kendpoint, headers=a1kheaders) as response:
+                with requests.get(url=a1kendpoint, headers=a1kheaders, timeout=(10, 30)) as response:
                     if response.status_code in (200,):
                         results = response.json()
                         if 'top_threats' in results:
@@ -206,7 +206,7 @@ def process(command, channel, username, params, files, conn):
                             messages.append({'text': f"**Last ReversingLabs DNS record resolution:** `{results['last_dns_records_time']}`\n"})
             if querytype == 'ip':
                 a1kendpoint += f"{query}/report/"
-                with requests.get(url=a1kendpoint, headers=a1kheaders) as response:
+                with requests.get(url=a1kendpoint, headers=a1kheaders, timeout=(10, 30)) as response:
                     if response.status_code in (200,):
                         results = response.json()
                         if 'top_threats' in results:
@@ -268,7 +268,7 @@ def process(command, channel, username, params, files, conn):
                     'include_networkthreatintelligence': True,
                     'skip_reanalysis': True,
                 }
-                with requests.post(url=a1kendpoint, headers=a1kheaders, json=data) as response:
+                with requests.post(url=a1kendpoint, headers=a1kheaders, json=data, timeout=(10, 30)) as response:
                     results = response.json()
                     if 'count' in results:
                         if results['count']>0:
@@ -303,7 +303,7 @@ def process(command, channel, username, params, files, conn):
                                 messages.append({'text': message})
                                 for samplehash in samplehashes:
                                     a1kendpoint = f"https://a1000.reversinglabs.com/api/samples/{samplehash}/download/"
-                                    with requests.get(url=a1kendpoint, headers=a1kheaders) as sample:
+                                    with requests.get(url=a1kendpoint, headers=a1kheaders, timeout=(10, 30)) as sample:
                                         if response.status_code in (200,):
                                             uploads.append({'filename': f"sample-{samplehash}.bin", 'bytes': sample.content})
                             uploads.append({'filename': 'reversingslabs-'+query+'-'+datetime.datetime.now().strftime('%Y%m%dT%H%M%S')+'.json', 'bytes': response.content})
@@ -315,7 +315,7 @@ def process(command, channel, username, params, files, conn):
                 if checkSHA256(query):
                     ticendpoint += f'/sha256/{query}'                    
                 ticendpoint += '?format=json&extended=True'
-                with requests.get(url=ticendpoint, headers=ticheaders, auth=(settings.APIURL['ticloud']['username'],settings.APIURL['ticloud']['password'])) as response:
+                with requests.get(url=ticendpoint, headers=ticheaders, auth=(settings.APIURL['ticloud']['username'],settings.APIURL['ticloud']['password']), timeout=(10, 30)) as response:
                     if response.status_code in (200,):
                         json_response = response.json()
                         if 'rl' in json_response:

--- a/commands/ripewhois/command.py
+++ b/commands/ripewhois/command.py
@@ -39,7 +39,7 @@ def process(command, channel, username, params, files, conn):
             if re.search(r"^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\:[0-9]*)?$", params):
                 data = params.split(':')[0]
             if data:
-                with requests.get(settings.APIURL['ripewhois']['url'] + data) as response:
+                with requests.get(settings.APIURL['ripewhois']['url'] + data, timeout=(10, 30)) as response:
                     json_response = response.json()
                     message = 'RIPE WHOIS lookup for `%s`' % (params,)
                     if 'status' in json_response:

--- a/commands/shodan/command.py
+++ b/commands/shodan/command.py
@@ -69,7 +69,7 @@ def process(command, channel, username, params, files, conn):
                     APIENDPOINT = settings.APIURL['shodan']['url'] + '/shodan/host/%s' % (ip,)
                     if apikey:
                         APIENDPOINT += '?key=%s' % (apikey,)
-                    with requests.get(APIENDPOINT, headers=headers) as response:
+                    with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if 'error' in json_response:
                             error = json_response['error']
@@ -138,7 +138,7 @@ def process(command, channel, username, params, files, conn):
                     if apikey:
                         APIENDPOINT += 'key=%s' % (apikey,)
                     APIENDPOINT += '&query=%s' % (host,)
-                    with requests.get(APIENDPOINT, headers=headers) as response:
+                    with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if 'matches' in json_response:
                             total = len(json_response['matches'])
@@ -232,7 +232,7 @@ def process(command, channel, username, params, files, conn):
                     facets = urllib.parse.quote(','.join(facets))
                     APIENDPOINT += '&facets=' + facets
                     text += ', facets: `' + urllib.parse.unquote(facets) + '`'
-                with requests.get(APIENDPOINT, headers=headers) as response:
+                with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if 'error' in json_response:
                         error = json_response['error']
@@ -340,7 +340,7 @@ def process(command, channel, username, params, files, conn):
                 table_header_displayed = False
                 for page in range(1,pages+1):
                     PAGEENDPOINT = APIENDPOINT+'&page='+str(page) if page>1 else APIENDPOINT
-                    with requests.get(PAGEENDPOINT, headers=headers) as response:
+                    with requests.get(PAGEENDPOINT, headers=headers, timeout=(10, 30)) as response:
                         json_response = response.json()
                         if 'error' in json_response:
                             error = json_response['error']
@@ -416,7 +416,7 @@ def process(command, channel, username, params, files, conn):
                 APIENDPOINT = settings.APIURL['shodan']['url'] + '/api-info'
                 if apikey:
                     APIENDPOINT += '?key=%s' % (apikey,)
-                with requests.get(APIENDPOINT, headers=headers) as response:
+                with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if 'error' in json_response:
                         error = json_response['error']

--- a/commands/snowplough/command.py
+++ b/commands/snowplough/command.py
@@ -43,7 +43,7 @@ def process(command, channel, username, params, files, conn):
             }
             print(headers)
             print(url)
-            with requests.get(url, headers=headers) as response:
+            with requests.get(url, headers=headers, timeout=(10, 30)) as response:
                 json_response = response.json()
                 print(json_response)
         except Exception as e:

--- a/commands/sslmate/command.py
+++ b/commands/sslmate/command.py
@@ -61,7 +61,7 @@ def process(command, channel, username, params, files, conn):
                     'Authorization': 'Bearer %s' % apikey,
                     'Content-Type': settings.CONTENTTYPE,
                 }
-                with requests.get(endpoint, headers=headers) as response:
+                with requests.get(endpoint, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if len(json_response):
                         if 'code' in json_response:

--- a/commands/threatfox/command.py
+++ b/commands/threatfox/command.py
@@ -58,7 +58,7 @@ def process(command, channel, username, params, files, conn):
                     'hash': params,
                 }
             if data:
-                with requests.post(settings.APIURL['threatfox']['url'], json=data, headers=headers) as response:
+                with requests.post(settings.APIURL['threatfox']['url'], json=data, headers=headers, timeout=(10, 30)) as response:
                     if response.status_code in (401,):
                         message = "Incorrect ThreatFox API key or not configured!"
                     else:

--- a/commands/triage/command.py
+++ b/commands/triage/command.py
@@ -105,7 +105,7 @@ def process(command, channel, username, params, files, conn):
                             APIENDPOINTOFFSET = APIENDPOINT+'&offset=%s' % (offset,)
                         else:
                             APIENDPOINTOFFSET = APIENDPOINT
-                        with requests.get(APIENDPOINTOFFSET, headers=headers) as response:
+                        with requests.get(APIENDPOINTOFFSET, headers=headers, timeout=(10, 30)) as response:
                             if not response.status_code == 200:
                                 try:
                                     json_response = response.json()
@@ -291,7 +291,7 @@ def process(command, channel, username, params, files, conn):
                                     message += '|\n'
                                     messages.append({'text': message})
                             APIENDPOINT = APIENDPOINT = settings.APIURL['triage']['url'].strip('/')+'/samples/%s/sample' % (query,)
-                            with requests.get(APIENDPOINT, headers=headers) as response:
+                            with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                                 if response.status_code == 200:
                                     messages.append({'text': 'Tria.ge Malware Sample (DANGEROUS):', 'uploads': [
                                                         {'filename': 'triage-'+querytype+'-'+query+'.bin', 'bytes': response.content}

--- a/commands/tweetfeed/command.py
+++ b/commands/tweetfeed/command.py
@@ -43,7 +43,7 @@ def process(command, channel, username, params, files, conn):
             regex = re.compile('[%s]' % stripchars)
             params = regex.sub('',params).replace('hxxp','http')
             APIENDPOINT = settings.APIURL['tweetfeed']['url']
-            with requests.get(APIENDPOINT, headers=headers) as response:
+            with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                 json_response = response.json()
                 if len(json_response):
                     count = 0

--- a/commands/unprotectit/command.py
+++ b/commands/unprotectit/command.py
@@ -39,11 +39,11 @@ def buildcache(messages):
             'Content-Type': settings.CONTENTTYPE,
         }
         page = 1
-        with requests.get(settings.APIURL['unprotectit']['url'], headers=headers) as cat_response:
+        with requests.get(settings.APIURL['unprotectit']['url'], headers=headers, timeout=(10, 30)) as cat_response:
             cat_json_response = cat_response.json()
             for category in cat_json_response:
                 cache[category] = {}
-                with requests.get(cat_json_response[category], headers=headers) as response:
+                with requests.get(cat_json_response[category], headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if 'count' in json_response:
                         if 'results' in json_response:
@@ -56,7 +56,7 @@ def buildcache(messages):
                         if 'next' in json_response:
                             nextpage = json_response['next']
                             while nextpage:
-                                with requests.get(nextpage, headers=headers) as response:
+                                with requests.get(nextpage, headers=headers, timeout=(10, 30)) as response:
                                     json_response = response.json()
                                     if 'count' in json_response:
                                         if 'results' in json_response:

--- a/commands/urlhaus/command.py
+++ b/commands/urlhaus/command.py
@@ -55,7 +55,7 @@ def process(command, channel, username, params, files, conn):
                 data = { 'url': params }
                 type = 'url'
             if type == 'url':
-                with requests.post(settings.APIURL['urlhaus']['url'], data=data) as response:
+                with requests.post(settings.APIURL['urlhaus']['url'], data=data, timeout=(10, 30)) as response:
                     if response.status_code in (401,):
                         message = "Incorrect URLhaus API key or not configured!"
                     else:
@@ -85,7 +85,7 @@ def process(command, channel, username, params, files, conn):
                             message += '\n'
                             messages.append({'text': message.strip()})
             if type == 'hash':
-                with requests.post(settings.APIURL['urlhaus']['payload'], data=data) as response:
+                with requests.post(settings.APIURL['urlhaus']['payload'], data=data, timeout=(10, 30)) as response:
                     if response.status_code in (401,):
                         message = "Incorrect URLhaus API key or not configured!"
                     else:

--- a/commands/urlscan/command.py
+++ b/commands/urlscan/command.py
@@ -46,7 +46,7 @@ def process(command, channel, username, params, files, conn):
                     "size": settings.ENTRIES,
                     "datasource": "scans",
                 }
-                with requests.get(settings.APIURL['urlscan']['url'], headers=headers, params=query) as response:
+                with requests.get(settings.APIURL['urlscan']['url'], headers=headers, params=query, timeout=(10, 30)) as response:
                     if response.status_code in (400,):
                         message = "Incorrect Urlscan query!"
                     elif response.status_code in (401,):
@@ -72,7 +72,7 @@ def process(command, channel, username, params, files, conn):
                                                     else:
                                                         message += f"| - "
                                                 verdicturl = result["result"]
-                                                with requests.get(verdicturl, headers=headers) as verdictresponse:
+                                                with requests.get(verdicturl, headers=headers, timeout=(10, 30)) as verdictresponse:
                                                     if not response.status_code in (200, 206):
                                                         messages.append({'text': "An error occurred retrieving Urlscan details"})
                                                     else:

--- a/commands/virustotal/command.py
+++ b/commands/virustotal/command.py
@@ -64,7 +64,7 @@ def process(command, channel, username, params, files, conn):
                 APIENDPOINT = settings.APIURL['virustotal']['url'] + 'domains/%s' % (params,)
             if querytype:
                 uploads = []
-                with requests.get(APIENDPOINT, headers=headers) as response:
+                with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                     json_response = response.json()
                     if 'data' in json_response:
                         data = json_response['data']
@@ -98,7 +98,7 @@ def process(command, channel, username, params, files, conn):
                                     for crowdsourced_yara_result in attributes['crowdsourced_yara_results']:
                                         if crowdsourced_yara_result['source'] == 'https://malpedia.caad.fkie.fraunhofer.de/':
                                             ruleset_name = crowdsourced_yara_result['ruleset_name'].replace('_auto','')
-                                            with requests.get(settings.APIURL['malpedia']['url'] + '/' + ruleset_name + '/zip', headers=malpedia_headers) as response:
+                                            with requests.get(settings.APIURL['malpedia']['url'] + '/' + ruleset_name + '/zip', headers=malpedia_headers, timeout=(10, 30)) as response:
                                                 if response.content:
                                                     bytes = response.content
                                                     if len(bytes)>0:
@@ -121,7 +121,7 @@ def process(command, channel, username, params, files, conn):
                                     else:
                                         verdict = 'safe'
                                     text += '\n - Maliciousness: `' + verdict + '` (' + str(probability) + '%)'
-                                    with requests.get(APIENDPOINT + '/behaviour_mitre_trees', headers=headers) as response:
+                                    with requests.get(APIENDPOINT + '/behaviour_mitre_trees', headers=headers, timeout=(10, 30)) as response:
                                         json_response = response.json()
                                         mitre_tree_names = ('Malwares', 'Subtechniques', 'Techniques', 'Tools')
                                         if 'data' in json_response:

--- a/modules/bluesky/feed.py
+++ b/modules/bluesky/feed.py
@@ -60,7 +60,7 @@ def query(settings=None):
                     for media in feed.entries[count]['media_content']:
                         if 'url' in media:
                             url = media['url']
-                            with requests.get(url, headers=headers) as response:
+                            with requests.get(url, headers=headers, timeout=(10, 30)) as response:
                                 if response.status_code in (200,206):
                                     filename = url.split('/')[-1]
                                     bytes = response.content

--- a/modules/cshub/feed.py
+++ b/modules/cshub/feed.py
@@ -41,7 +41,7 @@ def query(settings=None):
     items = []
     for category in settings.CATEGORIES:
         try:
-            with requests.get("https://www.cshub.com/rss/categories/"+category,headers=headers) as response:
+            with requests.get("https://www.cshub.com/rss/categories/"+category,headers=headers, timeout=(10, 30)) as response:
                 feed = feedparser.parse(response.content)
                 count = 0
                 stripchars = '`\\[\\]\'\"'

--- a/modules/euvd/feed.py
+++ b/modules/euvd/feed.py
@@ -42,7 +42,7 @@ def query(settings=None):
     try:
         for category in settings.CATEGORIES:
             feedurl = settings.CATEGORIES[category]
-            with requests.get(feedurl, headers=headers) as response:
+            with requests.get(feedurl, headers=headers, timeout=(10, 30)) as response:
                 if response.status_code in (200,204):
                     json_response = response.json()
                     for vulnerability in json_response:

--- a/modules/mastodon/feed.py
+++ b/modules/mastodon/feed.py
@@ -62,7 +62,7 @@ def query(settings=None):
                     for media in feed.entries[count]['media_content']:
                         if 'url' in media:
                             url = media['url']
-                            with requests.get(url, headers=headers) as response:
+                            with requests.get(url, headers=headers, timeout=(10, 30)) as response:
                                 if response.status_code in (200,206):
                                     filename = url.split('/')[-1]
                                     bytes = response.content

--- a/modules/phishingcatcher/feed.py
+++ b/modules/phishingcatcher/feed.py
@@ -47,7 +47,7 @@ def query(settings=None):
             authentication = (settings.AUTH['username'],settings.AUTH['password'])
         else:
             authentication = ()
-        with requests.get(settings.SUSLOG, auth=authentication) as response:
+        with requests.get(settings.SUSLOG, auth=authentication, timeout=(10, 30)) as response:
             if response.status_code in (200,301,302,303,307,308):
                 data = response.content.decode('utf-8').split('\n')
             else:

--- a/modules/ransomleak/feed.py
+++ b/modules/ransomleak/feed.py
@@ -44,7 +44,7 @@ def query(settings=None):
         authentication = (settings.AUTH['username'],settings.AUTH['password'])
     try:
         ENDPOINT = settings.URL
-        with requests.get(ENDPOINT, auth=authentication) as response:
+        with requests.get(ENDPOINT, auth=authentication, timeout=(10, 30)) as response:
             soup = BeautifulSoup(response.text,features='lxml')
             groups = [node.get('href') for node in soup.find_all('a') if node.get('href').endswith('.json')]
         fields = collections.OrderedDict({
@@ -76,7 +76,7 @@ def query(settings=None):
             for group in groups:
                 ENDPOINT = settings.URL+group
                 try:
-                    with requests.get(ENDPOINT, auth=authentication) as response:
+                    with requests.get(ENDPOINT, auth=authentication, timeout=(10, 30)) as response:
                         feed = yaml.safe_load(response.content) if response.status_code in (200,301,302,303,307,308) else None
                 except yaml.scanner.ScannerError:
                     pass

--- a/modules/ransomlook/feed.py
+++ b/modules/ransomlook/feed.py
@@ -36,7 +36,7 @@ def query(settings=None):
     count = 0
     stripchars = '\r\n|`\\[\\]\'\"'
     regex = re.compile(r'[%s]' % stripchars)
-    with requests.get(settings.URL+f'/{settings.ENTRIES}') as response:
+    with requests.get(settings.URL+f'/{settings.ENTRIES}', timeout=(10, 30)) as response:
         if response.status_code in (200,):
             json_response = response.json()
             if len(json_response):
@@ -57,7 +57,7 @@ def query(settings=None):
                             if not settings.SCREENDL:
                                 content += f" - Screenshot: [link]({url})"
                             else:
-                                with requests.get(url) as scrdl:
+                                with requests.get(url, timeout=(10, 30)) as scrdl:
                                     if scrdl.status_code in (200,):
                                         for header in scrdl.headers:
                                             if header.lower() == 'content-disposition':

--- a/modules/ransomwatch/feed.py
+++ b/modules/ransomwatch/feed.py
@@ -47,7 +47,7 @@ def query(settings=None):
                     history = shelve.open('modules/ransomwatch/'+settings.HISTORY,writeback=True)
         if not 'ransomwatch' in history:
             history['ransomransomwatch'] = []
-        with requests.get(settings.URL) as response:
+        with requests.get(settings.URL, timeout=(10, 30)) as response:
             feed = response.json()
         entries = sorted(feed, key=lambda feed: feed['discovered'], reverse=True)[:MAX]
         if len(entries):

--- a/modules/siemens/feed.py
+++ b/modules/siemens/feed.py
@@ -49,7 +49,7 @@ def query(settings=None):
     }
     while count < settings.ENTRIES:
         try:
-            with requests.get(settings.URL, headers=headers) as response: # Request advisories
+            with requests.get(settings.URL, headers=headers, timeout=(10, 30)) as response: # Request advisories
                 if response.status_code in (200,204):
                     jsonFeed = response.json()
                     detailURL = None
@@ -59,7 +59,7 @@ def query(settings=None):
                             break
                     if not detailURL:
                         raise ValueError("No link found")
-                    with requests.get(detailURL, headers=headers) as response:
+                    with requests.get(detailURL, headers=headers, timeout=(10, 30)) as response:
                         if response.status_code in (200,204):
                             jsonAdvisory = response.json()
                             link = next((

--- a/modules/wikijs/feed.py
+++ b/modules/wikijs/feed.py
@@ -37,7 +37,7 @@ def query(settings=None):
             headers = { 'Authorization': 'Bearer ' + settings.TOKEN,
                         'Content-Type': 'application/json',
                       },
-        )
+        timeout=(10, 30))
         if response.status_code == 200:
             items = []
             json = response.json()['data']['pages']['list']


### PR DESCRIPTION
## What this is

Mechanical sweep across `commands/` and `modules/`: every `requests.{get,post,put,patch,delete,head,options,request}()` call that didn't already have a `timeout=` kwarg gets `timeout=(10, 30)` — 10s connect, 30s read.

**63 files, 132 callsites, one-for-one line swap, 0 net lines.** AST-aware so multi-line calls and trailing-comma forms (e.g. `modules/wikijs/feed.py`) are handled correctly. Compile-checked across the whole tree.

## Why now

Phase 1's `asyncio.timeout(30)` in `handle_post` caps user-visible wall-clock — but the worker thread inside `run_in_executor` can't be cancelled mid-call. When the asyncio side gave up at 30s, the underlying `requests.get(...)` (with no timeout of its own) could keep blocking on a slow upstream for minutes, silently holding one of the 8 `command_workers` slots until the OS-level TCP timeout finally fired.

Real-world example from this morning's log:
```
WARNING - MatterBot - 2026-05-11 20:11:12,860 -
  Command timed out: module=alienvault command=@ioc user=@penguin channel=debug
```

The `alienvault` module hits **up to 5 sequential** OTX endpoints — any one slow endpoint busts the 30s budget. With this PR, individual HTTP calls fail in bounded time and the worker slot is released within ~30s of the asyncio timeout firing.

## What this does NOT change

- Happy-path commands stay fast (`timeout=(10, 30)` is well above normal API response times).
- The asyncio.timeout(30) bound on user-visible response is unchanged.
- Module logic is untouched — pure kwarg additions.

## Defaults rationale

| Phase | Value | Why |
|---|---|---|
| Connect | 10s | Generous for any reachable host; rejects dead/blackholed targets quickly. |
| Read | 30s | Matches the existing asyncio.timeout(30) at dispatch. Per-call rather than per-command; modules doing N sequential calls can still individually time out, surfacing the slow endpoint in `requests.exceptions.ReadTimeout` rather than burying it. |

Modules with legitimately long calls (large file uploads, scan APIs) can override per-call to higher values if/when needed — none currently observed in the codebase.

## How it was made

AST-aware injection script (`ast` module, libcst not installed). Walks each `.py`, finds `Call` nodes matching `requests.METHOD`, skips any with an existing `timeout` kwarg, splices `, timeout=(10, 30)` before the closing `)`. Handles three call shapes:

1. Empty arg list: `requests.get()` → `requests.get(timeout=(10, 30))`
2. Trailing comma: `requests.post(a, b,)` → `requests.post(a, b, timeout=(10, 30))` (no double comma)
3. Normal: `requests.get(url, headers=h)` → `requests.get(url, headers=h, timeout=(10, 30))`

Verification: zero compile errors across the tree; AST sweep confirms 0/132 callsites missing `timeout=` post-edit.

## Test plan

- [ ] Smoke test: a fast command (`!virustotal <known-hash>`) returns the same as before.
- [ ] Slow-upstream test: temporarily point a module at `https://10.255.255.1` (unroutable). The module should fail with a `ConnectTimeout` after 10s, not hang.
- [ ] Soak: run with feeds active for an hour. Inspect logs for `ReadTimeout`/`ConnectTimeout` from modules — these are now visible signals, not silent thread leaks.
- [ ] Watch the `Command timed out:` log lines (PR #156) — they should still fire on genuinely slow upstreams, but the worker slot should free within ~30s of the timeout instead of indefinitely.