### PR TITLE
Parallelize mwdb per-blob parents lookup

### DIFF
--- a/commands/mwdb/command.py
+++ b/commands/mwdb/command.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 import collections
+import concurrent.futures
 import mwdblib
 import re
 import requests
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module
@@ -229,8 +231,22 @@ def process(command, channel, username, params, files, conn):
                             if 'blobs' in json_response:
                                 if len(json_response['blobs']):
                                     blobs += json_response['blobs']
-                                    for blob in blobs:
-                                        blob['parents'] = getBlobParents(blob['id'], mwdb)
+                                    if blobs:
+                                        pool = ThreadPoolExecutor(max_workers=min(len(blobs), 6))
+                                        try:
+                                            future_to_blob = {
+                                                pool.submit(getBlobParents, blob['id'], mwdb): blob
+                                                for blob in blobs
+                                            }
+                                            done, _not_done = concurrent.futures.wait(
+                                                list(future_to_blob.keys()), timeout=25,
+                                            )
+                                            for fut in done:
+                                                future_to_blob[fut]['parents'] = fut.result()
+                                            for fut in (set(future_to_blob) - done):
+                                                future_to_blob[fut]['parents'] = None
+                                        finally:
+                                            pool.shutdown(wait=False, cancel_futures=True)
                     except:
                         raise
                 for file in files:


### PR DESCRIPTION
## What this is

Reference-port the concurrent-fetch pattern (PR #158, hardened by #159) to `commands/mwdb/command.py`. The multi-search path was looking up each returned blob's parents sequentially.

## Layer

In the `querytype == 'multi'` branch (line 224-235 of pre-PR), after the initial `blob?query=multi:<query>` returns a list of N blobs, the code walks them one by one:

```python
for blob in blobs:
    blob['parents'] = getBlobParents(blob['id'], mwdb)
```

`getBlobParents` issues a `mwdb.query(id)` per blob — one HTTP call through `mwdblib` per iteration. For a multi-search returning N blobs, wall-clock was `N × per-call latency`.

## Design

Standard restructure:

- `ThreadPoolExecutor(max_workers=min(len(blobs), 6))`
- Submit one `getBlobParents` per blob, map future → blob dict.
- Drain with `concurrent.futures.wait(timeout=25)`.
- For futures in `done`, assign `blob['parents'] = fut.result()` in place.
- For futures NOT in `done` (timed-out tail), assign `blob['parents'] = None` — same value `getBlobParents` already returns on internal exceptions, so the downstream rendering (`for parent in value:` in the blobs table, lines 280-322) sees the same shape it always has.
- Tear down with `pool.shutdown(wait=False, cancel_futures=True)` so the slow tail doesn't block return before the outer `asyncio.timeout(30)` in `handle_post` fires.

`getBlobParents` already wraps its `mwdb.query()` call in a bare `try/except` that swallows everything and returns `None`, so any per-thread mwdblib failure degrades gracefully.

## Why this path matters for @ioc

`mwdb` is on the `@ioc` broadcast list. When `@ioc <ip|domain|hash>` is invoked and the param doesn't match `checkHash` (i.e. anything other than md5/sha1/sha256/ssdeep), `querytype` defaults to `'multi'` and the multi-search branch fires. That's the branch this PR speeds up.

The `hash` path (single mwdb lookup → single `getFiles`/`getDownloads`/`getConfigs` call against a single-element `[hash]` list) is unchanged — no fanout to win there.

## What this does NOT change

- The initial `blob?query=multi:<query>` search call (single HTTP, no fanout).
- The downstream rendering of `blobs`, `files`, `configs`, `downloads` into Markdown tables.
- The hash-path, the config-path, or any of the formatting helpers.
- Module imports beyond adding `concurrent.futures` / `ThreadPoolExecutor`.
- mwdblib client construction (still one client per `process()` call, shared across threads — read-only queries should be safe; any per-thread failure falls into the existing `try/except` in `getBlobParents`).

## Test plan

- [ ] `@mwdb <md5>` (hash path) — verify unchanged: file/download/config tables render as before.
- [ ] `@mwdb <ipv4-or-domain>` (multi path) — verify all blobs render in the blobs table with their `parents` column populated, same content as before the PR.
- [ ] `@mwdb <unknown>` (multi path returning 0 blobs) — empty-list path, no exceptions.
- [ ] `@ioc <ip>` (full broadcast) — mwdb's contribution to the @ioc wall-clock should drop when many blobs come back.
- [ ] Slow-upstream test: throttle one blob's parent lookup. Verify other blobs' parents still populate and the slow blob ends up with `parents = None` (table cell `-`), no other rows affected.

## Followup

Remaining `@ioc`-bound fanout candidate from the earlier audit pass: `reversinglabs` (`for samplehash in samplehashes:` at L304 of `commands/reversinglabs/command.py`). I'll port that as a separate PR after this lands.

Earlier audit claims about `virustotal` / `malwarebazaar` / `urlhaus` being big fanout candidates were not supported by the code — those modules issue 1–3 `requests.*` calls total with no HTTP-per-iteration loops. They're not portable to this pattern.
