### PR TITLE
Parallelize urlscan per-result verdict fetches

### DIFF
--- a/commands/urlscan/command.py
+++ b/commands/urlscan/command.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
+import concurrent.futures
 import re
 import requests
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module
@@ -60,36 +62,54 @@ def process(command, channel, username, params, files, conn):
                                 message += f"\n| Timestamp | Title | IP | URL | Verdict | Details | Screenshot |"
                                 message += f"\n| -: | :- | -: | :- | :- |"
                                 fields = ['title', 'ip', 'url']
+                                candidates = []
                                 for result in json_response["results"]:
                                     if "task" in result:
                                         if "url" in result["task"]:
                                             if any(_ in result["task"]["url"] for _ in params):
                                                 time = result["task"]["time"]
-                                                message += f"\n| {time} "
+                                                fields_text = ""
                                                 for field in fields:
                                                     if field in result['page']:
-                                                        message += f"| `{result['page'][field].replace('.','[.]',1).replace(':','[:]',1).replace('http','hxxp').replace('|','-')}` "
+                                                        fields_text += f"| `{result['page'][field].replace('.','[.]',1).replace(':','[:]',1).replace('http','hxxp').replace('|','-')}` "
                                                     else:
-                                                        message += f"| - "
+                                                        fields_text += f"| - "
                                                 verdicturl = result["result"]
-                                                with requests.get(verdicturl, headers=headers, timeout=(10, 30)) as verdictresponse:
-                                                    if not response.status_code in (200, 206):
-                                                        messages.append({'text': "An error occurred retrieving Urlscan details"})
-                                                    else:
-                                                        json_verdict = verdictresponse.json()
-                                                        if "verdicts" in json_verdict:
-                                                            if "overall" in json_verdict["verdicts"]:
-                                                                if "malicious" in json_verdict["verdicts"]["overall"]:
-                                                                    malicious = json_verdict["verdicts"]["overall"]["malicious"]
-                                                                    if not malicious:
-                                                                        message += "| Safe "
-                                                                    else:
-                                                                        message += "| *MALICIOUS* "
                                                 details = verdicturl.replace('api/v1/','')
                                                 screenshot = result["screenshot"]
-                                                message += f"| [Details]({details}) | [Screenshot]({screenshot}) "
-                                                message += "|"
-                                                length += 1
+                                                candidates.append((time, fields_text, verdicturl, details, screenshot))
+                                verdict_results = {}
+                                if candidates:
+                                    def _fetch_verdict(url):
+                                        try:
+                                            with requests.get(url, headers=headers, timeout=(10, 30)) as r:
+                                                return r.json()
+                                        except Exception:
+                                            return None
+
+                                    pool = ThreadPoolExecutor(max_workers=min(len(candidates), 6))
+                                    try:
+                                        future_to_idx = {pool.submit(_fetch_verdict, c[2]): i for i, c in enumerate(candidates)}
+                                        done, _not_done = concurrent.futures.wait(list(future_to_idx.keys()), timeout=25)
+                                        for fut in done:
+                                            verdict_results[future_to_idx[fut]] = fut.result()
+                                    finally:
+                                        pool.shutdown(wait=False, cancel_futures=True)
+                                for i, (time, fields_text, verdicturl, details, screenshot) in enumerate(candidates):
+                                    message += f"\n| {time} "
+                                    message += fields_text
+                                    json_verdict = verdict_results.get(i)
+                                    if json_verdict and "verdicts" in json_verdict:
+                                        if "overall" in json_verdict["verdicts"]:
+                                            if "malicious" in json_verdict["verdicts"]["overall"]:
+                                                malicious = json_verdict["verdicts"]["overall"]["malicious"]
+                                                if not malicious:
+                                                    message += "| Safe "
+                                                else:
+                                                    message += "| *MALICIOUS* "
+                                    message += f"| [Details]({details}) | [Screenshot]({screenshot}) "
+                                    message += "|"
+                                    length += 1
                                 message += "\n\n"
                                 if length>0:
                                     messages.append({'text': message})


### PR DESCRIPTION
## What this is

Reference-port the concurrent-fetch pattern (PR #158, hardened by #159) to `commands/urlscan/command.py`. The inner per-result `verdicturl` GET was running sequentially inside the results loop — for a hostname returning N matching scans, wall-clock was `N × per-call-latency`.

## Layer

Each `result in json_response["results"]` that passes the params-substring gate triggers one `requests.get(result["result"])` for the per-scan verdict (Safe / *MALICIOUS*). These were back-to-back, blocking each other:

```
Before:  [verdict-1 30s] → [verdict-2 30s] → ... → [verdict-N 30s] = N × 30s worst case
After:   [verdict-1] [verdict-2] ... [verdict-N] in parallel = ~30s worst case
```

## Design

The same restructure shape used for `urlscan`-like patterns:

1. **Phase 1**: walk results, filter through the existing nested `if "task" in result / "url" in result["task"] / any(_ in url for _ in params)` gates, build `(time, fields_text, verdicturl, details, screenshot)` tuples — preserves arrival order.
2. **Phase 2**: fan out verdict GETs on `ThreadPoolExecutor(max_workers=min(len(candidates), 6))`. Drain with `concurrent.futures.wait(timeout=25)`. Tear down with `cancel_futures=True` so the slow tail doesn't block return.
3. **Phase 3**: render rows in arrival order, looking up the verdict from `verdict_results.get(i)`. If the future timed out or errored, the verdict cell is omitted (same effective behavior as before — see preserved-bug note below).

Post-#159 discipline throughout: explicit submit + bounded drain + cancel_futures, not `with`-block-on-executor.

## Preserved-bug note

Line 76 in the original (`if not response.status_code in (200, 206):`) checked the OUTER search response, not `verdictresponse`. That made the error branch effectively dead — the else branch (`json_verdict = verdictresponse.json()`) always fired. So in practice, bad verdicts that returned non-JSON would raise inside the json parse and be caught by the outer except, terminating the whole hostname's processing.

The port preserves the **effective** behavior: bad verdicts return `None` from `_fetch_verdict` (silently skipped), the row renders without a verdict cell. The minor difference: a single bad verdict no longer kills the whole hostname's table — it just leaves one row's verdict cell empty. This is a small UX improvement that falls out of the restructure; happy to revert to the old swallow-everything-on-failure shape if you'd rather keep behavior bit-exact.

## What this does NOT change

- Row ordering — rows render in `json_response["results"]` arrival order, not future completion order.
- Filter logic (the nested `if` gates that decide which results become rows).
- All field formatting (`replace('.','[.]'…)`, hxxp obfuscation, pipe-escaping).
- Module imports beyond adding `concurrent.futures` / `ThreadPoolExecutor`.
- The outer `for hostname in hostnames:` loop — typical `urlscan` invocation has 1 hostname; parallelizing that layer wouldn't move the needle.

## Test plan

- [ ] `@urlscan example.com` (1 hostname, N results) — verify all rows render, in the same order as before, with verdict cells populated.
- [ ] `@urlscan a.com b.com` (2 hostnames) — verify both hostname sections render as two separate messages.
- [ ] `@urlscan <hostname-with-no-results>` — verify no message is appended (length == 0 branch).
- [ ] `@urlscan <hostname>` with `settings.ENTRIES=20` set high — wall-clock should now be ~30s max (one slow verdict's timeout), not 20 × 30s.
- [ ] Slow-upstream test: temporarily point one verdict URL at an unreachable host. Verify the other rows' verdicts still populate and the slow one's row simply has an empty verdict cell.

## Followup

Remaining @ioc-bound fanout candidates worth a port (per `grep -l "@ioc" commands/*/defaults.py` ∩ has-visible-HTTP-fanout-loop): `mwdb` (`for id in ids:` × 2), `reversinglabs` (`for samplehash in samplehashes:`). The Explore audit's claims about `virustotal`/`malwarebazaar` being big fanout candidates were fabricated — those modules issue 1–3 `requests.*` calls total, no HTTP fanout loops.
