### PR TITLE
Parallelize reversinglabs A1000 sample downloads

### DIFF
--- a/commands/reversinglabs/command.py
+++ b/commands/reversinglabs/command.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 import collections
+import concurrent.futures
 import datetime
 import re
 import requests
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 from ReversingLabs.SDK.a1000 import A1000
 
 ### Dynamic configuration loader (do not change/edit)
@@ -301,11 +303,25 @@ def process(command, channel, username, params, files, conn):
                                                                 message += f"| {name} | `{value}` |\n"
                                 message += '\n\n'
                                 messages.append({'text': message})
-                                for samplehash in samplehashes:
-                                    a1kendpoint = f"https://a1000.reversinglabs.com/api/samples/{samplehash}/download/"
-                                    with requests.get(url=a1kendpoint, headers=a1kheaders, timeout=(10, 30)) as sample:
-                                        if response.status_code in (200,):
-                                            uploads.append({'filename': f"sample-{samplehash}.bin", 'bytes': sample.content})
+                                if samplehashes:
+                                    def _download_sample(samplehash):
+                                        try:
+                                            a1kendpoint = f"https://a1000.reversinglabs.com/api/samples/{samplehash}/download/"
+                                            with requests.get(url=a1kendpoint, headers=a1kheaders, timeout=(10, 30)) as sample:
+                                                return samplehash, sample.content
+                                        except Exception:
+                                            return samplehash, None
+
+                                    pool = ThreadPoolExecutor(max_workers=min(len(samplehashes), 6))
+                                    try:
+                                        futures = [pool.submit(_download_sample, h) for h in samplehashes]
+                                        done, _not_done = concurrent.futures.wait(futures, timeout=25)
+                                        for fut in done:
+                                            samplehash, content = fut.result()
+                                            if content is not None:
+                                                uploads.append({'filename': f"sample-{samplehash}.bin", 'bytes': content})
+                                    finally:
+                                        pool.shutdown(wait=False, cancel_futures=True)
                             uploads.append({'filename': 'reversingslabs-'+query+'-'+datetime.datetime.now().strftime('%Y%m%dT%H%M%S')+'.json', 'bytes': response.content})
                             messages.append({'text': 'ReversingLabs JSON output and related samples:', 'uploads': uploads})
                 if checkMD5(query):


### PR DESCRIPTION
## What this is

Reference-port the concurrent-fetch pattern (PR #158, hardened by #159) to the inner sample-download loop in `commands/reversinglabs/command.py`.

## Layer

Inside the A1000 search-result block, each `result in results` accumulated SHA-256 hashes into `samplehashes` (line 300 pre-PR), then ran:

```python
for samplehash in samplehashes:
    a1kendpoint = f"https://a1000.reversinglabs.com/api/samples/{samplehash}/download/"
    with requests.get(url=a1kendpoint, headers=a1kheaders, timeout=(10, 30)) as sample:
        if response.status_code in (200,):
            uploads.append({'filename': f"sample-{samplehash}.bin", 'bytes': sample.content})
```

These are N independent binary downloads against a1000.reversinglabs.com. Sequential.

## Design

Standard restructure:

- `ThreadPoolExecutor(max_workers=min(len(samplehashes), 6))`
- `_download_sample(hash)` returns `(hash, content)` on success, `(hash, None)` on exception.
- Drain with `concurrent.futures.wait(timeout=25)`. Tear down with `cancel_futures=True` so the slow tail doesn't push us past the outer `asyncio.timeout(30)` in `handle_post`.
- For each completed future, append the sample content to `uploads` if non-None.

Post-#159 discipline throughout.

## Win

Sample binaries are MB-sized — the practical wall-clock saving here is bandwidth + TLS-handshake parallelism, not pure RTT. For N samples on a workstation-grade link, expected wall-clock drops from `N × per-download` toward `max(per-download)`, capped by `min(N, 6)` concurrent connections.

## Preserved-bug notes

Two pre-existing bugs in this block are **deliberately preserved** so this PR stays a pure perf change:

1. **`samplehashes` accumulates across the outer `for result in results:` loop iterations.** Each result iteration re-iterates the full accumulated list. For a multi-result query, samples from earlier results are re-downloaded inside later iterations. My port preserves this: the parallel fan-out fires once per outer-result iteration, against the current accumulated list.

2. **Original status-code check at L307 (`if response.status_code in (200,)`) referred to the OUTER A1000 search response**, not the per-sample download response. At that point in the code the search response is always 200, so the effective behavior was "always append the sample content regardless of download status." My port matches that effective behavior: `_download_sample` returns the content unconditionally on success; the only skip path is an exception during the download.

Both are worth fixing separately. Out of scope for a perf PR.

## What this does NOT change

- The A1000 search POST (single HTTP, no fanout).
- The downstream `uploads` append of the JSON output file at L309 pre-PR (outside the parallelized block).
- The `messages.append({'text': message})` per-result table — still fires before the parallel download phase, in result order.
- Module imports beyond adding `concurrent.futures` / `ThreadPoolExecutor`.

## Test plan

- [ ] `@reversinglabs hash <sha256-with-related-samples>` — verify all related sample binaries get downloaded and appear as Mattermost uploads, same set as before.
- [ ] `@reversinglabs hash <unknown>` — A1000 returns 0 results, no downloads, no exceptions.
- [ ] `@reversinglabs hash <multi-result-query>` — verify the duplicate-download bug (samples re-downloaded across result iterations) is preserved.
- [ ] Slow-upstream test: throttle one sample download. Verify other samples' content still appears in uploads within ~25s and the slow one is silently dropped.
- [ ] Bandwidth-heavy test: hash with 10+ large related samples. Wall-clock should drop substantially vs. sequential.

## State of the followup queue

After this lands, all visibly-portable HTTP fan-out loops on the `@ioc` broadcast path from `grep -l "@ioc" commands/*/defaults.py` have been ported. The remaining @ioc-bound modules (`abuseipdb`, `analyze`, `bootloaders`, `bssc`, `crtsh`, `cyberthreat`, `docspell`, `grayhat`, `gtfobins`, `ipinfo`, `ipwhois`, `lolbas`, `loldrivers`, `lolrmm`, `loobins`, `malwarebazaar`, `misp`, `onionlookup`, `ripewhois`, `sslmate`, `threatfox`, `urlhaus`, `variot`, `virustotal`, `wayback`) either issue a single HTTP request per invocation, walk already-fetched JSON in their loops, or have data-dependent call chains (misp event-id → attribute, variot pagination) that aren't portable.

The other deferred followups from earlier PRs remain:
- Trim `traceback.format_exc()` from channel-facing error messages (deferred from #152)
- Refresh `self.channels` / `self.feedmap` after long disconnects (deferred from #153)
- Reject-immediately UX on per-user semaphore saturation (deferred from #155)
