### PR TITLE
splunk: stop disabling TLS verification globally for the whole bot process

### DIFF
--- a/modules/splunk/feed.py
+++ b/modules/splunk/feed.py
@@ -15,7 +15,6 @@
 import bs4
 import feedparser
 import re
-import ssl
 
 def query(settings=None):
     if settings:
@@ -32,8 +31,6 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
-    if hasattr(ssl, '_create_unverified_context'):
-        ssl._create_default_https_context = ssl._create_unverified_context
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
     count = 0
     stripchars = '`\\[\\]\'\"'


### PR DESCRIPTION
## What this changes

Two lines removed from `modules/splunk/feed.py`:

```python
-import ssl
...
-    if hasattr(ssl, '_create_unverified_context'):
-        ssl._create_default_https_context = ssl._create_unverified_context
```

## Why this is bigger than splunk

`ssl._create_default_https_context` is the **process-global** factory for every `urllib`/`feedparser` HTTPS connection. The bot's module loader imports every `modules/*/feed.py` at startup, so this override fires before any other feed runs — and after that point, **every** outbound https connection from the bot proceeds without CA verification.

That includes the ~200 RSS feeds the bot ingests via `feedparser.parse(...)`, every advisory pull, every dashboard fetch — anything in the bot process that uses `urllib` defaults under the hood.

Even after the SSRF hardening landed in #167 (bluesky/mastodon `_safe_fetch`) and #173 (urlscan verdict-host allowlist) tightened host filtering, the feeds were still pulling over unverified TLS. A MITM on any RSS upstream could substitute arbitrary content into a Mattermost channel post — the threat model that PR #164 (ransomleak `verify=False` removal, since deferred) was trying to address, except scoped to a single module instead of the whole bot.

The `hasattr()` guard has been a no-op since Python 3.4.3 (the function has always existed in modern Python). The assignment on the next line is the real effect.

## Fix

Remove both lines + the now-unused `import ssl`. The default `ssl.create_default_context` (CA-verifying) is what every Python project should be using.

## Failure mode if splunk's RSS upstream actually depends on this

If the splunk RSS feed serves from a cert-broken endpoint (expired, self-signed, mismatched SAN), the feed will start failing loudly with an `SSLError` — visible in the bot log, no longer silent acceptance. The operator can either fix the upstream or scope a per-call bypass to that one fetch (not re-enable a global override).

## What this does NOT change

- splunk feed parsing, channel routing, message shape — unchanged.
- Any other module's TLS behavior at the source-code level — they all already used `requests.get(...)` with library defaults, which are CA-verifying. But the `splunk` import was silently mutating Python's global default out from under them. After this PR, that silent mutation is gone and the defaults are honored.
- `ransomleak`'s explicit `session.verify = False` (a different, scoped issue) — that's the deferred ransomleak decision, separate PR.

## Verification

- File compile-checks clean.
- The pre-commit hook's semgrep blocker (`python.lang.security.unverified-ssl-context`, "Unverified SSL context detected", BLOCKING) has been firing on every commit this session. After this lands, it should stop.

## Source

Pre-existing finding, surfaced repeatedly by the pre-commit hook on every PR in this session. Not in the original Phase 2 queue.
