### PR TITLE
Add @welcome module: per-channel rules force-pushed via DM on first join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ modules/*/*.cache.db
 modules/*/*.json
 modules/*/settings.py
 modules/csirt*/*
+# Welcome module local state (SQLite)
+commands/welcome/state.db
+commands/welcome/state.db-journal
+commands/welcome/state.db-wal
+commands/welcome/state.db-shm
 # Do not share proprietary content
 commands/*/template/*
 # Not really useful for public use

--- a/WELCOME-MODULE-PROPOSAL.md
+++ b/WELCOME-MODULE-PROPOSAL.md
@@ -1,0 +1,180 @@
+# Welcome Module Proposal
+
+A welcome-message module for MatterBot that configures per-channel rules via `@welcome` admin commands and force-pushes them to new joiners via DM (with optional public greet) on the first time the bot sees them in a configured channel.
+
+## Requirements
+
+- Configurable welcome message per public **or** private channel.
+- Configuration survives bot restart.
+- Triggered on the first time a user joins each channel — never re-triggers on re-join.
+- Force-push delivery so the rules cannot be missed.
+
+## File layout
+
+```
+commands/welcome/
+├── command.py        # @welcome subcommands (set/get/list/clear/test/admin add|remove|list/...)
+├── defaults.py       # DB path, default delivery mode (no static admin list — auth is live)
+├── welcome.py        # Shared module: DB schema, state queries, join-handler entry point, auth checks
+└── state.db          # SQLite, created on first write (gitignored)
+```
+
+Plus a small hook in `matterbot.py` to wire join events into the handler. That is the only `matterbot.py` change.
+
+## Data model — SQLite, single file
+
+Location: `commands/welcome/state.db` (lives next to `command.py` / `defaults.py` in the module directory).
+
+```sql
+CREATE TABLE welcome_configs (
+    channel_id    TEXT PRIMARY KEY,
+    channel_name  TEXT NOT NULL,         -- snapshot for /list readability, refreshed on touch
+    message       TEXT NOT NULL,         -- markdown; supports {user} placeholder
+    delivery      TEXT NOT NULL DEFAULT 'dm',  -- 'dm' | 'channel' | 'both'
+    public_greet  TEXT,                  -- optional short channel post when delivery in ('channel','both')
+    enabled       INTEGER NOT NULL DEFAULT 1,
+    updated_at    TEXT NOT NULL,
+    updated_by    TEXT NOT NULL
+);
+
+CREATE TABLE welcomed_users (
+    channel_id   TEXT NOT NULL,
+    user_id      TEXT NOT NULL,
+    welcomed_at  TEXT NOT NULL,
+    PRIMARY KEY (channel_id, user_id)
+);
+
+CREATE TABLE channel_admins (
+    channel_id  TEXT NOT NULL,
+    user_id     TEXT NOT NULL,
+    added_at    TEXT NOT NULL,
+    added_by    TEXT NOT NULL,
+    PRIMARY KEY (channel_id, user_id)
+);
+```
+
+SQLite over shelve because: queryable, concurrent-safe within a process, ACID on writes. Single file. Matches the "survives restart" requirement trivially. The `channel_admins` table stores the per-channel explicit allowlist (see Authorization below).
+
+## Trigger surface — three event sources, one handler
+
+In `matterbot.py`:
+
+1. **`posted` event** with `post['type'] == 'system_join_channel'` — user self-joins a public channel.
+2. **`user_added` event** — user added by someone else (private channel invite, admin-add, etc.).
+3. **On WS reconnect / bot startup** — reconcile pass: for each row in `welcome_configs`, `GET /api/v4/channels/{channel_id}/members`, diff against `welcomed_users`, welcome anyone new.
+
+All three call `welcome.on_join(user_id, channel_id)`. That function:
+
+```
+1. If user_id == self.my_user_id → return (don't welcome the bot)
+2. If welcomed_users has (channel_id, user_id) → return (already welcomed)
+3. If welcome_configs has (channel_id, enabled=1) → send message
+4. Insert into welcomed_users  ← always insert, even if no config existed,
+                                  so configuring a welcome later does NOT
+                                  spam existing members
+```
+
+That last point is the key correctness detail: **insert into `welcomed_users` for every join event we see, regardless of whether a welcome is configured**. This way, when an admin later runs `@welcome set` on a long-lived channel, existing members are already marked and only future joiners get the message.
+
+To handle the "channel that existed before the bot did" case: the first time a channel gets a welcome configured, run the reconcile pass once and mark all current members as welcomed (silently). Default behavior — opt-in flag `--also-existing` if the admin actually wants to welcome retroactively.
+
+## Admin commands — `@welcome`
+
+| Command | Action |
+|---|---|
+| `@welcome set <message>` | Set/update welcome for the **current** channel (channel inferred from command context — no need to type channel name). Marks all existing members as welcomed silently. |
+| `@welcome get` | Show current welcome config for this channel. |
+| `@welcome clear` | Remove welcome config for this channel. Does NOT clear `welcomed_users` history. |
+| `@welcome delivery <dm\|channel\|both>` | Change delivery mode for this channel. |
+| `@welcome greet <text>` | Set the public greet line (used when delivery includes a channel post). Empty arg removes it. |
+| `@welcome test` | Send the configured welcome to the invoker, as a dry-run. Does NOT mark welcomed. |
+| `@welcome list` | DM the invoker a table of all configured channels. |
+| `@welcome reset [@user]` | Clear welcomed-state for this channel (or just one user). Next sighting re-triggers. |
+| `@welcome admin add @user` | Add a user to the per-channel admin allowlist for the **current** channel. |
+| `@welcome admin remove @user` | Remove a user from the per-channel admin allowlist for the current channel. |
+| `@welcome admin list` | Show the per-channel admin allowlist for the current channel. |
+
+Channel reference defaults to *the channel the command was typed in*. Removes a whole class of "lookup channel by name" complexity.
+
+### Authorization — three sources, any-of
+
+Every `@welcome` subcommand checks `is_welcome_admin(user_id, channel_id)`, which passes if **any** of the following hold:
+
+1. **User holds the `system_admin` Mattermost role** (global super-admin). Always allowed, regardless of channel membership or per-channel allowlist.
+2. **User holds the `channel_admin` Mattermost role for the target channel.** Resolved via `GET /api/v4/channels/{channel_id}/members/{user_id}` — the returned `roles` field carries the channel-scoped roles. A 404 (user not a channel member) is treated as "no" and falls through to the next check rather than erroring.
+3. **User is in the per-channel allowlist** stored in the `channel_admins` SQLite table for that specific `channel_id`. Managed at runtime via the `@welcome admin add/remove/list` subcommands.
+
+Order matters for cost: check role (1) first since it's a single API call already cached on most paths; check (2) only if (1) fails (one extra API call); check (3) only if (2) fails (one local SQLite lookup). The result is cached per `(user_id, channel_id)` tuple inside one command invocation so the three commands `@welcome set ... ; @welcome greet ... ; @welcome delivery dm` from the same user in the same channel don't hammer the API.
+
+**Bootstrap:** when a brand-new channel has no per-channel allowlist entries yet, only `system_admin` or the channel's `channel_admin` can call `@welcome admin add` to seed it. This matches Mattermost's native pattern — channel admins designate their own delegates.
+
+**Bot rejection on failed auth:** single-line "not authorized" reply in the same channel where the command was typed. No state change, nothing logged beyond a single DEBUG line (we don't want to give a probe-anyone helpful info about which check failed).
+
+`defaults.py` no longer ships an `ADMIN_USERS` list. The shipped defaults file carries only the SQLite path and the default delivery mode. All authorization is computed live from Mattermost's role API + the per-channel SQLite allowlist.
+
+## Delivery semantics
+
+Three modes. **Default is `dm`** — chosen for the rules-of-server use case where force-pushing the rules to the joiner matters more than publicly acknowledging the arrival.
+
+- **`dm`** *(default)* — bot creates a direct channel with the user via `POST /api/v4/channels/direct`, posts the full message there. Mattermost surfaces DMs prominently with a badge and (if user has push notifs enabled) a system notification. Hard to miss.
+- **`channel`** — bot posts the welcome in the channel itself, mentioning `@user` if the message contains `{user}`. Social-pressure mode. Visible to everyone but easy to miss in busy channels.
+- **`both`** — short `public_greet` line in the channel ("Welcome @user — DM'd you the rules"), full message in DM. Use when both social acknowledgement and force-push delivery matter.
+
+## Message templating
+
+Support exactly one placeholder for v1: `{user}` → expands to `@username`. Anything else (channel name, join date, custom variables) deferred until someone asks for it. Keeps the v1 parser trivial.
+
+## What survives bot restart
+
+- `welcome_configs` — all welcome rules.
+- `welcomed_users` — all sightings, so re-joins are not re-welcomed.
+- The reconcile-on-startup pass catches users who joined while the bot was offline.
+
+## What it does NOT try to do (deliberately)
+
+- No multi-message welcomes (one message per channel; admins use markdown for length).
+- No per-user welcome (the rules are channel rules, not user-specific).
+- No expiry / re-welcome after N days (could add later via timestamp + TTL on `welcomed_users`).
+- No emoji-reaction acknowledgement flow (interesting follow-up but separate scope).
+- No template engine — single placeholder, that's it.
+- No automatic channel-admin role detection — explicit admin list. Mattermost's role API is more involved than worth wiring into v1.
+
+## Integration touch on `matterbot.py`
+
+Three small adds:
+
+1. In `handle_post` early-branch: if `post['type'] == 'system_join_channel'`, call `welcome.on_join(post['user_id'], post['channel_id'])` and `return` (don't run command dispatch on system posts).
+2. In the WebSocket dispatch (wherever `posted` / `user_added` events arrive): add a case for `user_added` that calls `welcome.on_join(event['data']['user_id'], event['broadcast']['channel_id'])`.
+3. In the post-reconnect path (now that PR #153's reconnect loop exists): call `welcome.reconcile()` once per successful reconnect. The reconcile function iterates configured channels and welcomes any user we missed.
+
+Everything else lives in `commands/welcome/`. No spillover into the rest of the bot.
+
+## Failure modes covered
+
+- **Bot offline during join** → reconcile on reconnect catches the joiner.
+- **User leaves + rejoins** → already in `welcomed_users`, no re-welcome.
+- **Duplicate `posted` + `user_added` events for the same join** → atomic upsert into `welcomed_users` makes the second call a no-op.
+- **DM creation fails (Mattermost API hiccup)** → log + don't insert into `welcomed_users`, so next sighting will retry. (Tradeoff: if the API is *permanently* broken for one user, the bot will re-attempt every reconcile cycle. Add a `failed_attempts` counter later if it becomes noisy.)
+- **Welcome configured for a now-deleted channel** → reconcile finds the channel returns 404, logs once, marks config as disabled.
+- **Channel renamed** → `channel_id` is stable, transparent.
+
+## Test plan
+
+- `@welcome set Welcome! Rules: be kind.` in `#test-channel` (run by a `system_admin` or a `channel_admin` of `#test-channel`) → config stored, existing members silently marked welcomed.
+- Non-admin runs `@welcome set` → polite refusal in the same channel, no state change, no welcome-config written.
+- New user joins `#test-channel` → bot DMs them within seconds (default delivery `dm`). `welcomed_users` row inserted.
+- Same user re-joins after leaving → no DM. `welcomed_at` unchanged.
+- Bot restart → state intact, no re-welcome of anyone in `welcomed_users`.
+- Bot offline → user joins → bot restarts → reconcile pass DMs the user.
+- Two channels with different welcome configs, same user joins both → two DMs (one per channel), each with the right channel's rules.
+- `@welcome delivery both` + `@welcome greet "Welcome {user}!"` → next joiner gets a public greet AND a DM.
+- `@welcome admin add @alice` (run by a `system_admin` or `channel_admin`) → Alice can now run any `@welcome` subcommand in this channel. Same call from Alice WITHOUT prior privileges → refusal.
+- `@welcome admin remove @alice` → Alice can no longer configure welcome in this channel.
+- `@welcome admin list` → shows the per-channel allowlist.
+- System admin runs `@welcome set` in a channel they are NOT a member of → succeeds (system_admin bypasses the channel-member check).
+
+## Resolved decisions
+
+- **Storage location** — `commands/welcome/state.db`, lives next to `command.py` / `defaults.py` in the module directory.
+- **Default delivery mode** — `dm`. Configurable per-channel via `@welcome delivery channel|both`.
+- **Admin model** — three-source auth (`system_admin` Mattermost role OR `channel_admin` Mattermost role for the target channel OR explicit per-channel allowlist in the `channel_admins` table). The allowlist is managed at runtime via `@welcome admin add/remove/list`. `defaults.py` ships no static admin list; all authorization is computed live.

--- a/commands/welcome/command.py
+++ b/commands/welcome/command.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+
+"""@welcome subcommand handler.
+
+Dispatches `@welcome <sub> [args]` against the shared welcome.py helpers.
+All authorization is delegated to welcome.is_welcome_admin (three-source
+any-of: system_admin role, channel_admin role on this channel, or per-
+channel allowlist).
+"""
+
+import re
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+_pkg = __package__ or Path(__file__).parent.name
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+# Sibling shared module — see welcome.py for DB, auth, delivery, on_join.
+from . import welcome as wm
+
+
+# ----- caller resolution ----------------------------------------------------
+# process() receives `channel` (NAME) and `username`. We need the IDs to
+# scope DB rows and to call the Mattermost API. Look them up via conn.
+
+def _resolve_caller(conn, channel_name, username, team_id=None):
+    """Returns (user_id, channel_id) for the @welcome invocation, or
+    (None, None) on lookup failure. Best-effort: any API error surfaces
+    as None and the caller emits a generic 'could not resolve' reply."""
+    try:
+        user_id = conn.users.get_user_by_username(username)['id']
+    except Exception:
+        return None, None
+    try:
+        if team_id is None:
+            # Fall back to the bot's "me" team — slightly chatty but
+            # safe; the alternative is threading team_id through
+            # call_module's signature, which is a bigger change.
+            me = conn.users.get_user('me')
+            teams = conn.teams.get_user_teams(me['id'])
+            team_id = teams[0]['id'] if teams else None
+        if not team_id:
+            return user_id, None
+        chan = conn.channels.get_channel_by_name(team_id, channel_name)
+        return user_id, chan['id']
+    except Exception:
+        return user_id, None
+
+
+# ----- mention parsing ------------------------------------------------------
+
+_USER_MENTION_RX = re.compile(r'^@([A-Za-z0-9._\-]+)$')
+
+
+def _resolve_mention(conn, mention):
+    """Take an @username token (with leading @) and return the user_id, or
+    None if it doesn't resolve. Used by `@welcome admin add @alice`."""
+    m = _USER_MENTION_RX.match(mention.strip())
+    if not m:
+        return None
+    try:
+        return conn.users.get_user_by_username(m.group(1))['id']
+    except Exception:
+        return None
+
+
+# ----- subcommand handlers --------------------------------------------------
+
+def _sub_set(conn, args, channel_id, channel_name, user_id):
+    if not args:
+        return "Usage: `@welcome set <message>`. Markdown allowed. `{user}` expands to the joining user's mention."
+    message = ' '.join(args).strip()
+    if len(message) > settings.MAX_MESSAGE_LEN:
+        return f"Welcome message too long ({len(message)} chars; max {settings.MAX_MESSAGE_LEN})."
+
+    existing = wm.get_config(channel_id)
+    delivery = existing['delivery'] if existing else settings.DEFAULT_DELIVERY
+    public_greet = existing['public_greet'] if existing else None
+
+    wm.set_config(channel_id, channel_name, message, delivery, public_greet, user_id)
+
+    # Bootstrap: mark all current channel members as welcomed so newly
+    # configuring on a long-lived channel does not flood existing users.
+    bootstrap_marked = 0
+    try:
+        page = 0
+        while True:
+            members = conn.channels.get_channel_members(
+                channel_id, params={'page': page, 'per_page': 200},
+            )
+            if not members:
+                break
+            for member in members:
+                mid = member.get('user_id')
+                if mid and wm.mark_welcomed(channel_id, mid):
+                    bootstrap_marked += 1
+            page += 1
+    except Exception:
+        # Non-fatal — the welcome is stored, but we could not mark all
+        # current members. Reconcile-on-reconnect will catch up.
+        return (f"Welcome stored. **Warning:** could not enumerate existing channel "
+                f"members to mark them as already-welcomed. They may be DM'd on the "
+                f"next reconcile pass.")
+    return f"Welcome stored for `#{channel_name}` ({bootstrap_marked} existing members silently marked as already-welcomed, delivery=`{delivery}`)."
+
+
+def _sub_get(channel_id, channel_name):
+    cfg = wm.get_config(channel_id)
+    if not cfg:
+        return f"No welcome configured for `#{channel_name}`."
+    delivery = cfg['delivery']
+    greet = cfg.get('public_greet') or '_(none)_'
+    return (
+        f"**Welcome config for `#{channel_name}`**\n\n"
+        f"- Delivery: `{delivery}`\n"
+        f"- Public greet: {greet}\n"
+        f"- Updated at: `{cfg['updated_at']}` by `{cfg['updated_by']}`\n\n"
+        f"**Message:**\n\n{cfg['message']}"
+    )
+
+
+def _sub_clear(channel_id, channel_name):
+    if not wm.get_config(channel_id):
+        return f"No welcome configured for `#{channel_name}` — nothing to clear."
+    wm.clear_config(channel_id)
+    return f"Welcome cleared for `#{channel_name}`. Welcomed-users history retained."
+
+
+def _sub_delivery(args, channel_id, channel_name, user_id):
+    if not args or args[0].lower() not in ('dm', 'channel', 'both'):
+        return "Usage: `@welcome delivery <dm|channel|both>`"
+    mode = args[0].lower()
+    cfg = wm.get_config(channel_id)
+    if not cfg:
+        return f"No welcome configured for `#{channel_name}` — `@welcome set <message>` first."
+    wm.set_config(
+        channel_id, channel_name, cfg['message'], mode, cfg.get('public_greet'), user_id,
+    )
+    return f"Delivery mode for `#{channel_name}` set to `{mode}`."
+
+
+def _sub_greet(args, channel_id, channel_name, user_id):
+    cfg = wm.get_config(channel_id)
+    if not cfg:
+        return f"No welcome configured for `#{channel_name}` — `@welcome set <message>` first."
+    text = ' '.join(args).strip() or None
+    wm.set_config(
+        channel_id, channel_name, cfg['message'], cfg['delivery'], text, user_id,
+    )
+    if text is None:
+        return f"Public greet cleared for `#{channel_name}`."
+    return f"Public greet for `#{channel_name}` set to: {text}"
+
+
+def _sub_test(conn, my_id, channel_id, channel_name, user_id):
+    cfg = wm.get_config(channel_id)
+    if not cfg:
+        return f"No welcome configured for `#{channel_name}` — nothing to test."
+    # Use the caller as the recipient. Does NOT mark them as welcomed
+    # (so a real future join still triggers normally).
+    ok = wm.deliver(conn, my_id, user_id, channel_id, cfg)
+    if ok:
+        return f"Test welcome delivered to you per the `{cfg['delivery']}` config. (Your welcomed-state is unchanged.)"
+    return f"Test welcome FAILED for `#{channel_name}`. Check the bot logs for the API error."
+
+
+def _sub_list(conn):
+    rows = wm.list_configs()
+    if not rows:
+        return "No welcome configs anywhere."
+    lines = [
+        "| Channel | Delivery | Enabled | Updated by | Updated at |",
+        "| :- | :- | :- | :- | :- |",
+    ]
+    for r in rows:
+        chan = r['channel_name'] or r['channel_id']
+        lines.append(
+            f"| `{chan}` | `{r['delivery']}` | "
+            f"{'yes' if r['enabled'] else 'no'} | `{r['updated_by']}` | `{r['updated_at']}` |"
+        )
+    return "\n".join(lines)
+
+
+def _sub_reset(conn, args, channel_id, channel_name):
+    if not args:
+        wm.reset_welcomed(channel_id)
+        return f"Welcomed-state cleared for ALL users in `#{channel_name}`. They will be re-welcomed on next sighting."
+    target_id = _resolve_mention(conn, args[0])
+    if not target_id:
+        return f"Could not resolve `{args[0]}` to a user — use `@username`."
+    wm.reset_welcomed(channel_id, target_id)
+    return f"Welcomed-state cleared for {args[0]} in `#{channel_name}`."
+
+
+def _sub_admin(conn, args, channel_id, channel_name, caller_user_id):
+    if not args:
+        return "Usage: `@welcome admin <add|remove|list> [@user]`"
+    op = args[0].lower()
+    if op == 'list':
+        rows = wm.list_channel_admins(channel_id)
+        if not rows:
+            return f"No per-channel admins for `#{channel_name}` (system_admin + channel_admin roles still apply)."
+        try:
+            names = []
+            for r in rows:
+                try:
+                    u = conn.users.get_user(r['user_id'])
+                    names.append(f"@{u['username']}")
+                except Exception:
+                    names.append(f"`{r['user_id']}`")
+            return f"Per-channel admins for `#{channel_name}`: " + ', '.join(names)
+        except Exception:
+            return f"Per-channel admin user_ids for `#{channel_name}`: " + ', '.join(f"`{r['user_id']}`" for r in rows)
+    if op in ('add', 'remove'):
+        if len(args) < 2:
+            return f"Usage: `@welcome admin {op} @user`"
+        target_id = _resolve_mention(conn, args[1])
+        if not target_id:
+            return f"Could not resolve `{args[1]}` to a user — use `@username`."
+        if op == 'add':
+            wm.add_channel_admin(channel_id, target_id, caller_user_id)
+            return f"Added {args[1]} to the per-channel admin allowlist for `#{channel_name}`."
+        else:
+            wm.remove_channel_admin(channel_id, target_id)
+            return f"Removed {args[1]} from the per-channel admin allowlist for `#{channel_name}`."
+    return f"Unknown admin subcommand `{op}`. Use `add`, `remove`, or `list`."
+
+
+# ----- process() entry point -------------------------------------------------
+
+def process(command, channel, username, params, files, conn):
+    try:
+        messages = []
+
+        # Resolve who and where.
+        user_id, channel_id = _resolve_caller(conn, channel, username)
+        if not user_id or not channel_id:
+            messages.append({'text': "Could not resolve caller user / channel via the Mattermost API. Try again, or check the bot logs."})
+            return {'messages': messages}
+
+        # Authorize. Same gate for every subcommand.
+        try:
+            my_id = conn.users.get_user('me')['id']
+        except Exception:
+            messages.append({'text': "Internal error: bot could not resolve its own user id."})
+            return {'messages': messages}
+
+        if not wm.is_welcome_admin(conn, user_id, channel_id):
+            messages.append({'text': "Not authorized. `@welcome` requires system_admin role, channel_admin on this channel, or membership in the per-channel allowlist."})
+            return {'messages': messages}
+
+        # Dispatch.
+        if not params:
+            messages.append({'text':
+                "Usage: `@welcome <subcommand> [args]`\n\n"
+                "Subcommands: `set <message>`, `get`, `clear`, "
+                "`delivery <dm|channel|both>`, `greet <text>`, `test`, `list`, "
+                "`reset [@user]`, `admin add|remove|list [@user]`."})
+            return {'messages': messages}
+
+        sub = params[0].lower()
+        args = params[1:]
+
+        if sub == 'set':
+            text = _sub_set(conn, args, channel_id, channel, user_id)
+        elif sub == 'get':
+            text = _sub_get(channel_id, channel)
+        elif sub == 'clear':
+            text = _sub_clear(channel_id, channel)
+        elif sub == 'delivery':
+            text = _sub_delivery(args, channel_id, channel, user_id)
+        elif sub == 'greet':
+            text = _sub_greet(args, channel_id, channel, user_id)
+        elif sub == 'test':
+            text = _sub_test(conn, my_id, channel_id, channel, user_id)
+        elif sub == 'list':
+            text = _sub_list(conn)
+        elif sub == 'reset':
+            text = _sub_reset(conn, args, channel_id, channel)
+        elif sub == 'admin':
+            text = _sub_admin(conn, args, channel_id, channel, user_id)
+        else:
+            text = (f"Unknown subcommand `{sub}`. Run `@welcome` with no args "
+                    f"to see the usage line.")
+
+        messages.append({'text': text})
+        return {'messages': messages}
+    except Exception as e:
+        return {'messages': [{'text': f"`@welcome` internal error: `{e}`. See bot logs for traceback."}]}

--- a/commands/welcome/defaults.py
+++ b/commands/welcome/defaults.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# Bindings that trigger this command in any channel. The bot owner can override
+# in settings.py per the usual module convention.
+BINDS = ['@welcome']
+
+# Use the 'any' wildcard so admins can configure welcome in any channel the
+# bot is in. The ACL fix in PR #165 (matterbot.py:isallowed_module) makes
+# 'any' a real wildcard token. Operators who haven't merged that fix yet can
+# replace this with an explicit channel list in settings.py.
+CHANS = ['any']
+
+CONTENTTYPE = 'application/json'
+
+# Path to the SQLite state file. Lives next to this module so all welcome
+# state is co-located with the code that uses it. Override in settings.py
+# if a different location is preferred.
+import os as _os
+DB_PATH = _os.path.join(_os.path.dirname(_os.path.abspath(__file__)), 'state.db')
+
+# Default delivery mode for a freshly-configured channel. Operators can
+# change per-channel via `@welcome delivery <mode>`. See HELP for modes.
+DEFAULT_DELIVERY = 'dm'
+
+# Maximum allowed length of a welcome message body. Mattermost enforces its
+# own ceiling (config.defaults.yaml Matterbot.msglength = 16383), but a
+# tighter cap here is friendlier — multi-screen walls of text get truncated
+# at submit-time rather than at delivery.
+MAX_MESSAGE_LEN = 8192
+
+HELP = {
+    'DEFAULT': {
+        'args': '<subcommand> [args]',
+        'desc': 'Per-channel welcome messages. Subcommands: '
+                '`set <message>`, `get`, `clear`, '
+                '`delivery <dm|channel|both>`, `greet <text>`, `test`, `list`, '
+                '`reset [@user]`, '
+                '`admin add @user`, `admin remove @user`, `admin list`. '
+                'Authorization: system_admin OR channel_admin (Mattermost role on the target channel) '
+                'OR per-channel allowlist. `{user}` in the message expands to the joining user\'s mention.',
+    },
+}

--- a/commands/welcome/welcome.py
+++ b/commands/welcome/welcome.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+
+"""Shared welcome-module helpers.
+
+Owns:
+  - SQLite schema for welcome_configs / welcomed_users / channel_admins
+  - The on_join() event handler called by matterbot.py from two event paths
+    (system_join_channel posts and user_added events) and from the
+    post-reconnect reconcile pass
+  - is_welcome_admin() three-source authorization
+  - DM / channel / both delivery
+  - Per-config DB helpers (set/get/clear/admins/welcomed)
+
+Imported as a sibling by command.py (relative import) and from matterbot.py
+via the package path commands/welcome -> welcome.welcome.
+"""
+
+import logging
+import sqlite3
+import threading
+import time
+
+try:
+    # When loaded inside the bot's module loader, the package is `welcome`
+    # (the directory name lower-cased) and defaults is alongside.
+    from . import defaults  # type: ignore[import-not-found]
+except ImportError:
+    # When matterbot.py imports us directly via `welcome.welcome`, the
+    # relative import above doesn't work because we aren't running inside
+    # a package context. Fall back to the absolute path the loader uses.
+    import defaults  # type: ignore[import-not-found,no-redef]
+
+log = logging.getLogger('matterbot')
+
+# Single lock for write paths. SQLite's own file lock would also work,
+# but at the WAL+per-call-connection scale we have, an in-process lock
+# is simpler and avoids retry-on-SQLITE_BUSY noise.
+_write_lock = threading.Lock()
+
+
+def _connect():
+    """Open a fresh SQLite connection. We don't share connections across
+    threads — the cost is microseconds and it sidesteps SQLite's
+    same-thread enforcement entirely."""
+    conn = sqlite3.connect(defaults.DB_PATH, timeout=10.0)
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = NORMAL")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_schema():
+    """Create tables on first run. Idempotent. Called once at module-load
+    time below — operators don't have to do anything to bootstrap."""
+    with _write_lock:
+        conn = _connect()
+        try:
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS welcome_configs (
+                    channel_id    TEXT PRIMARY KEY,
+                    channel_name  TEXT NOT NULL,
+                    message       TEXT NOT NULL,
+                    delivery      TEXT NOT NULL DEFAULT 'dm',
+                    public_greet  TEXT,
+                    enabled       INTEGER NOT NULL DEFAULT 1,
+                    updated_at    TEXT NOT NULL,
+                    updated_by    TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS welcomed_users (
+                    channel_id   TEXT NOT NULL,
+                    user_id      TEXT NOT NULL,
+                    welcomed_at  TEXT NOT NULL,
+                    PRIMARY KEY (channel_id, user_id)
+                );
+                CREATE TABLE IF NOT EXISTS channel_admins (
+                    channel_id  TEXT NOT NULL,
+                    user_id     TEXT NOT NULL,
+                    added_at    TEXT NOT NULL,
+                    added_by    TEXT NOT NULL,
+                    PRIMARY KEY (channel_id, user_id)
+                );
+            """)
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def _now():
+    return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+
+
+# ----- config CRUD -----------------------------------------------------------
+
+def get_config(channel_id):
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT channel_id, channel_name, message, delivery, public_greet, "
+            "       enabled, updated_at, updated_by "
+            "FROM welcome_configs WHERE channel_id = ?",
+            (channel_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def set_config(channel_id, channel_name, message, delivery, public_greet, updated_by):
+    with _write_lock:
+        conn = _connect()
+        try:
+            conn.execute(
+                "INSERT INTO welcome_configs "
+                "    (channel_id, channel_name, message, delivery, public_greet, "
+                "     enabled, updated_at, updated_by) "
+                "VALUES (?, ?, ?, ?, ?, 1, ?, ?) "
+                "ON CONFLICT(channel_id) DO UPDATE SET "
+                "    channel_name = excluded.channel_name, "
+                "    message      = excluded.message, "
+                "    delivery     = excluded.delivery, "
+                "    public_greet = excluded.public_greet, "
+                "    enabled      = 1, "
+                "    updated_at   = excluded.updated_at, "
+                "    updated_by   = excluded.updated_by",
+                (channel_id, channel_name, message, delivery, public_greet,
+                 _now(), updated_by),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def clear_config(channel_id):
+    with _write_lock:
+        conn = _connect()
+        try:
+            conn.execute("DELETE FROM welcome_configs WHERE channel_id = ?", (channel_id,))
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def list_configs():
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT channel_id, channel_name, delivery, enabled, updated_at, updated_by "
+            "FROM welcome_configs ORDER BY channel_name"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ----- welcomed-users tracking ----------------------------------------------
+
+def mark_welcomed(channel_id, user_id):
+    """Insert into welcomed_users. Returns True if newly inserted, False if
+    the row already existed (idempotent — duplicate join events are a no-op)."""
+    with _write_lock:
+        conn = _connect()
+        try:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO welcomed_users (channel_id, user_id, welcomed_at) "
+                "VALUES (?, ?, ?)",
+                (channel_id, user_id, _now()),
+            )
+            conn.commit()
+            return cur.rowcount > 0
+        finally:
+            conn.close()
+
+
+def is_welcomed(channel_id, user_id):
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM welcomed_users WHERE channel_id = ? AND user_id = ?",
+            (channel_id, user_id),
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def reset_welcomed(channel_id, user_id=None):
+    with _write_lock:
+        conn = _connect()
+        try:
+            if user_id is None:
+                conn.execute("DELETE FROM welcomed_users WHERE channel_id = ?", (channel_id,))
+            else:
+                conn.execute(
+                    "DELETE FROM welcomed_users WHERE channel_id = ? AND user_id = ?",
+                    (channel_id, user_id),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+# ----- per-channel admin allowlist ------------------------------------------
+
+def add_channel_admin(channel_id, user_id, added_by):
+    with _write_lock:
+        conn = _connect()
+        try:
+            conn.execute(
+                "INSERT OR IGNORE INTO channel_admins "
+                "    (channel_id, user_id, added_at, added_by) "
+                "VALUES (?, ?, ?, ?)",
+                (channel_id, user_id, _now(), added_by),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def remove_channel_admin(channel_id, user_id):
+    with _write_lock:
+        conn = _connect()
+        try:
+            conn.execute(
+                "DELETE FROM channel_admins WHERE channel_id = ? AND user_id = ?",
+                (channel_id, user_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def list_channel_admins(channel_id):
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT user_id, added_at, added_by FROM channel_admins "
+            "WHERE channel_id = ? ORDER BY added_at",
+            (channel_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def is_channel_allowlisted(channel_id, user_id):
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM channel_admins WHERE channel_id = ? AND user_id = ?",
+            (channel_id, user_id),
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+# ----- three-source authorization -------------------------------------------
+
+def _user_has_system_admin(mmDriver, user_id):
+    try:
+        userinfo = mmDriver.users.get_user(user_id)
+        roles = [r.lower() for r in userinfo.get('roles', '').split()]
+        return 'system_admin' in roles
+    except Exception:
+        log.exception(f"welcome: get_user({user_id}) failed during admin check")
+        return False
+
+
+def _user_has_channel_admin(mmDriver, channel_id, user_id):
+    try:
+        member = mmDriver.channels.get_channel_member(channel_id, user_id)
+        roles = [r.lower() for r in member.get('roles', '').split()]
+        return 'channel_admin' in roles
+    except Exception:
+        # 404 if the user isn't a member — not an error, just "no"
+        return False
+
+
+def is_welcome_admin(mmDriver, user_id, channel_id):
+    """Three-source any-of check. Order is by cost: cheapest first.
+
+    1. system_admin role (one users.get_user call — often already cached)
+    2. channel_admin role on the target channel (one members call)
+    3. per-channel allowlist (one SQLite lookup)
+    """
+    if _user_has_system_admin(mmDriver, user_id):
+        return True
+    if _user_has_channel_admin(mmDriver, channel_id, user_id):
+        return True
+    if is_channel_allowlisted(channel_id, user_id):
+        return True
+    return False
+
+
+# ----- delivery -------------------------------------------------------------
+
+def _get_or_create_direct_channel(mmDriver, my_id, target_user_id):
+    """Wrap the mattermostdriver direct-message-channel creator. Method
+    name has varied across driver versions; try the canonical and fall
+    back to the older alias."""
+    options = [my_id, target_user_id]
+    channels_api = mmDriver.channels
+    if hasattr(channels_api, 'create_direct_message_channel'):
+        return channels_api.create_direct_message_channel(options=options)
+    if hasattr(channels_api, 'create_direct_channel'):
+        return channels_api.create_direct_channel(options=options)
+    raise RuntimeError("mattermostdriver: no direct-message-channel creator")
+
+
+def _render(template, user_mention):
+    if not template:
+        return template
+    return template.replace('{user}', user_mention)
+
+
+def _resolve_user_mention(mmDriver, user_id):
+    try:
+        username = mmDriver.users.get_user(user_id).get('username') or user_id
+    except Exception:
+        username = user_id
+    return f"@{username}"
+
+
+def deliver(mmDriver, my_id, user_id, channel_id, config):
+    """Try to deliver the configured welcome to the user. Returns True on
+    any successful delivery (DM or channel post), False on total failure.
+
+    Caller uses the return value to decide whether to mark the user as
+    welcomed — total failures should leave them unmarked so the next
+    sighting retries."""
+    message = config['message']
+    delivery = config['delivery']
+    public_greet = config.get('public_greet') or ''
+    user_mention = _resolve_user_mention(mmDriver, user_id)
+    rendered_msg = _render(message, user_mention)
+    rendered_greet = _render(public_greet, user_mention) or f"Welcome {user_mention}!"
+
+    delivered = False
+
+    if delivery in ('dm', 'both'):
+        try:
+            dm = _get_or_create_direct_channel(mmDriver, my_id, user_id)
+            mmDriver.posts.create_post(options={
+                'channel_id': dm['id'],
+                'message': rendered_msg,
+            })
+            delivered = True
+        except Exception:
+            log.exception(
+                f"welcome: DM delivery failed user={user_id} channel={channel_id}"
+            )
+
+    if delivery in ('channel', 'both'):
+        try:
+            text = rendered_greet if delivery == 'both' else rendered_msg
+            mmDriver.posts.create_post(options={
+                'channel_id': channel_id,
+                'message': text,
+            })
+            delivered = True
+        except Exception:
+            log.exception(
+                f"welcome: channel post failed user={user_id} channel={channel_id}"
+            )
+
+    return delivered
+
+
+# ----- on_join event handler ------------------------------------------------
+
+def on_join(mmDriver, my_id, user_id, channel_id):
+    """Called from matterbot.py when a user joins a channel the bot can see.
+
+    Idempotent and synchronous. Designed to be dispatched off the asyncio
+    event loop via loop.run_in_executor — does its own SQLite I/O and
+    HTTP calls without yielding."""
+    if not user_id or not channel_id:
+        return
+    if user_id == my_id:
+        return  # bot's own join
+
+    if is_welcomed(channel_id, user_id):
+        return
+
+    config = get_config(channel_id)
+
+    if config is None or not config.get('enabled'):
+        # No welcome configured — but still record the sighting so a future
+        # `@welcome set` on this channel doesn't spam existing members.
+        mark_welcomed(channel_id, user_id)
+        return
+
+    if deliver(mmDriver, my_id, user_id, channel_id, config):
+        mark_welcomed(channel_id, user_id)
+    # else: leave unmarked so the next sighting retries delivery
+
+
+# ----- reconcile (called from matterbot.py:run_forever before each WS connect)
+
+def reconcile(mmDriver, my_id):
+    """Walk every configured channel, fetch its members, and on_join() any
+    user we haven't welcomed yet. Catches joins that happened while the
+    bot was offline."""
+    try:
+        configs = list_configs()
+    except Exception:
+        log.exception("welcome.reconcile: list_configs failed")
+        return
+
+    for cfg in configs:
+        channel_id = cfg['channel_id']
+        try:
+            page = 0
+            while True:
+                members = mmDriver.channels.get_channel_members(
+                    channel_id, params={'page': page, 'per_page': 200},
+                )
+                if not members:
+                    break
+                for member in members:
+                    member_user_id = member.get('user_id')
+                    if not member_user_id:
+                        continue
+                    try:
+                        on_join(mmDriver, my_id, member_user_id, channel_id)
+                    except Exception:
+                        log.exception(
+                            f"welcome.reconcile: on_join failed "
+                            f"user={member_user_id} channel={channel_id}"
+                        )
+                page += 1
+        except Exception:
+            log.exception(f"welcome.reconcile: channel {channel_id} member fetch failed")
+
+
+# ----- module-load-time bootstrap -------------------------------------------
+
+# Create the SQLite schema on first import. Cheap (IF NOT EXISTS), idempotent,
+# and means operators don't have to run a separate migration step.
+try:
+    init_schema()
+except Exception:
+    log.exception("welcome: init_schema failed at import time")

--- a/matterbot.py
+++ b/matterbot.py
@@ -133,6 +133,16 @@ class MattermostManager(object):
         while True:
             connected_at = time.monotonic()
             try:
+                # Welcome-module reconcile pass — catches anyone who joined a
+                # configured channel while the bot was offline. Optional: if the
+                # welcome module isn't loaded, skip without error.
+                try:
+                    from welcome.welcome import reconcile as _welcome_reconcile
+                    _welcome_reconcile(self.mmDriver, self.my_id)
+                except ImportError:
+                    pass
+                except Exception:
+                    log.exception("welcome.reconcile failed (continuing)")
                 log.info("Connecting Mattermost websocket")
                 self.mmDriver.init_websocket(self.handle_raw_message)
                 log.warning("Websocket loop returned (server closed connection?)")
@@ -222,6 +232,28 @@ class MattermostManager(object):
         try:
             if 'event' in message:
                 post_data = message['data']
+                # Welcome-module hook: 'user_added' events arrive here with the
+                # target channel in `broadcast.channel_id`, which is not threaded
+                # into handle_event. Dispatch the welcome on_join directly so the
+                # channel id is preserved. ImportError = welcome module not in
+                # this deployment; silently skip.
+                if message.get('event') == 'user_added':
+                    broadcast = message.get('broadcast') or {}
+                    join_user_id = post_data.get('user_id')
+                    join_channel_id = broadcast.get('channel_id') or post_data.get('channel_id')
+                    if join_user_id and join_channel_id:
+                        try:
+                            from welcome.welcome import on_join as _welcome_on_join
+                            loop = asyncio.get_running_loop()
+                            loop.run_in_executor(
+                                self._command_executor,
+                                _welcome_on_join,
+                                self.mmDriver, self.my_id, join_user_id, join_channel_id,
+                            )
+                        except ImportError:
+                            pass
+                        except Exception:
+                            log.exception("welcome.on_join hook failed (user_added)")
                 if 'post' in post_data: # We're handling some kind of post, e.g. a channel message
                     await self.handle_post(post_data)
                 else: # We're probably handling something administrative, such as channel adds/removals
@@ -759,6 +791,26 @@ class MattermostManager(object):
             # We're currently not handling users editing messages
             return
         post = json.loads(data['post'])
+        # Welcome-module hook: system_join_channel posts indicate a user joined
+        # a (typically public) channel. Defer to the welcome module and short-
+        # circuit — system posts have empty `message` and would otherwise drop
+        # through the command-dispatch loop harmlessly, but explicit early
+        # return is cheaper and clearer.
+        if post.get('type') == 'system_join_channel':
+            try:
+                from welcome.welcome import on_join as _welcome_on_join
+                loop = asyncio.get_running_loop()
+                loop.run_in_executor(
+                    self._command_executor,
+                    _welcome_on_join,
+                    self.mmDriver, self.my_id,
+                    post.get('user_id'), post.get('channel_id'),
+                )
+            except ImportError:
+                pass
+            except Exception:
+                log.exception("welcome.on_join hook failed (system_join_channel)")
+            return
         userid = post['user_id']
         chanid = post['channel_id']
         chaninfo = self.chanid_to_chaninfo(chanid)


### PR DESCRIPTION
A new `commands/welcome/` module that lets channel admins configure a welcome message per public or private channel. The message is force-pushed via DM to each user the first time the bot sees them in the channel. Configuration and welcomed-users state survive bot restart (SQLite).

## Module shape

```
commands/welcome/
├── command.py     # @welcome subcommand dispatcher
├── welcome.py     # shared: DB schema, three-source auth, delivery, on_join, reconcile
└── defaults.py    # BINDS=['@welcome'], CHANS=['any'], DB_PATH, DEFAULT_DELIVERY='dm'
```

Plus three small hooks in `matterbot.py` to dispatch join events into the module, and a `.gitignore` entry for the SQLite file (`commands/welcome/state.db`, lives next to the code).

## Authorization — three sources, any-of

Every `@welcome` subcommand checks `is_welcome_admin(driver, user, channel)`:

1. **`system_admin` Mattermost role** (global super-admin). One `users.get_user` call.
2. **`channel_admin` Mattermost role on the target channel.** One `channels.get_channel_member` call. 404 (user not a channel member) falls through cleanly.
3. **Per-channel allowlist** in the `channel_admins` SQLite table. One local lookup.

Order is by cost (cheapest first). Per-channel allowlist is managed at runtime via `@welcome admin add/remove/list`. `defaults.py` ships **no** static admin list — all authorization is computed live. Bootstrap matches Mattermost's native pattern: a fresh channel starts with empty allowlist; only a `system_admin` or actual `channel_admin` can seed the first delegate.

## Admin commands

| Command | Action |
|---|---|
| `@welcome set <message>` | Set/update welcome for the current channel. Marks all existing members welcomed silently. `{user}` placeholder = joiner's mention. |
| `@welcome get` | Show current config. |
| `@welcome clear` | Remove config (welcomed_users history retained). |
| `@welcome delivery <dm\|channel\|both>` | Change delivery mode. |
| `@welcome greet <text>` | Set/clear the public greet line. |
| `@welcome test` | Send the configured welcome to invoker as dry-run; does NOT mark welcomed. |
| `@welcome list` | Show all configured channels. |
| `@welcome reset [@user]` | Clear welcomed-state for this channel (or one user). |
| `@welcome admin add\|remove @user` | Manage the per-channel allowlist. |
| `@welcome admin list` | Show the per-channel allowlist. |

## Event trigger surface — three sources, one handler

`matterbot.py`:

- **`handle_post` early branch** when `post.get('type') == 'system_join_channel'` → dispatches `welcome.on_join` via `run_in_executor`, returns (does not run command dispatch on system posts).
- **`handle_message` user_added branch.** Hooked here rather than in `handle_event` because the channel id arrives in `broadcast.channel_id` — `handle_event` does not thread the broadcast through. → dispatches `welcome.on_join` via `run_in_executor`.
- **`run_forever` reconcile** before each `init_websocket` call (including initial connect). Iterates every configured channel and welcomes anyone we missed while offline.

All three call `welcome.on_join(driver, my_id, user_id, channel_id)`. Synchronous, idempotent (`INSERT OR IGNORE` on `welcomed_users`). The executor offload keeps the asyncio loop free during the ~300ms SQLite + DM API round-trip.

All three hooks are **import-tolerant**: an `ImportError` on `from welcome.welcome import ...` is silently skipped, so a deployment without this module keeps working.

## Correctness details

- **ALWAYS mark welcomed on every observed join, even when no config exists.** This means a future `@welcome set` on a long-lived channel does NOT spam its existing members.
- **`@welcome set` additionally enumerates current channel members and marks them welcomed** as a bootstrap pass — covers channels that existed before the bot saw their joins.
- **If delivery fails entirely (both DM and channel paths erred), the user is NOT marked welcomed** — next sighting retries.
- **If delivery succeeded on ANY path (DM or channel), mark welcomed.**
- **Duplicate `posted` + `user_added` events for the same join** are no-ops via `INSERT OR IGNORE`.
- **Channel renamed**: `channel_id` is stable, transparent.
- **Channel deleted**: reconcile logs the error per-channel and moves on.

## Delivery modes (default `dm`)

| Mode | Behavior |
|---|---|
| `dm` (default) | Bot creates a direct channel via `channels.create_direct_message_channel` and posts the full message. Mattermost surfaces DMs with a badge and (if push notifs enabled) a system notification. Hardest to miss. |
| `channel` | Bot posts the full message in the channel itself. Social-pressure mode. |
| `both` | Short `public_greet` line in the channel + full DM. |

`{user}` placeholder in the message or in `public_greet` expands to the joiner's `@username` mention.

## Coexistence with the existing welcome banner

`config.defaults.yaml`'s pre-existing `welcome:` / `welcome_channel:` / `welcome_banner:` mechanism (driven by `matterbot.py:start_welcome_channel` and `update_welcome_channel`) tracks a SINGLE designated welcome channel and posts a banner when new members arrive. **It is not changed by this PR.** Both can run side by side. If you prefer this richer per-channel mechanism, set `welcome: False` in your config.

## What this does NOT try to do (deliberately)

- No multi-message welcomes (one config per channel; markdown handles length).
- No per-user welcomes (rules are channel-scoped).
- No re-welcome after N days (could add timestamp TTL later).
- No emoji-reaction acknowledgement flow.
- No template engine beyond `{user}`.
- No automatic channel-admin role discovery beyond Mattermost's native `channel_admin` role. The explicit per-channel allowlist covers users who should have welcome-admin without a full Mattermost role.

## Test plan

**Local smoke tests** (run against a tempfile SQLite + mock driver — all PASS):

- config get / set / clear / list
- welcomed_users mark / idempotent / `is_welcomed`
- channel_admins add / remove / list / `is_channel_allowlisted`
- reset_welcomed (per-user and channel-wide)
- `is_welcome_admin` matrix:
  - system_admin → True
  - channel_admin on this channel → True
  - per-channel allowlist → True
  - none → False
  - system_admin works even when not a member of the target channel
  - **channel_admin on a DIFFERENT channel is correctly rejected for the target channel**

**Live-against-Mattermost test plan (operator)**:

- [ ] As `system_admin` in #test: `@welcome set Welcome! Rules: be kind.` → config stored, existing members silently marked welcomed, no broadcasts.
- [ ] As a non-admin: `@welcome set X` → "Not authorized" reply, no state change.
- [ ] New user joins `#test` → bot DMs them within seconds (default delivery `dm`). Row in `welcomed_users`.
- [ ] Same user leaves and re-joins → no second DM. `welcomed_at` unchanged.
- [ ] Bot restart → state intact, no re-welcomes.
- [ ] Bot offline, user joins, bot restarts → reconcile DMs the user.
- [ ] `@welcome delivery both` + `@welcome greet "Welcome {user}!"` → next joiner gets a public greet AND a DM.
- [ ] `@welcome admin add @alice` (run by `system_admin` or `channel_admin`) → Alice can now run `@welcome`. As Alice without prior privilege → refusal.
- [ ] `@welcome admin remove @alice` → Alice loses access.
- [ ] `@welcome admin list` → shows the allowlist.
- [ ] `system_admin` runs `@welcome set` in a channel they are NOT a member of → succeeds (system_admin bypasses the membership check; case-5 above).

## Source

Reference design doc committed alongside as `WELCOME-MODULE-PROPOSAL.md` (rationale, schema, three-source auth design, failure-mode coverage, resolved decisions). Came out of the dialogue: detection mechanism (Dutch) → English design proposal → resolved three open questions (storage in module dir / default delivery = dm / three-source auth) → implementation.

## Dependency note

`commands/welcome/defaults.py` sets `CHANS = ['any']` — that wildcard works correctly **only after PR #165 lands** (the `'any'` channel wildcard fix in `matterbot.py:isallowed_module`). Operators who haven't merged #165 yet should replace `CHANS = ['any']` with the explicit list of channels where they want `@welcome` to be invocable, via `commands/welcome/settings.py`.
