### PR TITLE
dnstwist: add @dnstwist command for typosquatting permutation lookup

### DIFF
--- a/commands/dnstwist/command.py
+++ b/commands/dnstwist/command.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+
+import contextlib
+import io
+import logging
+import re
+
+log = logging.getLogger("MatterBot")
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+
+_pkg = __package__ or Path(__file__).parent.name
+
+
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+
+
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+# Strict RFC-1123 hostname check — rejects URLs with paths, IPs, and shell
+# metacharacters so the operator-supplied string is safe to pass to dnstwist.
+_DOMAIN_RE = re.compile(
+    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
+    r"(?:\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+)
+
+
+def _format_results(domain, results, registered_only):
+    if not results:
+        if registered_only:
+            return f"No registered permutations found for `{domain}`."
+        return f"No permutations generated for `{domain}`."
+
+    by_fuzzer = {}
+    for r in results:
+        fuzzer = r.get("fuzzer", "unknown")
+        by_fuzzer.setdefault(fuzzer, []).append(r)
+
+    lines = []
+    for fuzzer in sorted(by_fuzzer):
+        entries = by_fuzzer[fuzzer]
+        lines.append(f"\n## {fuzzer} ({len(entries)})")
+        for r in entries:
+            perm = r.get("domain", "?")
+            a = r.get("dns_a") or []
+            aaaa = r.get("dns_aaaa") or []
+            ns = r.get("dns_ns") or []
+            mx = r.get("dns_mx") or []
+            extras = []
+            if a:
+                extras.append("A=" + ",".join(a))
+            if aaaa:
+                extras.append("AAAA=" + ",".join(aaaa))
+            if ns:
+                extras.append("NS=" + ",".join(ns))
+            if mx:
+                extras.append("MX=" + ",".join(mx))
+            if extras:
+                lines.append(f"  {perm}  [{' | '.join(extras)}]")
+            else:
+                lines.append(f"  {perm}")
+
+    return "\n".join(lines)
+
+
+def process(command, channel, username, params, files, conn):
+    messages = []
+
+    if not params:
+        return {
+            "messages": [
+                {
+                    "text": "Usage: `@dnstwist <domain>` — generates typosquatting permutations of a domain."
+                }
+            ]
+        }
+
+    raw = params[0].strip().lower().strip(".")
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    domain = raw.split("/", 1)[0]
+
+    if not _DOMAIN_RE.match(domain):
+        return {
+            "messages": [
+                {
+                    "text": f"`{params[0]}` does not look like a valid domain. Pass a bare hostname like `example.com`."
+                }
+            ]
+        }
+
+    try:
+        # Lazy import so a missing dep produces a clean message rather than
+        # crashing module load and taking the whole bot down.
+        import dnstwist
+
+        kwargs = {"domain": domain, "format": "null"}
+        if settings.REMOTE_LOOKUPS:
+            kwargs["registered"] = True
+            kwargs["threads"] = settings.THREADS
+
+        # dnstwist may emit progress chatter to stdout/stderr; capture it so the
+        # bot's logs don't fill up with CLI-style output when called programmatically.
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            results = dnstwist.run(**kwargs)
+
+        if results is None:
+            results = []
+
+        truncation_note = ""
+        if len(results) > settings.MAX_RESULTS:
+            results = results[: settings.MAX_RESULTS]
+            truncation_note = (
+                f"\n_Result list truncated at {settings.MAX_RESULTS} entries; "
+                "run dnstwist locally for the full set._"
+            )
+
+        registered_only = bool(settings.REMOTE_LOOKUPS)
+        body = _format_results(domain, results, registered_only)
+
+        truncated = False
+        if len(body) > settings.MAX_OUTPUT_CHARS:
+            body = body[: settings.MAX_OUTPUT_CHARS]
+            truncated = True
+
+        mode = (
+            "registered permutations"
+            if registered_only
+            else "permutations (no DNS resolution)"
+        )
+        wrapped = (
+            f"**DNSTwist {mode} for `{domain}`:**\n```\n{body}\n```{truncation_note}"
+        )
+        if truncated:
+            wrapped += (
+                f"\n_Output truncated at {settings.MAX_OUTPUT_CHARS} characters._"
+            )
+
+        messages.append({"text": wrapped})
+    except ImportError:
+        log.warning(
+            "dnstwist module: dnstwist package not installed; "
+            "install with `pip install dnstwist`"
+        )
+        messages.append(
+            {
+                "text": "DNSTwist is not installed on this host. "
+                "Run `pip install dnstwist` and restart the bot."
+            }
+        )
+    except Exception as e:
+        log.exception("dnstwist module error")
+        messages.append({"text": f"An error occurred in DNSTwist:\nError: {str(e)}"})
+
+    return {"messages": messages}

--- a/commands/dnstwist/defaults.py
+++ b/commands/dnstwist/defaults.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+BINDS = ["@dnstwist"]
+CHANS = ["debug"]
+
+# Whether DNSTwist should perform DNS lookups against the generated permutations
+# and return only registered ones. This is the killer feature of the tool —
+# without DNS resolution you only get a permutation list with no signal about
+# which ones are actually live. Unlike `unfurl` (which leaks the queried URL to
+# shorteners and threat-intel services on remote_lookups=True), the privacy
+# cost here is just public DNS queries for typosquat candidates of the
+# user-supplied domain, so this defaults to True.
+# Set to False if you want a pure offline permutation enumeration.
+REMOTE_LOOKUPS = True
+
+# Per-run DNS resolution thread count. dnstwist's own default is 10.
+THREADS = 10
+
+# Soft cap on the number of result rows kept after fuzzing. dnstwist can
+# produce thousands of permutations; truncating here keeps the channel
+# message tractable and well under Mattermost's message ceiling.
+MAX_RESULTS = 200
+
+# Soft cap on the rendered message body. Mattermost rejects very large
+# messages; anything above this is truncated with a footer note.
+MAX_OUTPUT_CHARS = 8000
+
+HELP = {
+    "DEFAULT": {
+        "args": "<domain>",
+        "desc": "Generates typosquatting and lookalike permutations of a domain "
+        "using DNSTwist (https://github.com/elceef/dnstwist) and resolves them "
+        "against public DNS to find registered ones. Useful for brand-protection "
+        "monitoring and phishing triage. "
+        "Example: `@dnstwist paypal.com`",
+    },
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ beautifulsoup4
 chardet
 ConfigArgParse
 dfir-unfurl[all]
+dnstwist
 feedparser
 graphviz
 holehe


### PR DESCRIPTION
## Summary

Wraps [elceef/dnstwist](https://github.com/elceef/dnstwist) as a MatterBot command. Takes a domain, generates typosquatting and lookalike permutations (homoglyph, addition, omission, bit-squat, etc.), and resolves them against public DNS to return only registered ones. Useful for brand-protection monitoring and phishing triage.

Closes #137.

## Design notes

- **Local-lib pattern** (no API key) — mirrors the shape of `commands/argostrans/` and the recently added `commands/unfurl/` (#183).
- **`REMOTE_LOOKUPS=True` default** (differs from `unfurl`'s `False`). The killer feature of dnstwist is filtering to actually-registered permutations via DNS. The privacy cost is just public DNS queries for typosquats of the user-supplied domain — minimal compared to unfurl's shortener-expansion / threat-intel leak surface. Setting `False` gives a pure offline permutation enumeration.
- **Lazy import** of `dnstwist` so a missing package produces a clean in-channel message instead of crashing module load and taking the whole bot down.
- **Strict RFC-1123 hostname regex** on input — rejects URLs with paths, IPs, and shell metacharacters so the operator string is safe to pass to dnstwist.
- **URL-stripping prefix** so a pasted `https://paypal.com/path` still works.
- **`MAX_RESULTS` (200)** caps row count, **`MAX_OUTPUT_CHARS` (8000)** caps body length — well under Mattermost's 16K message ceiling.
- **`contextlib.redirect_stdout/stderr`** around `dnstwist.run()` to prevent any CLI-style progress chatter from polluting the bot log.
- **`except Exception as e:`** (not bare `except:`) to avoid the F821 regression class from #171/#181.

## Files

- `commands/dnstwist/command.py` (new) — `process()` handler, ~160 LOC
- `commands/dnstwist/defaults.py` (new) — `BINDS=['@dnstwist']`, `CHANS=['debug']`, `REMOTE_LOOKUPS=True`, `THREADS=10`, `MAX_RESULTS=200`, `MAX_OUTPUT_CHARS=8000`, HELP
- `requirements.txt` — add `dnstwist` (alphabetical)

## Test plan

- [x] `py_compile` clean on both module files.
- [x] No-params branch returns usage hint without requiring `dnstwist` installed.
- [x] Invalid-domain branch returns validation rejection without invoking dnstwist.
- [x] Domain regex accepts `paypal.com`, rejects `paypal.com/path`, rejects `not a domain!`.
- [x] Module loads with `dnstwist` absent — clean ImportError-branch message, no crash.
- [x] `dnstwist` v20250130 confirmed installable from PyPI; `dnstwist.run` symbol confirmed present.
- [ ] Smoke test with `dnstwist` installed: `dnstwist.run(domain='example.com', registered=True, format='null', threads=10)` produces parseable output and the formatter renders it. *(My local sandbox timed out at 60s on this call — it may be slower than expected even on small domains; needs verification in a live bot environment with realistic timeouts.)*
- [ ] Smoke test in a live bot instance against `paypal.com` — verify rendered output fits in a Mattermost code-fence and the per-fuzzer grouping is readable.
- [ ] Verify `REMOTE_LOOKUPS=False` path produces a usable permutation enumeration (no DNS chatter).