### PR TITLE
Remove credential leaks, TLS-verify bypass, and recursive-response default

### DIFF
--- a/commands/snowplough/command.py
+++ b/commands/snowplough/command.py
@@ -34,20 +34,15 @@ def process(command, channel, username, params, files, conn):
         messages = []
         params = params[0].replace('[.]','.')
         token = base64.b64encode(f"{settings.APIURL['servicenow']['username']}:{settings.APIURL['servicenow']['password']}".encode('utf-8')).decode('ascii')
-        print(token)
         url = settings.APIURL['servicenow']['url']
         try:
             headers = {
                 'Content-Type': settings.CONTENTTYPE,
                 'Authorization': 'Basic %s' % (token,),
             }
-            print(headers)
-            print(url)
             with requests.get(url, headers=headers, timeout=(10, 30)) as response:
                 json_response = response.json()
-                print(json_response)
         except Exception as e:
             messages.append({'text': "An error occurred searching ServiceNow:`%s`\nError: %s" % (str(e),traceback.format_exc())})
         finally:
-            print(messages)
             return {'messages': messages}

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -41,7 +41,7 @@ Matterbot:
   welcome_banner: "**Welcome to this Mattermost!**" # Put your single-line welcome banner here. Use the welcome_file for larger messages (e.g. ToS)
   welcome_channel: "abc" # Set this to the channel ID where the bot will welcome users
   welcome_file: "welcome.msg" # Optionally, add this message to the generic welcome
-  recursion: True # Is the bot allowed to respond to its own messages?
+  recursion: False # Is the bot allowed to respond to its own messages? Default False to prevent feedback loops.
   msglength: 16383 # Change to '4000' if you are using Mattermost <=5.x (seriously, you should upgrade!)
   logcmd: True
   logcmdparams: False

--- a/modules/ransomleak/feed.py
+++ b/modules/ransomleak/feed.py
@@ -106,7 +106,6 @@ def query(settings=None):
                                             session = requests.Session()
                                             session.max_redirects = 3
                                             session.headers = headers
-                                            session.verify = False
                                             with session.get(url,allow_redirects=False,timeout=10) as response:
                                                 session.cookies.update(session.cookies)
                                             with session.get(url,allow_redirects=False,timeout=10) as response:


### PR DESCRIPTION
Three independent quick-win fixes bundled into a single PR. No functional behavior change beyond what each item explicitly addresses.

## 1. `commands/snowplough/command.py` — remove five debug `print()` leaks

Pre-PR the module bare-`print()`'d five values, all of which land in stdout (and `matterfeed.log`):

| Line | Leaked value |
|---|---|
| 37 | `token` — base64-encoded `username:password` for the ServiceNow API |
| 44 | `headers` — including the `Authorization: Basic <token>` line |
| 45 | `url` — internal ServiceNow endpoint |
| 48 | `json_response` — the full ticket payload (can contain customer data, incident detail, PII) |
| 52 | `messages` — final user-facing output (less sensitive but pointless log noise) |

All five are debug residue, not intentional logging — no log-level gate, no formatter, just bare `print()`. Removed.

## 2. `modules/ransomleak/feed.py:109` — drop `session.verify = False`

The ransomleak feed module silently disabled TLS certificate verification on its second-stage fetch. That accepts MITM substitution of the upstream HTML, which is then parsed and pushed straight into Mattermost as a feed post. No other module in `modules/` does this — it was a one-off outlier, almost certainly leftover from local debugging against a cert-broken endpoint.

Removed. The fetch now uses the default (`verify=True`) like every other feed module in the tree.

## 3. `config.defaults.yaml:44` — flip `recursion: True` → `False`

The shipped default allowed the bot to respond to its own messages, which is a feedback-loop hazard on any module whose output happens to match a command trigger. Operators who knowingly want self-response (testing, a deliberate echo module) can flip it back; the safe default is off, and matches what most readers of the config assume the bot is already doing.

## What this does NOT change

- snowplough still issues the same `GET`, parses the same response shape, surfaces the same error message on failure. Only the print-to-stdout side-channel goes away.
- ransomleak still uses the same `requests.Session`, same headers, same cookie-stash + double-GET pattern, same redirect cap. Only the silent TLS bypass goes away.
- `recursion: False` matches what most operators already think the bot does by default. Anyone with a deliberate recursion use case can override in their `config.yaml`.

## Test plan

- [ ] Start the bot, invoke `!snowplough <query>`. Verify the channel response is unchanged; check `matterfeed.log` no longer contains the base64 token, headers, URL, or ticket JSON.
- [ ] Run the ransomleak feed loop against the production endpoint. Verify feed posts continue to arrive. (If the upstream's TLS cert is broken at the time of testing, fetches will now fail loudly — that's correct behavior; fix the upstream rather than re-enable the bypass.)
- [ ] Boot the bot with the shipped defaults and confirm `recursion: False` is in effect: the bot does not react to its own posts in any channel.

## Source

Item 1 of the Phase 2 queue (`matterbot_phase2_queue.md`). Phase 1's `requests.*` timeout sweep (#157), gather restructure (#159), and the four fan-out ports (#160–#163) are all merged; the queue gate is satisfied.
