### PR TITLE
welcome: strip leading @ from sender_name before user lookup

### DIFF
--- a/commands/welcome/command.py
+++ b/commands/welcome/command.py
@@ -8,7 +8,10 @@ any-of: system_admin role, channel_admin role on this channel, or per-
 channel allowlist).
 """
 
+import logging
 import re
+
+log = logging.getLogger('matterbot')
 
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module
@@ -46,10 +49,18 @@ from . import welcome as wm
 def _resolve_caller(conn, channel_name, username, team_id=None):
     """Returns (user_id, channel_id) for the @welcome invocation, or
     (None, None) on lookup failure. Best-effort: any API error surfaces
-    as None and the caller emits a generic 'could not resolve' reply."""
+    as None and the caller emits a generic 'could not resolve' reply.
+
+    Mattermost's WS post events expose `sender_name` as `@<username>`
+    (with the @ prefix). The users.get_user_by_username API expects the
+    bare username — the @ is rejected by username validation and the
+    server returns 404 ("Sorry, we could not find the page."). Strip
+    leading @s before the lookup."""
+    bare_username = username.lstrip('@')
     try:
-        user_id = conn.users.get_user_by_username(username)['id']
-    except Exception:
+        user_id = conn.users.get_user_by_username(bare_username)['id']
+    except Exception as e:
+        log.warning(f"welcome: get_user_by_username({bare_username!r}) failed: {e}")
         return None, None
     try:
         if team_id is None:
@@ -57,13 +68,26 @@ def _resolve_caller(conn, channel_name, username, team_id=None):
             # safe; the alternative is threading team_id through
             # call_module's signature, which is a bigger change.
             me = conn.users.get_user('me')
-            teams = conn.teams.get_user_teams(me['id'])
+            # Method name varies across mattermostdriver versions; try
+            # the canonical names in order before giving up.
+            teams = None
+            teams_api = conn.teams
+            for method_name in ('get_user_teams', 'get_teams_for_user'):
+                method = getattr(teams_api, method_name, None)
+                if method is not None:
+                    try:
+                        teams = method(me['id'])
+                        break
+                    except Exception:
+                        continue
             team_id = teams[0]['id'] if teams else None
         if not team_id:
+            log.warning(f"welcome: could not resolve a team_id for channel={channel_name!r}")
             return user_id, None
         chan = conn.channels.get_channel_by_name(team_id, channel_name)
         return user_id, chan['id']
-    except Exception:
+    except Exception as e:
+        log.warning(f"welcome: channel lookup failed channel={channel_name!r}: {e}")
         return user_id, None
 
 


### PR DESCRIPTION
## Symptom

`@welcome` was returning **"Could not resolve caller user / channel via the Mattermost API"** and the bot log was filling with:

```
ERROR - mattermostdriver.websocket - 2026-05-13 21:34:37,972 - Sorry, we could not find the page.
```

every time someone invoked the module.

## Root cause

Mattermost's WS post events expose `sender_name` as `@<username>` (with the `@` prefix). `matterbot.py:handle_post` passes that through to each module's `process()` as the `username` parameter. `welcome.command._resolve_caller` passed it unmodified to `users.get_user_by_username`, which expects the **bare** username — Mattermost's username validation rejects the `@` and the server returns its HTML 404 page. `mattermostdriver` logs the response body before re-raising; my caught `Exception` then surfaces the user-facing "Could not resolve caller" reply.

Verified: every other module that uses `username` only treats it as a display string, so the bug is specific to `welcome.command` introduced by #168.

## Fix

- `lstrip('@')` before `get_user_by_username`. Idempotent and tolerates the edge cases (bare username, `@@`, empty string — verified locally).
- Surface the failed lookup target via `log.warning` so the next diagnosis doesn't require guessing what was looked up.
- Add a small fallback for the teams API lookup: try `teams.get_user_teams(...)` then `teams.get_teams_for_user(...)`, since the method name has varied across `mattermostdriver` versions. Same defensive pattern as `welcome.py:_get_or_create_direct_channel`.
- Add `import logging` at the top of `command.py` so the new warnings have somewhere to land.

## What is NOT changed

- `_resolve_mention` (used by `@welcome admin add @alice`) already correctly strips the `@` via the regex group; left as is.
- The auth path (`is_welcome_admin` and its `_user_has_system_admin` / `_user_has_channel_admin` callers) operates on `user_id` (already an ID, never a username), so it's unaffected.
- All API calls past `_resolve_caller` get the resolved `user_id` / `channel_id`, so they continue to work.

## Test plan

- [ ] `@welcome` (no subcommand) in any channel — bot replies with the usage line (was failing before).
- [ ] `@welcome set Welcome to #test` as a `system_admin` — config stored, response is the "Welcome stored for #test (N existing members silently marked...)" message.
- [ ] `@welcome set X` as a non-admin — "Not authorized" reply (was previously failing earlier in the pipeline before the auth check could even run).
- [ ] `@welcome admin add @alice` — uses `_resolve_mention` (already correct). Verify Alice can subsequently run `@welcome`.
- [ ] Watch the bot log — no more `Sorry, we could not find the page.` 404 spam on `@welcome` invocations.

Follow-up to #168.
