### PR TITLE
unfurl: add @unfurl command for URL parsing via dfir-unfurl

### DIFF
--- a/commands/unfurl/command.py
+++ b/commands/unfurl/command.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import logging
+
+log = logging.getLogger("MatterBot")
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+
+_pkg = __package__ or Path(__file__).parent.name
+
+
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+
+
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+
+def process(command, channel, username, params, files, conn):
+    messages = []
+
+    if not params:
+        return {
+            "messages": [
+                {"text": "Usage: `@unfurl <URL>` — parses a URL into its components."}
+            ]
+        }
+
+    url = params[0].strip()
+    if not url:
+        return {
+            "messages": [
+                {"text": "Usage: `@unfurl <URL>` — parses a URL into its components."}
+            ]
+        }
+
+    try:
+        # Import lazily so a missing dep produces a clean message rather than
+        # crashing module load and taking the whole bot down.
+        from unfurl.core import run as unfurl_run
+
+        tree = unfurl_run(
+            url,
+            data_type="url",
+            return_type="text",
+            remote_lookups=settings.REMOTE_LOOKUPS,
+        )
+
+        if not tree:
+            messages.append(
+                {"text": f"Unfurl produced no output for `{url}`."}
+            )
+            return {"messages": messages}
+
+        truncated = False
+        if len(tree) > settings.MAX_OUTPUT_CHARS:
+            tree = tree[: settings.MAX_OUTPUT_CHARS]
+            truncated = True
+
+        body = f"**Unfurl tree for `{url}`:**\n```\n{tree}\n```"
+        if truncated:
+            body += (
+                f"\n_Output truncated at {settings.MAX_OUTPUT_CHARS} characters; "
+                "run unfurl locally for the full tree._"
+            )
+
+        messages.append({"text": body})
+    except ImportError:
+        log.warning(
+            "unfurl module: dfir-unfurl package not installed; "
+            "install with `pip install dfir-unfurl[all]`"
+        )
+        messages.append(
+            {
+                "text": "Unfurl is not installed on this host. "
+                "Run `pip install dfir-unfurl[all]` and restart the bot."
+            }
+        )
+    except Exception as e:
+        log.exception("unfurl module error")
+        messages.append(
+            {"text": f"An error occurred in Unfurl:\nError: {str(e)}"}
+        )
+
+    return {"messages": messages}

--- a/commands/unfurl/defaults.py
+++ b/commands/unfurl/defaults.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+BINDS = ["@unfurl"]
+CHANS = ["debug"]
+
+# Whether unfurl should reach out to remote services for enrichment
+# (e.g. shortener expansion, threat-intel lookups). Defaults to False
+# so the bot stays self-contained and doesn't leak the queried URL
+# to third parties without explicit opt-in.
+REMOTE_LOOKUPS = False
+
+# Soft cap on the text tree returned to the channel. Mattermost will
+# reject very large messages; anything above this is truncated with
+# a footer note instead of being silently dropped.
+MAX_OUTPUT_CHARS = 8000
+
+HELP = {
+    "DEFAULT": {
+        "args": "<URL>",
+        "desc": "Parses a URL with Unfurl (https://github.com/obsidianforensics/unfurl) "
+        "and returns its components as a tree: decoded tracking params, "
+        "embedded base64, JWT contents, timestamps, UUIDs, and more. "
+        "Useful for triaging suspicious URLs without visiting them. "
+        "Example: `@unfurl https://example.com/path?utm_source=foo&id=eyJhbGciOi...`",
+    },
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ azure-storage-blob
 beautifulsoup4
 chardet
 ConfigArgParse
+dfir-unfurl[all]
 feedparser
 graphviz
 lxml


### PR DESCRIPTION
## Summary

Wraps [obsidianforensics/unfurl](https://github.com/obsidianforensics/unfurl) (`dfir-unfurl`) as a MatterBot command. Takes a URL, returns its component tree (decoded tracking params, embedded base64, JWT contents, timestamps, UUIDs, etc.) inside a fenced code block — useful for triaging suspicious URLs without visiting them.

Closes #94.

## Design notes

- **Local-lib pattern** (no API key, no network by default) — mirrors the shape of `commands/argostrans/`.
- **`remote_lookups=False`** default keeps queried URLs from leaking to third-party enrichment services (shortener expansion, etc.) without explicit opt-in.
- **Output capped at `MAX_OUTPUT_CHARS` (8000)** with a truncation note, well under Mattermost's 16K message ceiling.
- **Lazy import** of `unfurl.core` so a missing `dfir-unfurl` produces a clean in-channel message instead of crashing module load and taking the whole bot down.
- **`except Exception as e:`** (not bare `except:`) to avoid the F821 regression class that PR #171 introduced and #181 hotfixed.
- **`dfir-unfurl[all]`** pin in `requirements.txt` so the help-text-advertised parsers (JWT, protobuf, etc.) actually work — the bare `dfir-unfurl` install would silently no-op those.

## Files

- `commands/unfurl/command.py` (new) — `process()` handler, ~100 LOC
- `commands/unfurl/defaults.py` (new) — `BINDS=['@unfurl']`, `CHANS=['debug']`, `REMOTE_LOOKUPS=False`, `MAX_OUTPUT_CHARS=8000`, HELP
- `requirements.txt` — add `dfir-unfurl[all]` (alphabetical)

## Test plan

- [ ] `pip install dfir-unfurl[all]` then `python3 -c "from commands.unfurl import command; print(command.process('@unfurl', '#debug', 'tester', ['https://twitter.com/_RyanBenson/status/1205161015177961473'], None, None))"` — verify tree output renders.
- [x] Module loads with `dfir-unfurl` absent — clean error message, no crash on import.
- [x] No-params branch returns usage hint.
- [x] Syntax + ast parse clean.
- [ ] Smoke test in a live bot instance against a complex URL (encoded params, base64 segments).
- [ ] Verify output renders cleanly in Mattermost with the code-fence wrapper.