### PR TITLE
Hotfix: bind `e` in 6 except blocks regressed by #171

### DIFF
--- a/commands/botscout/command.py
+++ b/commands/botscout/command.py
@@ -73,7 +73,7 @@ def process(command, channel, username, params, files, conn):
                     messages.append({'text': message})
                 else:
                     messages.append({'text': 'An error occurred querying the BotScout API:\nError: `%s`' % (response.content,)})
-        except:
+        except Exception as e:
             log.exception("botscout module error")
             messages.append({'text': 'An error occurred in the BotScout module:\nError: `%s`' % (str(e),)})
         finally:

--- a/commands/euvd/command.py
+++ b/commands/euvd/command.py
@@ -173,7 +173,7 @@ def process(command, channel, username, params, files, conn):
                             messages.append({'text': text, 'uploads': [{'filename': 'euvd-'+querytype+'-'+datetime.datetime.now().strftime('%Y%m%dT%H%M%S')+'.csv', 'bytes': euvdcsv}]})
                         else:
                             messages.append({'text': text})
-    except:
+    except Exception as e:
         log.exception("euvd module error")
         messages.append({'text': 'An error occurred in the EUVD module:\nError: `%s`' % (str(e),)})
     finally:

--- a/commands/opencve/command.py
+++ b/commands/opencve/command.py
@@ -217,7 +217,7 @@ def process(command, channel, username, params, files, conn):
                             messages.append({'text': text, 'uploads': [{'filename': 'opencve-'+querytype+'-'+datetime.datetime.now().strftime('%Y%m%dT%H%M%S')+'.csv', 'bytes': opencvecsv}]})
                         else:
                             messages.append({'text': text})
-    except:
+    except Exception as e:
         log.exception("opencve module error")
         messages.append({'text': 'An error occurred in the OpenCVE module:\nError: `%s`' % (str(e),)})
     finally:

--- a/commands/proxycheck/command.py
+++ b/commands/proxycheck/command.py
@@ -153,7 +153,7 @@ def process(command, channel, username, params, files, conn):
                                 message += "\n\n"
                             if len(message):
                                 messages.append({'text': message})
-        except:
+        except Exception as e:
             log.exception("proxycheck module error")
             messages.append({'text': 'An error occurred in the ProxyCheck module:\nError: `%s`' % (str(e),)})
         finally:

--- a/commands/variot/command.py
+++ b/commands/variot/command.py
@@ -185,7 +185,7 @@ def process(command, channel, username, params, files, conn):
                             messages.append({'text': 'No VARIoT results found for: `%s`' % (' '.join(query),)})
                     else:
                         messages.append({'text': 'An error occurred searching VARIoT:\nError: `%s`' % (response.status_code,)})
-    except:
+    except Exception as e:
         log.exception("variot module error")
         messages.append({'text': 'An error occurred in the VARIoT module:\nError: `%s`' % (str(e),)})
     finally:

--- a/commands/wayback/command.py
+++ b/commands/wayback/command.py
@@ -86,7 +86,7 @@ def process(command, channel, username, params, files, conn):
                                     messages.append({'text': f"URL `{query}` is not present in the archive.org's Wayback Machine."})
                 else:
                     messages.append({'text': f"URL `{query}` is not valid for archive.org's Wayback Machine."})
-    except:
+    except Exception as e:
         log.exception("wayback module error")
         messages.append({'text': 'An error occurred in the Wayback Machine module:\nError: `%s`' % (str(e),)})
     finally:


### PR DESCRIPTION
**Type: latent-regression hotfix.** PR #171 (traceback channel-leak sweep) replaced this pattern:

```python
messages.append({'text': '... %s' % (str(e), traceback.format_exc())})
```

with:

```python
messages.append({'text': '... %s' % (str(e),)})
```

across 46 modules. **In modules where the surrounding `except:` was BARE (no `as e:`)**, that left `str(e)` referencing a name that was never bound. The error-handler path itself raises `NameError`, eating the original exception and replacing the user-facing reply with a Python stack trace from `call_module`'s outer except.

Latent — only fires on the *secondary* failure path, so the bug sat undetected post-#171 merge. Caught by `ruff check . --select F821` during the inventory pass for the code-quality backlog issue (#180).

## The 6 callsites

Identical shape in all six. Each gets `except:` → `except Exception as e:`.

| File | Line |
|---|---|
| `commands/botscout/command.py` | 75 |
| `commands/euvd/command.py` | 176 |
| `commands/opencve/command.py` | 220 |
| `commands/proxycheck/command.py` | 156 |
| `commands/variot/command.py` | 188 |
| `commands/wayback/command.py` | 89 |

## Bonus correctness side-effect

Tightening `except:` to `except Exception as e:` also stops these six callsites from swallowing `KeyboardInterrupt` and `SystemExit` — aligns with the SIGTERM drain story from #154. Doesn't fix the broader 252-callsite bare-except sweep (tracked in #180) but removes 6 from that count for free.

## Verification

- All 6 files compile cleanly.
- `ruff check . --select F821` no longer flags any of them.
- Pre-existing F821 findings in `attackmatrix`, `censys`, `matterfeed`, `ransomleak`, `ransomwatch` are **NOT** introduced by this PR — they're called out in #180 for their own followups.

## Why this slipped through

The traceback sweep was tested against modules where `except Exception as e:` was already the shape (the common case). The bare-except minority got the same mechanical edit and the test pass relied on the happy path — module didn't fail upstream during testing, so the broken error-handler branch was never exercised.

Lesson: future sweeps that touch error-handler paths need to either (a) refuse to edit a bare except, or (b) include test scenarios that force the except branch to execute. Captured in #180's out-of-session observations.

## Source

Issue #180 ("Code-quality backlog") — checks off the first sub-list under 🔴 Real bugs: "Regressions introduced by PR #171 (traceback channel-leak sweep)".
