### PR TITLE
Fix #180 E722: narrow bare-except in core dispatch + feed loops

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -62,8 +62,8 @@ class MattermostManager(object):
         })
         try:
             self.mmDriver.login()
-        except:
-            log.error("Mattermost server is unreachable. Perhaps it is down, or you might have misconfigured one or more setting(s). Shutting down!")
+        except Exception:
+            log.exception("Mattermost server is unreachable. Perhaps it is down, or you might have misconfigured one or more setting(s). Shutting down!")
             return False
         self.me = self.mmDriver.users.get_user(user_id='me')
         log.info("Who am I: %s" % (self.me,))
@@ -104,8 +104,8 @@ class MattermostManager(object):
         try:
             with open(options.Matterbot['bindmap'],'w') as f:
                 json.dump(self.commands,f)
-        except:
-            log.error("An error occurred writing the bindmap file: %s" % (options.Matterbot['bindmap'],))
+        except Exception:
+            log.exception("An error occurred writing the bindmap file: %s" % (options.Matterbot['bindmap'],))
         # Resolve function calls and update the module help
         for root, dirs, files in os.walk(modulepath):
             for module in fnmatch.filter(files, "command.py"):
@@ -188,8 +188,8 @@ class MattermostManager(object):
                     if self.is_in_channel(welcome_channel_id):
                         channel_members = self.mmDriver.channels.get_channel_members(welcome_channel_id)
                         return [_['user_id'] for _ in channel_members]
-        except:
-            log.error("An error occurred updating the welcome channel state!")
+        except Exception:
+            log.exception("An error occurred updating the welcome channel state!")
 
     async def update_welcome_channel(self):
         try:
@@ -199,8 +199,8 @@ class MattermostManager(object):
                     if self.is_in_channel(welcome_channel_id):
                         channel_members = self.mmDriver.channels.get_channel_members(welcome_channel_id)
                         return [_['user_id'] for _ in channel_members]
-        except:
-            log.error("An error occurred updating the welcome channel state!")
+        except Exception:
+            log.exception("An error occurred updating the welcome channel state!")
 
     async def update_bindmap(self):
         try:
@@ -210,16 +210,16 @@ class MattermostManager(object):
                 del self.bindmap[module]['process']
             with open(options.Matterbot['bindmap'],'w') as f:
                 json.dump(self.bindmap,f)
-        except:
-            log.error("An error occurred updating the `%s` bindmap file; config changes were not successfully saved!" % (options.Matterbot['bindmap'],))
+        except Exception:
+            log.exception("An error occurred updating the `%s` bindmap file; config changes were not successfully saved!" % (options.Matterbot['bindmap'],))
 
     async def update_feedmap(self):
         try:
             self.newfeedmap = copy.deepcopy(self.feedmap)
             with open(options.Matterbot['feedmap'],'w') as f:
                 json.dump(self.newfeedmap,f)
-        except:
-            log.error("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (options.Matterbot['feedmap'],))
+        except Exception:
+            log.exception("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (options.Matterbot['feedmap'],))
 
     async def handle_raw_message(self, raw_json: str):
         try:
@@ -401,7 +401,8 @@ class MattermostManager(object):
             normalized_roles = [str(e).lower() for e in botadmins]
             if any(role in roles for role in normalized_roles) or userid in botadmins:
                 return True
-        except:
+        except Exception:
+            log.exception("isadmin check failed; treating as non-admin")
             return None
 
     def is_in_channel(self, chanid, userid=None):
@@ -743,8 +744,8 @@ class MattermostManager(object):
                                     try:
                                         with open(welcome_file) as f:
                                             text += f.read()
-                                    except:
-                                        log.error(f"The welcome message file {welcome_file} could not be read!")
+                                    except Exception:
+                                        log.exception(f"The welcome message file {welcome_file} could not be read!")
                             await self.send_message(welcome_channel, text)
 
 

--- a/matterfeed.py
+++ b/matterfeed.py
@@ -60,26 +60,26 @@ class MattermostManager(object):
                     channelmap[channel_info['name']] = channel_info['id']
             self.log.info("Complete : Channels updated ...")
             return channelmap
-        except:
+        except Exception:
             if options.debug:
-                self.log.error("Error   : Cannot update channel map, announcements in additional channels might not work!")
+                self.log.exception("Error   : Cannot update channel map, announcements in additional channels might not work!")
             return {}
 
     def load_feedmap(self):
         try:
             with open(options.Modules['feedmap'],'r') as f:
                 return json.load(f)
-        except:
+        except Exception:
             if options.debug:
-                self.log.error(f"Error   : Cannot read {options.Modules['feedmap']} file. Announcements in additional channels might not work!")
+                self.log.exception(f"Error   : Cannot read {options.Modules['feedmap']} file. Announcements in additional channels might not work!")
             return {}
 
     def update_feedmap(self):
         try:
             with open(options.Matterbot['feedmap'],'w') as f:
                 json.dump(self.feedmap,f)
-        except:
-            self.log.error("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (options.Matterbot['feedmap'],))
+        except Exception:
+            self.log.exception("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (options.Matterbot['feedmap'],))
 
     def createPost(self, channel, text, uploads = []):
         try:
@@ -322,7 +322,7 @@ class MattermostManager(object):
                 for newspost in items:
                     try:
                         channel, content, uploads = newspost
-                    except:
+                    except ValueError:
                         channel, content = newspost
                         uploads = []
                     if [channel, content, uploads] not in posts:


### PR DESCRIPTION
## Summary

First chunk of #180's E722 sweep, scoped to the two top-level files (`matterbot.py` and `matterfeed.py`). 12 bare-except callsites narrowed. The remaining 232 sites live in `commands/*` and `modules/*` and will be tackled per-directory in follow-up PRs to keep them reviewable.

Why this chunk first: bare `except:` swallows `KeyboardInterrupt` and `SystemExit`, which is SIGTERM-hostile (per #180's reference to the #154 graceful drain). The bot's core dispatch + feed loops are where this matters most — a Ctrl+C inside any of these blocks would be silently caught and the process would keep running.

### Per-case judgment

| File:Line | Fix | Rationale |
|---|---|---|
| `matterbot.py:65` | `except Exception:` + `log.exception` | Login fail in `__init__`. Let Ctrl+C propagate during startup; surface the driver error. |
| `matterbot.py:107` | `except Exception:` + `log.exception` | Bindmap write. Was swallowing IOError details. |
| `matterbot.py:191` | `except Exception:` + `log.exception` | `start_welcome_channel`. Generic error message was unhelpful for debugging. |
| `matterbot.py:202` | `except Exception:` + `log.exception` | `update_welcome_channel` async — same. |
| `matterbot.py:213` | `except Exception:` + `log.exception` | `update_bindmap` async. |
| `matterbot.py:221` | `except Exception:` + `log.exception` | `update_feedmap` async. |
| `matterbot.py:404` | `except Exception:` + `log.exception` (new message) | `isadmin` permission check. A swallowed exception here fail-closes to "not admin" (right direction), but doing it silently meant nobody knew the check had broken. Added an explicit log line. |
| `matterbot.py:746` | `except Exception:` + `log.exception` | Welcome message file read — was swallowing file-system errors. |
| `matterfeed.py:63` | `except Exception:` (log preserved, debug-guarded) | Channel-map update. Control flow unchanged. |
| `matterfeed.py:72` | `except Exception:` (log preserved, debug-guarded) | `load_feedmap`. Control flow unchanged. |
| `matterfeed.py:81` | `except Exception:` + `log.exception` | `update_feedmap` write. |
| `matterfeed.py:325` | `except ValueError:` (specific) | Catches tuple-unpacking arity mismatch (3-tuple vs 2-tuple from modules). Narrowed to the exact exception class. |

### Notes

- 7 of the 8 matterbot.py sites had a generic `log.error("An error occurred X")` line that threw away the exception info. Upgraded to `log.exception(...)` so the traceback lands in the log alongside the human-readable message. Caller behavior (return None/False/{}) unchanged.
- `matterfeed.py:325` was the only one where the bare-except was *deliberately* catching a specific control-flow case (unpacking arity). Narrowed to `ValueError` to make the intent explicit.

## Test plan

- [x] `ruff check --select E722 matterbot.py matterfeed.py` — clean (was 12 findings)
- [x] AST parse of both files
- [x] Repo-wide E722 count: 244 → 232 (confirmed dropped by 12)
- [ ] Operator: kill the bot with SIGINT and confirm it now exits promptly rather than catching the signal inside one of the touched try-blocks

## Follow-up

Remaining E722 sites (232) split roughly as:
- `commands/*` (~190 sites across ~60 modules)
- `modules/*` (~40 sites)

Will go in batches by directory or by file as separate PRs.

Refs #180