### PR TITLE
SSRF hardening: tlsgrab IP gate + bluesky/mastodon media-fetch filter

### DIFF
--- a/commands/tlsgrab/command.py
+++ b/commands/tlsgrab/command.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import OpenSSL
+import ipaddress
 import re
 import ssl
 
@@ -37,11 +38,20 @@ def process(command, channel, username, params, files, conn):
                 CNs = []
                 param = param.replace('[.]','.')
                 if re.search(r"^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\:[0-9]*)?$", param):
-                    ipaddress = param.split(':')[0]
+                    host = param.split(':')[0]
                     port = int(param.split(':')[1]) if ':' in param else 443
-                    message = '**TLSGrab** Canonical names for `'+ipaddress+'`:`'+str(port)+'`: '
+                    message = '**TLSGrab** Canonical names for `'+host+'`:`'+str(port)+'`: '
                     try:
-                        cert = ssl.get_server_certificate((ipaddress, port))
+                        host_ip = ipaddress.ip_address(host)
+                    except ValueError:
+                        messages.append({'text': message + 'invalid IP address.'})
+                        continue
+                    if (host_ip.is_private or host_ip.is_loopback or host_ip.is_link_local
+                            or host_ip.is_multicast or host_ip.is_reserved or host_ip.is_unspecified):
+                        messages.append({'text': message + 'refused — non-routable / internal address.'})
+                        continue
+                    try:
+                        cert = ssl.get_server_certificate((host, port))
                         x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert)
                         for component in x509.get_subject().get_components():
                             if component[0] == b'CN':

--- a/modules/bluesky/feed.py
+++ b/modules/bluesky/feed.py
@@ -14,9 +14,49 @@
 
 import bs4
 import feedparser
+import ipaddress
 import re
 import requests
+import socket
+from urllib.parse import urlparse
 
+
+def _safe_fetch(url, headers, max_bytes=5 * 1024 * 1024):
+    """SSRF-guarded HTTPS GET for upstream-RSS-controlled media URLs.
+
+    Returns the response body bytes on success, or None on any refusal
+    (non-https scheme, unresolvable host, private/loopback/link-local/
+    multicast/reserved IP, redirect, non-200/206 status, body over the
+    cap, transport exception). No partial bodies are returned: oversize
+    responses are dropped entirely so a hostile feed cannot exfiltrate
+    a giant payload through a media-attachment channel post.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != 'https' or not parsed.hostname:
+        return None
+    try:
+        resolved = socket.gethostbyname(parsed.hostname)
+        host_ip = ipaddress.ip_address(resolved)
+    except (socket.gaierror, ValueError):
+        return None
+    if (host_ip.is_private or host_ip.is_loopback or host_ip.is_link_local
+            or host_ip.is_multicast or host_ip.is_reserved or host_ip.is_unspecified):
+        return None
+    try:
+        with requests.get(url, headers=headers, timeout=(10, 30),
+                          allow_redirects=False, stream=True) as r:
+            if r.status_code not in (200, 206):
+                return None
+            chunks = []
+            total = 0
+            for chunk in r.iter_content(chunk_size=64 * 1024):
+                total += len(chunk)
+                if total > max_bytes:
+                    return None
+                chunks.append(chunk)
+            return b''.join(chunks)
+    except Exception:
+        return None
 
 
 def query(settings=None):
@@ -60,12 +100,11 @@ def query(settings=None):
                     for media in feed.entries[count]['media_content']:
                         if 'url' in media:
                             url = media['url']
-                            with requests.get(url, headers=headers, timeout=(10, 30)) as response:
-                                if response.status_code in (200,206):
-                                    filename = url.split('/')[-1]
-                                    bytes = response.content
-                                    upload = {'filename': filename, 'bytes': bytes}
-                                    uploads.append(upload)
+                            content = _safe_fetch(url, headers)
+                            if content is not None:
+                                filename = url.split('/')[-1]
+                                upload = {'filename': filename, 'bytes': content}
+                                uploads.append(upload)
                 for channel in settings.CHANNELS:
                     if upload:
                         items.append([channel, content, {'uploads': uploads}])

--- a/modules/bluesky/feed.py
+++ b/modules/bluesky/feed.py
@@ -100,10 +100,10 @@ def query(settings=None):
                     for media in feed.entries[count]['media_content']:
                         if 'url' in media:
                             url = media['url']
-                            content = _safe_fetch(url, headers)
-                            if content is not None:
+                            body = _safe_fetch(url, headers)
+                            if body is not None:
                                 filename = url.split('/')[-1]
-                                upload = {'filename': filename, 'bytes': content}
+                                upload = {'filename': filename, 'bytes': body}
                                 uploads.append(upload)
                 for channel in settings.CHANNELS:
                     if upload:

--- a/modules/mastodon/feed.py
+++ b/modules/mastodon/feed.py
@@ -102,10 +102,10 @@ def query(settings=None):
                     for media in feed.entries[count]['media_content']:
                         if 'url' in media:
                             url = media['url']
-                            content = _safe_fetch(url, headers)
-                            if content is not None:
+                            body = _safe_fetch(url, headers)
+                            if body is not None:
                                 filename = url.split('/')[-1]
-                                upload = {'filename': filename, 'bytes': content}
+                                upload = {'filename': filename, 'bytes': body}
                                 uploads.append(upload)
                 for channel in settings.CHANNELS:
                     if upload:

--- a/modules/mastodon/feed.py
+++ b/modules/mastodon/feed.py
@@ -15,9 +15,49 @@
 import bs4
 import feedparser
 import html
+import ipaddress
 import re
 import requests
+import socket
+from urllib.parse import urlparse
 
+
+def _safe_fetch(url, headers, max_bytes=5 * 1024 * 1024):
+    """SSRF-guarded HTTPS GET for upstream-RSS-controlled media URLs.
+
+    Returns the response body bytes on success, or None on any refusal
+    (non-https scheme, unresolvable host, private/loopback/link-local/
+    multicast/reserved IP, redirect, non-200/206 status, body over the
+    cap, transport exception). No partial bodies are returned: oversize
+    responses are dropped entirely so a hostile feed cannot exfiltrate
+    a giant payload through a media-attachment channel post.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != 'https' or not parsed.hostname:
+        return None
+    try:
+        resolved = socket.gethostbyname(parsed.hostname)
+        host_ip = ipaddress.ip_address(resolved)
+    except (socket.gaierror, ValueError):
+        return None
+    if (host_ip.is_private or host_ip.is_loopback or host_ip.is_link_local
+            or host_ip.is_multicast or host_ip.is_reserved or host_ip.is_unspecified):
+        return None
+    try:
+        with requests.get(url, headers=headers, timeout=(10, 30),
+                          allow_redirects=False, stream=True) as r:
+            if r.status_code not in (200, 206):
+                return None
+            chunks = []
+            total = 0
+            for chunk in r.iter_content(chunk_size=64 * 1024):
+                total += len(chunk)
+                if total > max_bytes:
+                    return None
+                chunks.append(chunk)
+            return b''.join(chunks)
+    except Exception:
+        return None
 
 
 def query(settings=None):
@@ -62,12 +102,11 @@ def query(settings=None):
                     for media in feed.entries[count]['media_content']:
                         if 'url' in media:
                             url = media['url']
-                            with requests.get(url, headers=headers, timeout=(10, 30)) as response:
-                                if response.status_code in (200,206):
-                                    filename = url.split('/')[-1]
-                                    bytes = response.content
-                                    upload = {'filename': filename, 'bytes': bytes}
-                                    uploads.append(upload)
+                            content = _safe_fetch(url, headers)
+                            if content is not None:
+                                filename = url.split('/')[-1]
+                                upload = {'filename': filename, 'bytes': content}
+                                uploads.append(upload)
                 for channel in settings.CHANNELS:
                     if upload:
                         items.append([channel, content, {'uploads': uploads}])


### PR DESCRIPTION
Three SSRF surfaces hardened in one PR. All three accepted upstream-controlled hosts (user-supplied for `tlsgrab`, RSS-feed-supplied for `bluesky` and `mastodon`) and fed them to `ssl.get_server_certificate` / `requests.get` with no scheme check, no IP filter, no body cap, and no redirect control. A hostile input could turn the bot into an internal-network prober — and, in the RSS cases, into an unintentional data-exfiltration channel via "media attachment" channel posts.

This PR ships **two commits**:
1. The main SSRF hardening (tlsgrab IP gate + bluesky/mastodon `_safe_fetch` helper).
2. A follow-up rename fix on bluesky/mastodon where my first commit introduced a `content` variable that shadowed the channel post text. Caught before merge — kept as a separate commit for review clarity rather than amended, so the regression and the fix are both visible.

## 1. `commands/tlsgrab/command.py` — IP gate before the TLS handshake

Pre-PR: the IPv4 regex validated SHAPE only — any well-formed dotted-quad passed. The bot then issued `ssl.get_server_certificate` to that address and posted the subject CNs to the channel. A user could ask the bot to probe `127.0.0.1:6379`, `10.0.0.0/8`, or the cloud metadata endpoint `169.254.169.254`, leaking internal topology and cert names to anyone in the channel.

**Fix:** after the regex match, parse the host via `ipaddress.ip_address` and reject if any of `{is_private, is_loopback, is_link_local, is_multicast, is_reserved, is_unspecified}`. A user-visible refusal message is posted so legitimate users get feedback. The local variable previously named `ipaddress` (shadowing the stdlib module) is renamed `host`.

Verified IP gate behavior:

| IP | Result |
|---|---|
| `8.8.8.8`, `1.1.1.1` | ✓ allowed |
| `127.0.0.1` | ✗ blocked (loopback) |
| `10.0.0.1`, `192.168.1.1` | ✗ blocked (private) |
| `169.254.169.254` | ✗ blocked (link-local — AWS/GCP/Azure metadata) |
| `224.0.0.1` | ✗ blocked (multicast) |
| `0.0.0.0` | ✗ blocked (unspecified) |

## 2 + 3. `modules/bluesky/feed.py` + `modules/mastodon/feed.py` — `_safe_fetch` for RSS-driven media URLs

Pre-PR: an upstream-RSS-controlled media URL was fetched via `requests.get(url, ...)` and the body posted as a Mattermost file attachment. No scheme check, no host filter, no body-size cap, and `allow_redirects` defaulted to True — so a hostile feed entry's `media_content` URL could serve `http://169.254.169.254/...` (or a 30x to it) and have the bot DM/post the cloud metadata response back to the channel.

**Fix:** each module now has a `_safe_fetch(url, headers, max_bytes=5 MiB)` helper that enforces:

- scheme must be `https`
- hostname must resolve to a public IP (block private/loopback/link-local/multicast/reserved/unspecified)
- `allow_redirects=False`
- `stream=True` with a 5 MiB total-body cap (oversize → drop, no partial returned)
- any transport exception silently returns `None`

The two RSS modules ship identical copies of this helper. Not extracted to a shared utility (no precedent for cross-module imports under `modules/`); revisit if a third RSS media-fetch surface emerges.

## Note on the IP-gate TOCTOU

DNS resolution happens before `requests.get`, so a hostile resolver could in theory return different IPs to each call. The pre-fetch gate is still useful defense-in-depth — the practical attack surface is much narrower than the unfiltered version. Full mitigation (pinning the resolved IP through to the socket via a custom adapter) is out of scope for this PR.

## Note on the bug fixed in commit 2

In the first commit, I assigned the fetched bytes to a local named `content`. But `content` was already in scope as the Mattermost POST TEXT (the line `"<NAME>: [<title>](<link>)\n><description>\n"` built ~10 lines earlier). Each media-attachment iteration overwrote `content` with the binary blob, so the subsequent `items.append([channel, content, {"uploads": uploads}])` would push the binary into the text slot. Posts with no media attachments were unaffected (inner loop never ran). Posts WITH media — exactly the case this PR is meant to harden — would have surfaced as broken channel entries.

Caught by re-reading the linter-reformatted file before push. Second commit renames my local to `body`, leaving `content` (the post text) untouched. Two-line change per file.

## What this does NOT change

- TLS handshake logic in tlsgrab is unchanged for public targets.
- Bluesky/mastodon RSS parsing, channel routing, description handling, and the upload structure are all unchanged.
- Module-level imports beyond adding `ipaddress`, `socket`, and `urllib.parse.urlparse`.

## Test plan

- [ ] `@tlsgrab 8.8.8.8` → unchanged behavior, returns CNs.
- [ ] `@tlsgrab 127.0.0.1` → polite refusal message in channel, no probe.
- [ ] `@tlsgrab 169.254.169.254` → polite refusal, no metadata leak.
- [ ] `@tlsgrab 192.168.1.1:443` → polite refusal.
- [ ] Bluesky feed with a media item served from a public CDN over HTTPS → image attaches as before, channel text is the post header + description (NOT the binary bytes).
- [ ] Bluesky feed with a media item URL pointing at `http://example.com/...` (http scheme) → silently dropped, post text still appears.
- [ ] Mastodon feed: same two scenarios.
- [ ] Hypothetical hostile feed entry with `media_content.url = http://169.254.169.254/...` → fetch is refused, no body posted to channel.
- [ ] Feed item with a >5 MiB media URL → no upload, no truncated upload, channel post text appears clean.

## Source

Queue items 7 (H2) and 8 (H4) from `matterbot_phase2_queue.md`.
