### PR TITLE
isadmin: case-normalize botadmins entries for role-name matching

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -391,7 +391,15 @@ class MattermostManager(object):
         try:
             userinfo = self.mmDriver.users.get_user(userid)
             roles = [_.lower() for _ in userinfo['roles'].split()]
-            if any(entry in roles for entry in options.Matterbot['botadmins']) or userid in options.Matterbot['botadmins']:
+            # botadmins entries can be EITHER a Mattermost role name (e.g.
+            # 'system_admin') OR a Mattermost user id (opaque token). Role
+            # names need case-insensitive matching against `roles` (which is
+            # lowercased above); user ids are case-sensitive and must match
+            # exactly. We normalize the role-name comparison to lowercase
+            # but keep the userid comparison as-is.
+            botadmins = options.Matterbot['botadmins'] or []
+            normalized_roles = [str(e).lower() for e in botadmins]
+            if any(role in roles for role in normalized_roles) or userid in botadmins:
                 return True
         except:
             return None


### PR DESCRIPTION
Tiny follow-up to PR #165.

## Problem

After #165 fixed the `any(list) in roles` dead-code clause, `isadmin()` correctly walks `botadmins` and checks each entry against the lowercased `roles` list. But the entries themselves were never normalized — `botadmins: ['system_admin']` works, `botadmins: ['System_Admin']` or `['SYSTEM_ADMIN']` silently fails because the comparison is case-sensitive.

Mattermost emits role names in lowercase, but the operator-facing UI sometimes shows them with first-letter capitalization (e.g. "System Admin"). An operator following the UI conventions could write the same shape in `config.yaml` and end up with no admin privileges and no diagnostic.

## Fix

Lowercase the `botadmins` entries before the role-membership check. User-id entries in `botadmins` stay case-sensitive (Mattermost user IDs are opaque tokens that should match exactly).

```python
botadmins = options.Matterbot['botadmins'] or []
normalized_roles = [str(e).lower() for e in botadmins]
if any(role in roles for role in normalized_roles) or userid in botadmins:
    return True
```

Also defensively coerced `botadmins or []` — the config can be missing or null, and `None or []` keeps the rest of the function from `TypeError`-ing before the bare-except returns None.

## Verified

All 8 cases from a local mock check:

| `botadmins` config | result | scenario |
|---|---|---|
| `['system_admin']` | allowed | lowercase role name |
| `['System_Admin']` | allowed | mixed-case role name (was broken pre-PR) |
| `['SYSTEM_ADMIN']` | allowed | uppercase role name (was broken pre-PR) |
| `['u-the-caller']` | allowed | userid exact match |
| `['u123abc']` (mismatch) | denied | userid mismatch |
| `['Other_Role']` | denied | role name that doesn't match |
| `[]` | denied | empty list |
| `None` | denied | None config (was TypeError) |

## Out of scope

- The bare `except:` at L397/405 still swallows `KeyboardInterrupt` / `SystemExit`. That's in the backlog as part of the broader bare-except sweep.
