### PR TITLE
Parameterize docgen/ewa GraphQL mutations to close injection sinks

### DIFF
--- a/commands/docgen/command.py
+++ b/commands/docgen/command.py
@@ -119,19 +119,35 @@ def process(command, channel, username, params, files, conn):
                         if len(params)>1:
                             tags += ',"' + '", "'.join(params[1:]) + '"'
                         tags = "[" + tags + "]"
-                        query = """
-                        mutation Page {
+                        # GraphQL mutation — parameterized via variables so the user-
+                        # controlled fields (content, description, path, title, tags)
+                        # cannot break out of the """-delimited string literals to
+                        # inject additional mutation fields. The static mutation
+                        # text below is byte-stable across invocations; only the
+                        # variables dict carries user data.
+                        mutation = """
+                        mutation Page(
+                            $content: String!,
+                            $description: String!,
+                            $editor: String!,
+                            $isPublished: Boolean!,
+                            $isPrivate: Boolean!,
+                            $locale: String!,
+                            $path: String!,
+                            $tags: [String],
+                            $title: String!
+                        ) {
                             pages {
                                 create (
-                                    content: \"\"\"%s\"\"\",
-                                    description: \"\"\"%s\"\"\",
-                                    editor: "%s",
-                                    isPublished: %s,
-                                    isPrivate: %s,
-                                    locale: "%s",
-                                    path: "%s",
-                                    tags: %s,
-                                    title: \"\"\"%s\"\"\"
+                                    content: $content,
+                                    description: $description,
+                                    editor: $editor,
+                                    isPublished: $isPublished,
+                                    isPrivate: $isPrivate,
+                                    locale: $locale,
+                                    path: $path,
+                                    tags: $tags,
+                                    title: $title
                                 )
                                 {
                                     responseResult {
@@ -148,9 +164,23 @@ def process(command, channel, username, params, files, conn):
                                 }
                             }
                         }
-                        """ % (pagecontent, description, editor, isPublished, isPrivate, locale, path, tags, title,)
-                        query = json.dumps({'query': query.strip()})
-                        with requests.post(settings.APIURL['docgen']['url']+'/graphql', headers=headers, data=query, timeout=(10, 30)) as response:
+                        """
+                        tags_list = [title] + list(params[1:])
+                        payload = json.dumps({
+                            'query': mutation.strip(),
+                            'variables': {
+                                'content': pagecontent,
+                                'description': description,
+                                'editor': editor,
+                                'isPublished': True,
+                                'isPrivate': False,
+                                'locale': locale,
+                                'path': path,
+                                'tags': tags_list,
+                                'title': title,
+                            },
+                        })
+                        with requests.post(settings.APIURL['docgen']['url']+'/graphql', headers=headers, data=payload, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if 'data' in json_response:
                                 if 'pages' in json_response['data']:
@@ -184,19 +214,32 @@ def process(command, channel, username, params, files, conn):
                         if len(params)>1:
                             tags += ',"' + '", "'.join(params[1:]) + '"'
                         tags = "[" + tags + "]"
-                        query = """
-                        mutation Page {
+                        # Same parameterized mutation shape as the Excel-conversion
+                        # path above. User-controlled fields flow via variables,
+                        # never via string interpolation into the mutation text.
+                        mutation = """
+                        mutation Page(
+                            $content: String!,
+                            $description: String!,
+                            $editor: String!,
+                            $isPublished: Boolean!,
+                            $isPrivate: Boolean!,
+                            $locale: String!,
+                            $path: String!,
+                            $tags: [String],
+                            $title: String!
+                        ) {
                             pages {
                                 create (
-                                    content: \"\"\"%s\"\"\",
-                                    description: \"\"\"%s\"\"\",
-                                    editor: "%s",
-                                    isPublished: %s,
-                                    isPrivate: %s,
-                                    locale: "%s",
-                                    path: "%s",
-                                    tags: %s,
-                                    title: \"\"\"%s\"\"\"
+                                    content: $content,
+                                    description: $description,
+                                    editor: $editor,
+                                    isPublished: $isPublished,
+                                    isPrivate: $isPrivate,
+                                    locale: $locale,
+                                    path: $path,
+                                    tags: $tags,
+                                    title: $title
                                 )
                                 {
                                     responseResult {
@@ -213,9 +256,23 @@ def process(command, channel, username, params, files, conn):
                                 }
                             }
                         }
-                        """ % (pagecontent, description, editor, isPublished, isPrivate, locale, path, tags, title,)
-                        query = json.dumps({'query': query.strip()})
-                        with requests.post(settings.APIURL['docgen']['url']+'/graphql', headers=headers, data=query, timeout=(10, 30)) as response:
+                        """
+                        tags_list = [title] + list(params[1:])
+                        payload = json.dumps({
+                            'query': mutation.strip(),
+                            'variables': {
+                                'content': pagecontent,
+                                'description': description,
+                                'editor': editor,
+                                'isPublished': True,
+                                'isPrivate': False,
+                                'locale': locale,
+                                'path': path,
+                                'tags': tags_list,
+                                'title': title,
+                            },
+                        })
+                        with requests.post(settings.APIURL['docgen']['url']+'/graphql', headers=headers, data=payload, timeout=(10, 30)) as response:
                             json_response = response.json()
                             if 'data' in json_response:
                                 if 'pages' in json_response['data']:

--- a/commands/ewa/command.py
+++ b/commands/ewa/command.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import ast
 import datetime
 import json
 import os
@@ -258,26 +259,53 @@ def process(command, channel, username, params, files, conn):
                                 ### Create a WikiJS page
                                 description = "%s" % (title,)
                                 editor = "markdown"
-                                isPublished = "true"
-                                isPrivate = "false"
                                 locale = "en"
                                 path = "/home/%s" % (cveid,)
-                                tags = "[" + settings.TAGS + ", "
-                                tags += "\"%s\"]" % (cveid,)
                                 title = "%s" % (cveid,)
-                                query = """
-                                mutation Page {
+                                # settings.TAGS is operator-defined as a comma-
+                                # quoted-strings format compatible with the legacy
+                                # GraphQL-list-literal interpolation (e.g.
+                                #   TAGS = '"ewa", "cve"'
+                                # ). Parse it into a real Python list via
+                                # ast.literal_eval wrapped in [...] for safety, then
+                                # append the cveid. Operators who set TAGS = "" or
+                                # who follow the documented quoted format keep
+                                # working unchanged.
+                                try:
+                                    tags_list = list(ast.literal_eval(f"[{settings.TAGS}]"))
+                                except (ValueError, SyntaxError):
+                                    tags_list = []
+                                tags_list = [str(t) for t in tags_list] + [cveid]
+                                # GraphQL mutation — parameterized via variables so
+                                # the user-controlled NVD-sourced fields (content,
+                                # description, tags, title, path) cannot break out
+                                # of the """-delimited string literals to inject
+                                # additional mutation fields. The static mutation
+                                # text below is byte-stable across invocations;
+                                # only the variables dict carries user data.
+                                mutation = """
+                                mutation Page(
+                                    $content: String!,
+                                    $description: String!,
+                                    $editor: String!,
+                                    $isPublished: Boolean!,
+                                    $isPrivate: Boolean!,
+                                    $locale: String!,
+                                    $path: String!,
+                                    $tags: [String],
+                                    $title: String!
+                                ) {
                                     pages {
                                         create (
-                                            content: \"\"\"%s\"\"\",
-                                            description: \"\"\"%s\"\"\",
-                                            editor: "%s",
-                                            isPublished: %s,
-                                            isPrivate: %s,
-                                            locale: "%s",
-                                            path: "%s",
-                                            tags: %s,
-                                            title: \"\"\"%s\"\"\"
+                                            content: $content,
+                                            description: $description,
+                                            editor: $editor,
+                                            isPublished: $isPublished,
+                                            isPrivate: $isPrivate,
+                                            locale: $locale,
+                                            path: $path,
+                                            tags: $tags,
+                                            title: $title
                                         )
                                         {
                                             responseResult {
@@ -294,9 +322,22 @@ def process(command, channel, username, params, files, conn):
                                         }
                                     }
                                 }
-                                """ % (content, description, editor, isPublished, isPrivate, locale, path, tags, title,)
-                                query = json.dumps({'query': query.strip()})
-                                with requests.post(settings.APIURL['ewa']['url']+'/graphql', headers=headers, data=query, timeout=(10, 30)) as response:
+                                """
+                                payload = json.dumps({
+                                    'query': mutation.strip(),
+                                    'variables': {
+                                        'content': content,
+                                        'description': description,
+                                        'editor': editor,
+                                        'isPublished': True,
+                                        'isPrivate': False,
+                                        'locale': locale,
+                                        'path': path,
+                                        'tags': tags_list,
+                                        'title': title,
+                                    },
+                                })
+                                with requests.post(settings.APIURL['ewa']['url']+'/graphql', headers=headers, data=payload, timeout=(10, 30)) as response:
                                     json_response = response.json()
                                     if 'data' in json_response:
                                         if 'pages' in json_response['data']:


### PR DESCRIPTION
## What this changes

Three GraphQL page-create mutations were assembled by interpolating user-controlled fields directly into the mutation text via `%`-formatting and triple-quoted block strings:

```python
query = """
mutation Page {
  pages {
    create (
      content: \"\"\"%s\"\"\",
      description: \"\"\"%s\"\"\",
      path: "%s",
      tags: %s,
      title: \"\"\"%s\"\"\",
      ...
""" % (content, description, ..., tags, title)
```

If any of `content` / `description` / `path` / `title` / `tags` contained a closing `"""` (or `"`), an attacker who controlled that field could break out of the GraphQL string literal and inject additional mutation fields — the GraphQL equivalent of SQL injection. They could flip `isPublished`, add malicious tags, or pivot to a different mutation entirely.

## Why the threat is realistic

- **`ewa`**: the `content` field is sourced from **NVD** via HTTP fetch (the description text of a CVE). CVE descriptions can contain arbitrary text including triple-quote sequences. PR #166 anchored the CVE-id regex so `cveid` is bounded, but the NVD-sourced content body is still attacker-influenced.
- **`docgen`**: `content` is the rendered Markdown of a user-uploaded Excel/image file. User-controlled.
- **`tags`**: spliced as a raw GraphQL list literal `[ "tag1", "tag2" ]`. A `tag` containing `"]` would break out cleanly.

## Fix

All three mutations refactored to use **GraphQL `variables`**. The mutation text is now static and byte-stable across invocations:

```graphql
mutation Page(
  $content: String!, $description: String!, $editor: String!,
  $isPublished: Boolean!, $isPrivate: Boolean!,
  $locale: String!, $path: String!, $tags: [String], $title: String!
) {
  pages { create (content: $content, description: $description, ...) { ... } }
}
```

User data flows via the `variables` field of the JSON body. The GraphQL server validates and escapes properly.

### Sinks closed

| File | Path |
|---|---|
| `commands/docgen/command.py` (Excel-conversion path) | original L122 |
| `commands/docgen/command.py` (image-upload path) | original L187 |
| `commands/ewa/command.py` (CVE Early-Warning path) | original L268 |

### Bonus hardening that fell out naturally

- `isPublished` / `isPrivate` now Python `True` / `False` instead of string-formatted `"true"` / `"false"` tokens.
- `tags` now a real Python list, not a hand-built GraphQL list-literal string.
- For `ewa`, `settings.TAGS` (operator-defined comma-quoted-strings format kept for backwards compat) is parsed via `ast.literal_eval` wrapped in `[...]`. Empty / malformed TAGS falls back to `[]`. Verified across the realistic shapes: `'"ewa", "cve"'` → `['ewa', 'cve']`, `''` → `[]`, `'"single"'` → `['single']`.

## What is NOT changed

- **ewa's two read queries** (`L55` static + `L75` interpolating `contentid`). The first is fully static. The second interpolates `contentid` which comes from the same GraphQL server's previous response — an internal-trusted integer. Defense-in-depth parameterization is possible but adds maintenance without closing a real attack surface.
- **`ewa`'s `path = "/home/<cveid>"` interpolation** elsewhere in the module. `cveid` is regex-anchored in PR #166 (`^CVE-\d{4}-\d{4,7}$`), so the path is bounded to the CVE format. If that anchor regresses, parameterizing the GraphQL variable wouldn't save the host filesystem — the `MODULEDIR + cve + .pdf` concatenation is the real sink. Out of scope.
- **`docgen`'s upload pipeline** (file bytes → base64 → embedded HTML). The base64 image data IS in the `content` field passed through `variables`, but the GraphQL server handles it as a string; no quoting concerns at this layer.

## Verification

- Both files compile clean.
- `grep -nE '\"\"\"%s\"\"\"' commands/{docgen,ewa}/command.py` → empty (no more user-content-in-triple-quote pattern).
- `ast.literal_eval` smoke test passes for the four representative TAGS shapes (multi, empty, single, no-space).

## Test plan

- [ ] `@ewa create CVE-2023-20855` against a WikiJS instance → page created normally, same URL shape as before.
- [ ] `@docgen <excel-file>` upload → conversion page created, content renders identically.
- [ ] `@docgen upload <image>` → image page created, image renders identically.
- [ ] **Injection test**: craft an Excel file whose markdown rendering contains `"""\n}, isPublished: false, content: """oops` (or similar). Verify the page-create succeeds with the literal text as the page content, NOT with `isPublished` flipped or any out-of-band mutation field set.
- [ ] **Tags edge case**: set `settings.TAGS = '"with,comma", "another"'` — verify the page is created with `[with,comma, another, <cveid>]` as actual list elements, not split.

Source: Phase 2 queue item 9 (`matterbot_phase2_queue.md`, H6).
