### PR TITLE
welcome: use canonical 'MatterBot' getLogger name

### DIFF
--- a/commands/welcome/command.py
+++ b/commands/welcome/command.py
@@ -11,7 +11,7 @@ channel allowlist).
 import logging
 import re
 
-log = logging.getLogger('matterbot')
+log = logging.getLogger('MatterBot')
 
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module

--- a/commands/welcome/welcome.py
+++ b/commands/welcome/welcome.py
@@ -30,7 +30,7 @@ except ImportError:
     # a package context. Fall back to the absolute path the loader uses.
     import defaults  # type: ignore[import-not-found,no-redef]
 
-log = logging.getLogger('matterbot')
+log = logging.getLogger('MatterBot')
 
 # Single lock for write paths. SQLite's own file lock would also work,
 # but at the WAL+per-call-connection scale we have, an in-process lock


### PR DESCRIPTION
Two-line follow-up. Pure relabel, no behavior change.

## What this changes

`commands/welcome/command.py:14` and `commands/welcome/welcome.py:33` previously bound:

```python
log = logging.getLogger('matterbot')   # ← all lowercase
```

`matterbot.py:908` actually uses:

```python
log = logging.getLogger('MatterBot')   # ← capital M, capital B
```

Python logger names are case-sensitive, so the welcome module was getting a **different** logger object than the bot core. Functionally the lines still landed in `matterfeed.log` via root-logger propagation (basicConfig configures the root; child loggers propagate by default), but the `%(name)s` format slot showed up as `matterbot` on welcome-originated lines and `MatterBot` on bot-core lines — two labels in the same file. Operators grepping by name had to know both.

After this PR:

```
ERROR - MatterBot - 2026-05-14 10:23:01 - Websocket loop crashed
ERROR - MatterBot - 2026-05-14 10:23:02 - welcome: get_user_by_username('alice') failed: ...
```

Single name everywhere.

## Companion change pushed to #171

The traceback channel-leak sweep on **PR #171** introduced the same lowercase name across all 46 module files it touched (same one-shot sweep script). An additional commit was pushed to that branch (`2505ac0`) with the same rename for those 46 files. When #171 lands, every module that has a `log` binding will use the canonical name.

This PR is just for the welcome files that are already on main.
