### PR TITLE
urlscan: pin verdict-fetch host/scheme + allow_redirects=False

### DIFF
--- a/commands/urlscan/command.py
+++ b/commands/urlscan/command.py
@@ -5,6 +5,7 @@ import re
 import requests
 import traceback
 from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import urlparse
 
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module
@@ -39,6 +40,27 @@ def process(command, channel, username, params, files, conn):
             'Content-Type': settings.CONTENTTYPE,
             'api-key': settings.APIURL['urlscan']['key'],
         }
+        # Pin verdict-fetch host + scheme to the operator-configured urlscan
+        # endpoint. The verdict URL we fetch comes from urlscan.io's search
+        # response body — without this check, a compromised or maliciously
+        # crafted response could redirect the bot's fetch (and the API key
+        # in `headers`) to an attacker-controlled host. Resolved once
+        # per process() invocation since settings.APIURL doesn't change.
+        _api_parsed = urlparse(settings.APIURL['urlscan']['url'])
+        _api_host = (_api_parsed.hostname or '').lower()
+        _api_scheme = _api_parsed.scheme
+
+        def _is_allowed_verdict_url(verdict_url):
+            try:
+                p = urlparse(verdict_url)
+            except Exception:
+                return False
+            return (
+                bool(_api_host)
+                and (p.hostname or '').lower() == _api_host
+                and p.scheme == _api_scheme
+            )
+
         try:
             pattern = r"\b(?:[a-zA-Z0-9-]+\.)+(?:[a-zA-Z]{2,}|xn--[a-zA-Z0-9-]+)\b"
             hostnames = re.findall(pattern, " ".join(params))
@@ -81,8 +103,12 @@ def process(command, channel, username, params, files, conn):
                                 verdict_results = {}
                                 if candidates:
                                     def _fetch_verdict(url):
+                                        if not _is_allowed_verdict_url(url):
+                                            return None
                                         try:
-                                            with requests.get(url, headers=headers, timeout=(10, 30)) as r:
+                                            with requests.get(url, headers=headers, timeout=(10, 30), allow_redirects=False) as r:
+                                                if r.status_code not in (200, 206):
+                                                    return None
                                                 return r.json()
                                         except Exception:
                                             return None


### PR DESCRIPTION
## Problem

The per-result verdict URL fetched in `commands/urlscan/command.py:_fetch_verdict` is sourced from the urlscan.io search response body (`result["result"]`). The bot's headers include the urlscan API key. Without a host/scheme allowlist and with `allow_redirects` defaulting to `True`, a compromised or maliciously crafted upstream response could redirect the bot's fetch — **and the API key in the headers** — to an attacker-controlled host.

PR #161 parallelized these verdict fetches but didn't pin them.

## Fix

Two layered hardening steps inside the existing `_fetch_verdict` closure:

### 1. Host + scheme allowlist

Derived once per `process()` invocation from the operator-configured `settings.APIURL['urlscan']['url']`:

```python
_api_parsed = urlparse(settings.APIURL['urlscan']['url'])
_api_host   = (_api_parsed.hostname or '').lower()
_api_scheme = _api_parsed.scheme
```

Every verdict URL's hostname must match `_api_host` (case-insensitive) and its scheme must match exactly. Self-hosted urlscan installs keep working — the allowlist follows the configured endpoint, not a hardcoded `urlscan.io`.

### 2. `allow_redirects=False` on the verdict GET

Even if a future regression slips a non-pinned URL through, the bot will not follow a 30x off the allowlisted host. Status-code gate (200/206) added at the same place so non-success responses don't try to `.json()`-parse error HTML.

## Allowlist verification

Sanity-check matrix run locally with the operator URL `https://urlscan.io/api/v1/search/`:

| Verdict URL | Allowed? |
|---|---|
| `https://urlscan.io/api/v1/result/abc123/` | ✓ |
| `https://URLSCAN.IO/api/v1/result/abc/` | ✓ (case-insensitive host match) |
| `http://urlscan.io/api/v1/result/abc/` | ✗ (wrong scheme) |
| `https://evil.com/api/v1/result/abc/` | ✗ (wrong host) |
| `https://urlscan.io.evil.com/path` | ✗ (subdomain trick — `.hostname` returns the full host) |
| `//attacker.com/foo` | ✗ (scheme-relative) |
| `javascript:alert(1)` | ✗ (exotic scheme) |
| `''` | ✗ |
| `not a url` | ✗ |

## What is NOT changed

- The outer search call (`requests.get(settings.APIURL['urlscan']['url'], ...)`) is operator-configured at the URL level, not user-supplied. Already trusted.
- IPv6/IPv4-numeric verdict hosts aren't separately blocked. If the operator points `settings.APIURL` at a numeric host, the allowlist follows that choice; choosing a numeric host is the operator's call.
- The renderer / table / message-build path is unchanged. Rows with a refused verdict URL render with an empty verdict cell — same UX as a verdict fetch that timed out or returned non-200.

## Test plan

- [ ] `@urlscan example.com` → unchanged behavior on legitimate scans; rows render with verdict cells populated.
- [ ] Manually patch the urlscan API response (or use a test fixture) so `result["result"]` is `https://evil.com/...` — verify the row renders with **no** verdict cell, and that the bot did **not** send the API key to `evil.com` (check egress logs or use a packet capture / DNS sinkhole).
- [ ] Self-hosted urlscan path: set `settings.APIURL['urlscan']['url'] = 'https://urlscan.internal.example/api/v1/search/'` — verify verdicts from `urlscan.internal.example` succeed, verdicts from `urlscan.io` (if any leaked in via misconfig) are refused.
- [ ] Verify `allow_redirects=False`: configure an HTTP server to return a 30x with `Location: https://attacker.com/...` for the verdict endpoint, hit `@urlscan` — bot should treat as a non-success and not follow.

Source: Phase 2 queue item 6 (`matterbot_phase2_queue.md`, H9).
