### PR TITLE
Parallelize alienvault endpoint fan-out (reference port)

### DIFF
--- a/commands/alienvault/command.py
+++ b/commands/alienvault/command.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import concurrent.futures
 import re
 import requests
 import traceback
@@ -76,14 +77,14 @@ def process(command, channel, username, params, files, conn):
                     endpoints = ('file/'+query+'/analysis',)
                 if querytype in ('url'):
                     endpoints = ('url/'+query+'/url_list',)
-                for endpoint in endpoints:
+                def _fetch_endpoint(endpoint):
                     APIENDPOINT = settings.APIURL['alienvault']['url']+endpoint+'?limit=10'
                     with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                         message = ''
                         try:
                             json_response = response.json()
                         except:
-                            continue
+                            return None
                         geofields = {
                             'asn': 'ASN',
                             'city': 'City',
@@ -170,7 +171,17 @@ def process(command, channel, username, params, files, conn):
                                                         message += '\n| **Families** | `%s` |' % '`, `'.join(sorted(families))
                         if len(message):
                             table = '| **AlienVault OTX** | **'+query+'** |\n| -: | :- |'+message+'\n\n'
-                            messages.append({'text': table})
+                            return {'text': table}
+                        return None
+                with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(endpoints), 6)) as pool:
+                    futures = [pool.submit(_fetch_endpoint, endpoint) for endpoint in endpoints]
+                    for fut in concurrent.futures.as_completed(futures):
+                        try:
+                            result = fut.result()
+                        except Exception:
+                            continue
+                        if result:
+                            messages.append(result)
     except Exception as e:
         messages.append({'text': 'A Python error occurred searching AlienVault OTX:%s\n%s' % (str(e), traceback.format_exc())})
     finally:


### PR DESCRIPTION
## What this is

Reference port of the **concurrent-fetch** pattern, applied to `commands/alienvault/command.py`. The module's `for endpoint in endpoints:` loop (up to 5 OTX endpoints per query) now fans out across a small `ThreadPoolExecutor` and drains via `as_completed`.

## Why

PR #157 (this PR's base) added `timeout=(10, 30)` to every `requests.*` callsite — bounded each individual HTTP call, but **didn't address the sequential blocking inside modules**. The `alienvault` module hits up to 5 sequential OTX endpoints; with #157 the worst case is still `5 × 30s = 150s`, well past the `asyncio.timeout(30)` outer budget in `handle_post` and starving a `command_workers` slot for the full sum.

This PR makes those endpoint calls fire concurrently. Worst case becomes `max(per-endpoint-timeout) ≈ 30s` — matching the outer asyncio bound.

```
Before:  [reputation 30s] → [geo 30s] → [malware 30s] → [url_list 30s] → [passive_dns 30s] = up to 150s
After:   [reputation 30s]
         [geo        30s]                                                 = up to 30s
         [malware    30s]   ← all in parallel, drained via as_completed
         [url_list   30s]
         [passive_dns 30s]
```

## Design

- `_fetch_endpoint(endpoint)` closure wraps the existing per-endpoint body. Captures `headers`, `query`, `settings` from enclosing scope. Returns `{'text': table}` or `None`. The body is unchanged — only `continue` swaps for `return None`, and the trailing `messages.append(...)` becomes `return {'text': table}`.
- `ThreadPoolExecutor(max_workers=min(len(endpoints), 6))` — bounded so a 1-endpoint query (hash lookup) doesn't spin up an oversized pool, and a 5-endpoint query (IPv4/IPv6/hostname) gets full parallelism.
- `as_completed(futures)` drains in completion order — fast endpoints render first, no head-of-line blocking from a slow one.
- `list.append()` from worker threads is safe — CPython's GIL makes single-list-append atomic, so no lock needed.
- Order across endpoint results is irrelevant — each endpoint produces an independent Markdown table that Mattermost renders in arrival order.

## Why a closure + nested ThreadPool, not a shared helper

Considered extracting a `commands/_common/http.py::concurrent_get(urls, ...)` first. Rejected for the reference port — each module's per-endpoint body does substantial parsing/formatting work (alienvault's is ~90 lines of nested dict walking), so the "fetched response" handed to a caller isn't useful on its own. A shared helper would either need to take a callback per URL (which is just `executor.submit` with extra steps) or only handle the fetch-and-parse-JSON step (leaving the per-endpoint formatting outside the pool, halving the parallelism win).

Per-module closure keeps the entire per-endpoint workload inside the pool. If a clean abstraction emerges after porting 2-3 more modules, refactor then.

## What this does NOT change

- Module output (same Markdown tables, same content, same `messages` list shape).
- Behavior on transient errors — JSON parse failures still skip the endpoint silently (just `return None` instead of `continue`).
- The `asyncio.timeout(30)` outer bound.
- The `command_workers=8` outer pool — inner pool is bounded to 6 and lives only for the lifespan of one `process()` call, so worst-case concurrent sockets per active command is `1 × 6 = 6`.

## Test plan

- [ ] `@alienvault 1.2.3.4` — IPv4 path, 5 endpoints. Verify all 5 tables still appear in Mattermost; verify wall-clock is ~max-of-5 not sum-of-5.
- [ ] `@alienvault google.com` — hostname path, 6 endpoints. Same checks.
- [ ] `@alienvault d41d8cd98f00b204e9800998ecf8427e` — hash path, 1 endpoint. Verify single-endpoint case still works (pool with 1 worker is a no-op overhead).
- [ ] Slow-upstream test: point one OTX endpoint at an unreachable host. Verify the other 4 endpoints' tables still render within ~30s while the slow one quietly times out and is dropped.
- [ ] `@ioc 1.2.3.4` (multi-module fan-out): alienvault should no longer be the slowest contributor when other modules finish.

## Followup

Same pattern applies to the other independent-fanout loops:
- `commands/attackmatrix/command.py` (categories loop, actor-overlap loop)
- `commands/malpedia/command.py` (actornames loop)
- `commands/shodan/command.py` (page-range loop)
- `commands/unprotectit/command.py` (categories loop)
- `commands/leakix/command.py` (endpoint loop)

**Leave sequential** (data-dependent chains where URL N+1 depends on URL N's response):
- `commands/ransomlook/command.py` (group → group-detail)
- `commands/mwdb/command.py` (id-known-upfront chains)
- `commands/reversinglabs/command.py` (samplehashes from prior response)

After review of this reference port, I'll open separate PRs (or commits on this branch, your call) for each fanout-shape module.

## Base note

This PR is based on `fix/requests-timeouts` (PR #157) — once #157 merges, this rebases trivially to `main`.