### PR TITLE
Parallelize malpedia top-level + MITRE fan-out

### DIFF
--- a/commands/malpedia/command.py
+++ b/commands/malpedia/command.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import base64
+import concurrent.futures
 import re
 import requests
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module
@@ -67,18 +69,28 @@ def process(command, channel, username, params, files, conn):
                 if text:
                     messages.append({'text': text, 'uploads': uploads})
             if re.search(r"^[A-Za-z0-9]+$", params):
-                apipath = 'find/actor/%s' % (params,)
-                with requests.get(settings.APIURL['malpedia']['url'] + apipath, headers=headers, timeout=(10, 30)) as response:
-                    actors = response.json()
-                apipath = 'find/family/%s' % (params,)
-                with requests.get(settings.APIURL['malpedia']['url'] + apipath, headers=headers, timeout=(10, 30)) as response:
-                    families = response.json()
+                def _fetch_malpedia(apipath):
+                    with requests.get(settings.APIURL['malpedia']['url'] + apipath, headers=headers, timeout=(10, 30)) as response:
+                        return response.json()
+
+                pool = ThreadPoolExecutor(max_workers=2)
+                try:
+                    actors_fut = pool.submit(_fetch_malpedia, 'find/actor/%s' % (params,))
+                    families_fut = pool.submit(_fetch_malpedia, 'find/family/%s' % (params,))
+                    done, _ = concurrent.futures.wait(
+                        (actors_fut, families_fut), timeout=25,
+                    )
+                    actors = actors_fut.result() if actors_fut in done else None
+                    families = families_fut.result() if families_fut in done else None
+                finally:
+                    pool.shutdown(wait=False, cancel_futures=True)
                 if actors:
                     items = {}
                     subtrees = ('Malwares', 'Matrices', 'Mitigations', 'Techniques', 'Tools')
                     for subtree in subtrees:
                         items[subtree] = set()
                     text = 'Malpedia actor search for `%s`:' % (params,)
+                    mitre_lookups = []
                     for actor in actors:
                         actornames = []
                         actornames.append(actor['common_name'])
@@ -87,19 +99,31 @@ def process(command, channel, username, params, files, conn):
                         text += '\n**Actor names/synonyms**: `' + '`, `'.join(sorted(actornames, key=str.lower)) + '`'
                         for actorname in actornames:
                             if re.search(r"^G[0-9]{4}$", actorname):
+                                mitre_lookups.append(actorname)
+                    if mitre_lookups:
+                        def _fetch_mitre(actorname):
+                            try:
                                 with requests.get(settings.APIURL['mitre']['url'] + 'Actors/' + actorname, headers=headers, timeout=(10, 30)) as response:
-                                    mitre = response.json()
-                                    if mitre:
-                                        for subtree in subtrees:
-                                            if not subtree in items:
-                                                if len(mitre[subtree])>0:
-                                                    items[subtree] = list()
-                                            if subtree in mitre:
-                                                if len(mitre[subtree])>0:
-                                                    for mitrecode in sorted(mitre[subtree], key=str.lower):
-                                                        name = ' '.join(mitre[subtree][mitrecode]['name'])
-                                                        mitreid = mitrecode
-                                                        items[subtree].add((mitreid, name))
+                                    return response.json()
+                            except Exception:
+                                return None
+
+                        pool = ThreadPoolExecutor(max_workers=min(len(mitre_lookups), 6))
+                        try:
+                            futures = [pool.submit(_fetch_mitre, name) for name in mitre_lookups]
+                            done, _ = concurrent.futures.wait(futures, timeout=25)
+                            for fut in done:
+                                mitre = fut.result()
+                                if not mitre:
+                                    continue
+                                for subtree in subtrees:
+                                    if subtree in mitre and len(mitre[subtree])>0:
+                                        for mitrecode in sorted(mitre[subtree], key=str.lower):
+                                            name = ' '.join(mitre[subtree][mitrecode]['name'])
+                                            mitreid = mitrecode
+                                            items[subtree].add((mitreid, name))
+                        finally:
+                            pool.shutdown(wait=False, cancel_futures=True)
                     text += '\n'
                     messages.append({'text': text})
                     for subtree in subtrees:


### PR DESCRIPTION
## What this is

Reference-port the concurrent-fetch pattern (PR #158, hardened by #159) to `commands/malpedia/command.py`. Two HTTP layers in this module are independent and were being executed sequentially.

## Layers

**Top-level** — `find/actor/<query>` and `find/family/<query>` are two endpoints with no data dependency between them. They were issued back-to-back. Now they fire on a 2-worker `ThreadPoolExecutor`, drained with `concurrent.futures.wait(timeout=25)`.

**Inner MITRE fan-out** — for every actor returned by `find/actor`, the module walks the actor's `common_name` + `synonyms` looking for ATT&CK G-IDs (`^G[0-9]{4}$`) and issues one `Actors/<G-id>` lookup per match. These were a nested sequential loop. They're now collected into a single list of lookups, fanned out on a `ThreadPoolExecutor(max_workers=min(N, 6))`, and drained with `wait(timeout=25)`. Results are folded into the same `items[subtree]` set as before (CPython GIL makes `set.add` atomic — no lock needed).

Both pools use the post-#159 discipline: explicit `submit` + bounded `wait` + `pool.shutdown(wait=False, cancel_futures=True)` so partial results return before the outer `asyncio.timeout(30)` in `handle_post` fires. No `with`-block-on-executor (which would hang on `__exit__` waiting for slow futures).

## Wall-clock effect on `@malpedia <query>`

Typical G-id case (e.g. `@malpedia G0096`) has 1–3 MITRE lookups behind 2 top-level calls.

| Path | Before | After |
|---|---|---|
| Top-level (actor + family) | 2 × per-call latency | max(actor, family) |
| Inner MITRE fan-out | N × per-call latency | max of N |
| One slow upstream call | freezes the rest until timeout | drained at 25s, others return |

For a query that hits the slow path in this module on the `@ioc` broadcast, this contributes to keeping the @ioc deadline near `max(per-module-time)` rather than `sum`.

## What this does NOT change

- Output formatting, the ordering of `messages` appended to the channel, or which fields are rendered.
- The `text` concatenation for "Actor names/synonyms" — that still happens in the outer sequential loop, so its order is deterministic by actor index.
- Module-level imports beyond adding `concurrent.futures` / `ThreadPoolExecutor`.
- The `if hash_algo:` (sample-download) branch — single `get/sample/<hash>/zip` call, no fanout opportunity.
- The `if families:` rendering — same as before; family list is consumed sequentially after the parallel fetch returns.

## Test plan

- [ ] `@malpedia APT28` (or any actor with G-id synonyms) — verify all `**Actor names/synonyms**` lines render in actor order, MITRE TTPs render in the same `subtree` order as before.
- [ ] `@malpedia G0096` (single G-id) — verify single-actor + single-MITRE-call case works (pool of 1 worker is harmless).
- [ ] `@malpedia <md5>` (sample-download path) — unchanged code path, verify download still works.
- [ ] `@malpedia <gibberish>` — `actors == []`, `families == []`, no MITRE lookups, no exceptions.
- [ ] Slow-upstream test: point one MITRE lookup at an unreachable host. Verify the other lookups' TTPs still render within ~25s and the slow one is silently dropped.
- [ ] `@ioc <param>` (multi-module fan-out via PR #159's outer `gather`) — malpedia's contribution to the @ioc wall-clock should drop when params trigger the G-id fan-out path.

## Followup

After this lands, remaining fanout-eligible modules on the `@ioc` broadcast (per `grep -l "@ioc" commands/*/defaults.py` ∩ visible HTTP fanout loops): `malwarebazaar`, `urlhaus`, `urlscan`, `virustotal`, `reversinglabs`, `mwdb`. Each warrants its own audit + port — I'll work them as separate PRs.

Sequential-by-design (do NOT parallelize): `misp` (event-id → attribute chain), `variot` (page N+1 needs page 1's total count), `bssc` (single endpoint per invocation).
