### PR TITLE
Fix #180 E711/E712: use is/is not for None and bool identity checks

### DIFF
--- a/commands/abuseipdb/command.py
+++ b/commands/abuseipdb/command.py
@@ -3,7 +3,6 @@
 import collections
 import re
 import requests
-import traceback
 
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module
@@ -144,9 +143,9 @@ def process(command, channel, username, params, files, conn):
                                         elif field == 'isWhitelisted':
                                             if value:
                                                 value = ':waving_white_flag:'
-                                            elif value == None:
+                                            elif value is None:
                                                 value = ':grey_question:'
-                                            elif value == False:
+                                            elif value is False:
                                                 value = ':waving_black_flag:'
                                         elif field == 'reports':
                                             uniquecats = set()

--- a/commands/asnwhois/command.py
+++ b/commands/asnwhois/command.py
@@ -3,7 +3,6 @@
 import logging
 import re
 import requests
-import traceback
 
 log = logging.getLogger('MatterBot')
 
@@ -49,7 +48,7 @@ def process(command, channel, username, params, files, conn):
                     json_response = response.json()
                     message = 'ASN WHOIS lookup for `%s`: ' % (data,)
                     if 'data' in json_response:
-                        if json_response['data']['asn'] == None:
+                        if json_response['data']['asn'] is None:
                             return {'messages': [
                                 {'text': 'ASN `%s` does not exist.' % (data,)}
                             ]}

--- a/commands/greynoise/command.py
+++ b/commands/greynoise/command.py
@@ -3,7 +3,6 @@
 import random
 import re
 import requests
-import traceback
 import urllib.parse
 
 ### Dynamic configuration loader (do not change/edit)
@@ -57,7 +56,7 @@ def process(command, channel, username, params, files, conn):
     try:
         if len(params)>0:
             querytype = params[0].lower() if params[0] in querytypes else 'community'
-            if not querytype in querytypes:
+            if querytype not in querytypes:
                 return
             APIENDPOINT = settings.APIURL['greynoise']['url']
             headers = {
@@ -155,9 +154,9 @@ def process(command, channel, username, params, files, conn):
                                                         metadatavalue = metadatavalue.strip()
                                                     elif metadatafield == 'tor':
                                                         metadatavalue = json_response[field][metadatafield]
-                                                        if metadatavalue == True:
+                                                        if metadatavalue is True:
                                                             metadatavalue = '`Yes`'
-                                                        elif metadatavalue == False:
+                                                        elif metadatavalue is False:
                                                             metadatavalue = '`No`'
                                                         else:
                                                             metadatavalue = ''
@@ -203,9 +202,9 @@ def process(command, channel, username, params, files, conn):
                                                         message += '\n| **%s** | %s |' % (rawdatafields[rawdatafield],rawdatavalue)
                                         else:
                                             value = json_response[field]
-                                            if value == True:
+                                            if value is True:
                                                 value = 'Yes'
-                                            if value == False:
+                                            if value is False:
                                                 value = 'No'
                                             if len(value):
                                                 message += '\n| **%s** | `%s` |' % (fields[field],value)

--- a/commands/ipwhois/command.py
+++ b/commands/ipwhois/command.py
@@ -40,7 +40,7 @@ def process(command, channel, username, params, files, conn):
                     json_response = response.json()
                     message = 'IPWHOIS lookup for `%s`' % (data,)
                     if 'success' in json_response:
-                        if json_response['success'] != True:
+                        if json_response['success'] is not True:
                             return {'messages': [
                                 {'text': 'IPWHOIS errored out while searching for `%s`' % (params,)}
                             ]}

--- a/matterbot.py
+++ b/matterbot.py
@@ -85,7 +85,7 @@ class MattermostManager(object):
             for module in fnmatch.filter(files, "command.py"):
                 module_name = root.split('/')[-1].lower()
                 module = importlib.import_module(module_name + '.' + 'command')
-                if not module_name in self.commands:
+                if module_name not in self.commands:
                     module.settings.BINDS = None
                     module.settings.CHANS = None
                     defaults = importlib.import_module(module_name + '.' + 'defaults')
@@ -189,7 +189,7 @@ class MattermostManager(object):
                         channel_members = self.mmDriver.channels.get_channel_members(welcome_channel_id)
                         return [_['user_id'] for _ in channel_members]
         except:
-            log.error(f"An error occurred updating the welcome channel state!")
+            log.error("An error occurred updating the welcome channel state!")
 
     async def update_welcome_channel(self):
         try:
@@ -200,7 +200,7 @@ class MattermostManager(object):
                         channel_members = self.mmDriver.channels.get_channel_members(welcome_channel_id)
                         return [_['user_id'] for _ in channel_members]
         except:
-            log.error(f"An error occurred updating the welcome channel state!")
+            log.error("An error occurred updating the welcome channel state!")
 
     async def update_bindmap(self):
         try:
@@ -211,7 +211,7 @@ class MattermostManager(object):
             with open(options.Matterbot['bindmap'],'w') as f:
                 json.dump(self.bindmap,f)
         except:
-            log.error(f"An error occurred updating the `%s` bindmap file; config changes were not successfully saved!" % (options.Matterbot['bindmap'],))
+            log.error("An error occurred updating the `%s` bindmap file; config changes were not successfully saved!" % (options.Matterbot['bindmap'],))
 
     async def update_feedmap(self):
         try:
@@ -219,7 +219,7 @@ class MattermostManager(object):
             with open(options.Matterbot['feedmap'],'w') as f:
                 json.dump(self.newfeedmap,f)
         except:
-            log.error(f"An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (options.Matterbot['feedmap'],))
+            log.error("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (options.Matterbot['feedmap'],))
 
     async def handle_raw_message(self, raw_json: str):
         try:
@@ -498,12 +498,12 @@ class MattermostManager(object):
                                 if 'ADMIN_ONLY' in self.feedmap['MODULES'][unclassified_feed]:
                                     displayname = unclassified_feed+r'(*)' if self.feedmap['MODULES'][unclassified_feed]['ADMIN_ONLY'] else unclassified_feed
                                 unclassified_feeds_displaynames.add(displayname)
-                            text += f"\n| Unclassified | `"+"`, `".join(sorted(unclassified_feeds_displaynames))+"` |"
+                            text += "\n| Unclassified | `"+"`, `".join(sorted(unclassified_feeds_displaynames))+"` |"
                         text += "\n\n"
                         text += "*An asterisk after a module name indicates the feed can only be enabled/disabled by a MatterBot admin.*\n"
                         messages.append(text)
                     if len(enabled_feeds):
-                        text = f"Enabled feeds: `"+"` ,`".join(sorted(enabled_feeds))+f"` ({len(enabled_feeds)})"
+                        text = "Enabled feeds: `"+"` ,`".join(sorted(enabled_feeds))+f"` ({len(enabled_feeds)})"
                         messages.append(text)
                     else:
                         text = "There are no feeds enabled in this channel.\n"
@@ -517,8 +517,8 @@ class MattermostManager(object):
                         messages.append(text)
                 if self.isadmin(userid) or options.Matterbot['feedmode'].lower() == 'user':
                     all_channel_types = [self.chanid_to_channame(_['id']) for _ in self.mmDriver.channels.get_channels_for_user(self.my_id,self.my_team_id) if self.is_in_channel(_['id'])]
-                    my_channels = [_ for _ in all_channel_types if not self.my_id in _]
-                    if not channame in my_channels:
+                    my_channels = [_ for _ in all_channel_types if self.my_id not in _]
+                    if channame not in my_channels:
                         text = f"@{username}, you cannot have feeds in a Direct Message window."
                         messages.append(text)
                     else:
@@ -548,7 +548,7 @@ class MattermostManager(object):
                                     if not ADMIN_ONLY or self.isadmin(userid):
                                         if mode == 'enable':
                                             if 'NAME' in self.feedmap['MODULES'][module_name]:
-                                                if not channame in self.feedmap['MODULES'][module_name]['CHANNELS']:
+                                                if channame not in self.feedmap['MODULES'][module_name]['CHANNELS']:
                                                     self.feedmap['MODULES'][module_name]['CHANNELS'].append(channame)
                                                     switched_feeds.add(module_name)
                                         elif mode == 'disable':
@@ -614,14 +614,14 @@ class MattermostManager(object):
                 text = "@" + username + ", you do not have permission to bind commands."
             else:
                 all_channel_types = [self.chanid_to_channame(_['id']) for _ in self.mmDriver.channels.get_channels_for_user(self.my_id,self.my_team_id) if self.is_in_channel(_['id'])]
-                my_channels = [_ for _ in all_channel_types if not self.my_id in _]
-                if not channame in my_channels:
+                my_channels = [_ for _ in all_channel_types if self.my_id not in _]
+                if channame not in my_channels:
                     text = "@" + username + ", you cannot bind commands to direct message windows."
                 else:
                     if params[0] == '*':
                         params = self.commands.keys() # Attempt to enable/disable all modules
                     for modulename in params:
-                        if not modulename in self.commands:
+                        if modulename not in self.commands:
                             text = "@" + username + ", there is no `%s` module loaded. Use one of the help commands (`%s`) to see a list of available modules." % (modulename,"`, `".join(options.Matterbot['helpcmds']))
                         elif command in ('!bind', '@bind'):
                             if channame in self.commands[modulename]['chans']:
@@ -630,7 +630,7 @@ class MattermostManager(object):
                                 self.commands[modulename]['chans'].append(channame)
                                 text = "The `%s` module is now available in the `%s` channel." % (modulename,self.channame_to_chandisplayname(channame))
                         elif command in ('!unbind', '@unbind'):
-                            if not channame in self.commands[modulename]['chans']:
+                            if channame not in self.commands[modulename]['chans']:
                                 text = "The `%s` module is not loaded in the `%s` channel." % (modulename,self.channame_to_chandisplayname(channame))
                             else:
                                 self.commands[modulename]['chans'].remove(channame)
@@ -776,7 +776,7 @@ class MattermostManager(object):
                     if 'text' in message:
                         text = message['text']
                     if 'uploads' in message:
-                        if message['uploads'] != None:
+                        if message['uploads'] is not None:
                             uploads = []
                             for upload in message['uploads']:
                                 filename = upload['filename']
@@ -868,7 +868,7 @@ class MattermostManager(object):
                         for module in self.commands:
                             if command in self.commands[module]['binds']:
                                 if self.isallowed_module(userid, module, chaninfo):
-                                    if not module in modules_to_run:
+                                    if module not in modules_to_run:
                                         modules_to_run.append(module)
                         if modules_to_run:
                             files = []


### PR DESCRIPTION
## Summary

Resolves the E711/E712 line items in #180's 🟡 lint-sweep section. 9 surgical edits across 5 files, plus auto-fixes from the pre-commit hook for other safe-fix lint findings in the same files (F401, E713, F541).

### Primary fix (9 lines — E711/E712)

Each callsite is a tri-state identity check (truthy / None / False, or True / False / other) where the author's intent was exact identity, not truthiness. Using `is`/`is not` preserves the original semantics without broadening to all falsy values (which `not value` would do).

| File:Line | Before | After | Why `is` over bare truthiness |
|---|---|---|---|
| `commands/abuseipdb/command.py:147,149` | `value == None`, `value == False` | `value is None`, `value is False` | Tri-state for `isWhitelisted`: truthy → white_flag, None → grey_question, False → black_flag. `not value` would merge None and False. |
| `commands/asnwhois/command.py:52` | `... == None` | `... is None` | Plain None check on a JSON field. |
| `commands/greynoise/command.py:158,160,206,208` | `... == True/False` | `... is True/False` | JSON booleans Yes/No/other with explicit else branch for "neither". |
| `commands/ipwhois/command.py:43` | `... != True` | `... is not True` | Identity check on JSON success flag. |
| `matterbot.py:779` | `... != None` | `... is not None` | Optional `uploads` field on message dict. |

### Auto-fixes bundled in (44 lines — F401/E713/F541)

The pre-commit hook applied ruff safe-fixes alongside the staged files:

- **F401** unused `import traceback` removed from 3 files (abuseipdb, asnwhois, greynoise). Pre-existing dead imports after the print()-debug-leak sweep in #178 made them unused.
- **E713** `not x in y` → `x not in y` (10 sites in `matterbot.py`). Semantically identical, PEP 8 preferred form.
- **F541** `f"static string"` → `"static string"` (4 sites in `matterbot.py`). f-strings with no interpolations are misleading and slightly slower.

All are ruff "safe" fixes — no semantic change risk.

## Test plan

- [x] `ruff check --select E711,E712 .` clean across the whole repo (was 9 findings)
- [x] AST parse of all 5 touched files
- [ ] Operator: trigger an AbuseIPDB lookup against an IP with `isWhitelisted = null` (None branch) and confirm `:grey_question:` still appears in the rendered table
- [ ] Operator: trigger a GreyNoise lookup and confirm `tor`/`bot`/`vpn` boolean fields render as `Yes`/`No`/empty correctly

Refs #180