### PR TITLE
Flip recursion default to False to prevent feedback loops

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -41,7 +41,7 @@ Matterbot:
   welcome_banner: "**Welcome to this Mattermost!**" # Put your single-line welcome banner here. Use the welcome_file for larger messages (e.g. ToS)
   welcome_channel: "abc" # Set this to the channel ID where the bot will welcome users
   welcome_file: "welcome.msg" # Optionally, add this message to the generic welcome
-  recursion: True # Is the bot allowed to respond to its own messages?
+  recursion: False # Is the bot allowed to respond to its own messages? Default False to prevent feedback loops.
   msglength: 16383 # Change to '4000' if you are using Mattermost <=5.x (seriously, you should upgrade!)
   logcmd: True
   logcmdparams: False


### PR DESCRIPTION
Single-line default flip in `config.defaults.yaml`. Replaces PR #164 (will close).

## What this changes

```diff
-  recursion: True # Is the bot allowed to respond to its own messages?
+  recursion: False # Is the bot allowed to respond to its own messages? Default False to prevent feedback loops.
```

`recursion: True` was a feedback-loop hazard — any module whose output happens to match a command trigger could self-trigger the bot and loop. Operators who deliberately want self-response (testing, echo modules) can flip it back in their `config.yaml`. The new in-line comment explains the rationale so a future reader doesn't toggle it back without thinking.

## Behavior change on deploy

Operators who never wrote `recursion:` explicitly in their `config.yaml` will pick up the new default after pulling. No shipped module is known to depend on recursion; risk surface is small.

## Why this is a replacement for #164

PR #164 bundled three independent fixes. Two of the three are no longer applicable:

- **snowplough print-leak removal** — the module was removed entirely in commit `91be40c` ("Snowplough is dead code"). Nothing left to fix.
- **ransomleak `session.verify = False` removal** — re-reviewed. The second-stage fetch hits victim landing pages which are commonly `.onion`, self-signed, expired-cert, or Cloudflared with broken TLS. Removing the bypass plausibly breaks the victim-name resolution feature for the realistic-prevalence case without much security gain (the threat model is MITM-injected HTML landing in a Mattermost channel post — a UX concern, not a security boundary). **Deferred for a separate decision** — either accept `verify=False` with an inline comment explaining the trade, or build a per-URL allowlist for known-broken-TLS sources.

Closing #164 leaves only this clean single-line change. The ransomleak question gets its own conversation when we get to it.

## Test plan

- [ ] Boot with the shipped defaults; confirm `recursion: False` is in effect (the bot does not respond to its own posts).
- [ ] Verify operators who set `recursion: True` explicitly in `config.yaml` still get that behavior (override works).
