### PR TITLE
waybacklister: add @waybacklister command for archived open-directory hunt

### DIFF
--- a/commands/waybacklister/command.py
+++ b/commands/waybacklister/command.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+
+import logging
+import re
+from urllib.parse import urlsplit
+
+import requests
+
+log = logging.getLogger("MatterBot")
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+
+_pkg = __package__ or Path(__file__).parent.name
+
+
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+
+
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+# Strict RFC-1123 hostname check — rejects URLs with paths, IPs, and shell
+# metacharacters so the operator-supplied string is safe to interpolate into
+# the CDX query as a bare host.
+_DOMAIN_RE = re.compile(
+    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
+    r"(?:\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+)
+
+
+def _looks_like_directory(url):
+    # CDX "original" entries are full URLs. A directory-shaped URL is one whose
+    # path component ends in `/` and has no querystring (querystrings on `/`
+    # paths almost always mean dynamic endpoints, not file listings).
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return False
+    if parts.query:
+        return False
+    path = parts.path or "/"
+    return path.endswith("/") and path != "/"
+
+
+def _format_results(domain, hits, total_rows):
+    if not hits:
+        return (
+            f"No directory-shaped paths found in the Wayback Machine for "
+            f"`{domain}` (checked {total_rows} archived URLs)."
+        )
+    lines = [
+        f"## Directory-shaped Wayback paths for {domain} ({len(hits)} of {total_rows} archived URLs)"
+    ]
+    for url in hits:
+        lines.append(f"  {url}")
+    return "\n".join(lines)
+
+
+def process(command, channel, username, params, files, conn):
+    messages = []
+
+    if not params:
+        return {
+            "messages": [
+                {
+                    "text": "Usage: `@waybacklister <domain>` — enumerates "
+                    "archived directory-shaped paths for a domain via the "
+                    "Wayback Machine CDX API."
+                }
+            ]
+        }
+
+    raw = params[0].strip().lower().strip(".")
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    domain = raw.split("/", 1)[0]
+
+    if not _DOMAIN_RE.match(domain):
+        return {
+            "messages": [
+                {
+                    "text": f"`{params[0]}` does not look like a valid domain. "
+                    "Pass a bare hostname like `example.com`."
+                }
+            ]
+        }
+
+    try:
+        response = requests.get(
+            settings.CDX_URL,
+            params={
+                "url": f"{domain}/*",
+                "output": "json",
+                "fl": "original",
+                "collapse": "urlkey",
+                "limit": settings.CDX_LIMIT,
+            },
+            headers={"User-Agent": settings.USER_AGENT},
+            timeout=(10, settings.TIMEOUT),
+            allow_redirects=False,
+        )
+    except requests.exceptions.Timeout:
+        log.warning("waybacklister: CDX timeout for %s", domain)
+        return {
+            "messages": [
+                {
+                    "text": f"Wayback CDX timed out after {settings.TIMEOUT}s. "
+                    "The Internet Archive is occasionally slow — try again later."
+                }
+            ]
+        }
+    except requests.exceptions.RequestException:
+        log.exception("waybacklister: CDX request failed")
+        return {
+            "messages": [
+                {
+                    "text": "Wayback CDX request failed. "
+                    "Check bot logs for details."
+                }
+            ]
+        }
+
+    if response.status_code != 200:
+        log.warning(
+            "waybacklister: CDX returned HTTP %s for %s",
+            response.status_code,
+            domain,
+        )
+        return {
+            "messages": [
+                {
+                    "text": f"Wayback CDX returned HTTP {response.status_code} "
+                    f"for `{domain}`."
+                }
+            ]
+        }
+
+    try:
+        rows = response.json()
+    except ValueError:
+        log.exception("waybacklister: CDX returned non-JSON body")
+        return {
+            "messages": [
+                {"text": "Wayback CDX returned a malformed response body."}
+            ]
+        }
+
+    # CDX json shape: [["original"], ["http://example.com/"], ["http://example.com/about/"], ...]
+    # First row is the header; skip it.
+    if not rows or len(rows) < 2:
+        return {
+            "messages": [
+                {
+                    "text": f"Wayback has no archived URLs for `{domain}`."
+                }
+            ]
+        }
+
+    urls = [row[0] for row in rows[1:] if row]
+    hits = sorted({u for u in urls if _looks_like_directory(u)})
+
+    if len(hits) > settings.MAX_RESULTS:
+        hits = hits[: settings.MAX_RESULTS]
+        truncation_note = (
+            f"\n_Result list truncated at {settings.MAX_RESULTS} entries._"
+        )
+    else:
+        truncation_note = ""
+
+    body = _format_results(domain, hits, len(urls))
+
+    truncated = False
+    if len(body) > settings.MAX_OUTPUT_CHARS:
+        body = body[: settings.MAX_OUTPUT_CHARS]
+        truncated = True
+
+    wrapped = f"**Wayback directory enumeration for `{domain}`:**\n```\n{body}\n```{truncation_note}"
+    if truncated:
+        wrapped += (
+            f"\n_Output truncated at {settings.MAX_OUTPUT_CHARS} characters._"
+        )
+
+    messages.append({"text": wrapped})
+    return {"messages": messages}

--- a/commands/waybacklister/defaults.py
+++ b/commands/waybacklister/defaults.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+BINDS = ["@waybacklister", "@wbl"]
+CHANS = ["debug"]
+
+# Wayback CDX endpoint. The bot only ever talks to web.archive.org with a
+# domain it has already validated against a strict RFC-1123 regex, so the
+# outbound surface here is just "a query string built from a known hostname".
+CDX_URL = "https://web.archive.org/cdx/search/cdx"
+
+# CDX request timeout in seconds. The Internet Archive is occasionally slow;
+# this gives it ~30s before we return a clean timeout message instead of
+# blocking the user's command worker.
+TIMEOUT = 30
+
+# Per-query CDX row cap. The collapse=urlkey filter already deduplicates by
+# canonical URL, so 1000 is enough to cover most domains worth listing
+# without producing a multi-megabyte response.
+CDX_LIMIT = 1000
+
+# Soft cap on the rendered directory list. Mattermost rejects very large
+# messages; anything above this is truncated with a footer note.
+MAX_OUTPUT_CHARS = 6000
+
+# Cap the number of URLs we render to the channel after filtering. The CDX
+# limit above bounds the upstream payload; this bounds the user-facing list.
+MAX_RESULTS = 200
+
+# User-Agent for the CDX call. Some Wayback edges return 403 for the default
+# python-requests UA; pinning an identifying string keeps the query routable
+# and makes Internet Archive abuse-handlers able to reach the operator.
+USER_AGENT = "MatterBot-waybacklister/1.0 (+https://github.com/uforia/MatterBot)"
+
+HELP = {
+    "DEFAULT": {
+        "args": "<domain>",
+        "desc": "Enumerates paths the Wayback Machine has archived for a "
+        "domain and filters for directory-shaped URLs (paths ending in `/`). "
+        "Inspired by wayBackLister (https://github.com/anmolksachan/wayBackLister) "
+        "— useful as a first-pass open-directory hunt without sending traffic "
+        "to the live domain. "
+        "Example: `@waybacklister example.com`",
+    },
+}


### PR DESCRIPTION
## Summary

Adds the `@waybacklister` (alias `@wbl`) command. Queries the [Wayback Machine CDX API](https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server) directly for archived URLs of a domain, filters for directory-shaped paths (trailing `/`, no querystring), and returns the deduplicated list.

Inspired by [wayBackLister](https://github.com/anmolksachan/wayBackLister) — that tool is a single-file Python script that hits the same CDX endpoint we hit here, so vendoring it would add zero functional value over the direct query and would require pinning a non-PyPI git dep. No new requirements.

Security shape:
- Strict RFC-1123 domain regex before the host is interpolated into the CDX query.
- `allow_redirects=False`, identifying User-Agent.
- Bounded request body (CDX_LIMIT) and bounded message body (MAX_OUTPUT_CHARS, MAX_RESULTS) with truncation footers.

Closes #143

## Test plan

- [ ] `@waybacklister example.com` in `debug` channel — should return a directory list.
- [ ] `@waybacklister not a domain` — validation message.
- [ ] `@waybacklister some-domain-with-no-archives.invalid` — graceful "no archived URLs" message.
- [ ] Confirm timeout/CDX-non-200 paths surface clean error messages, not tracebacks.