### PR TITLE
gitignore: ignore OS noise (.DS_Store, Thumbs.db, etc.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# OS noise
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+desktop.ini


### PR DESCRIPTION
## Summary

Adds OS-noise entries to `.gitignore` so `git status` stops listing macOS Finder and Windows Explorer scratch files for every contributor on those platforms.

Spotted while working on PRs #183 / #184 — every `git status` was returning `.DS_Store` and `commands/.DS_Store` as untracked, which clutters the working-tree view and risks one of them getting accidentally `git add .`'d in a future PR.

## Entries added

| Pattern | Source |
|---|---|
| `.DS_Store` | macOS Finder thumbnail/metadata cache |
| `.DS_Store?` | macOS Finder backup variant |
| `._*` | macOS resource-fork sidecars |
| `.Spotlight-V100` | macOS Spotlight index (volume root) |
| `.Trashes` | macOS volume-level trash directory |
| `Thumbs.db` | Windows Explorer thumbnail cache |
| `desktop.ini` | Windows Explorer folder-display config |

## Files

- `.gitignore` — +9 lines, new `# OS noise` section at the end.

## Test plan

- [x] On macOS, after pulling this branch, `git status` no longer lists `.DS_Store` files.
- [x] Existing `.DS_Store` files removed from the repo root and `commands/` (untracked, so just `rm` — they were never committed).