### PR TITLE
mastodon: subscribe to @malicious_browser_bot for malicious-extension alerts

### DIFF
--- a/modules/mastodon/defaults.py
+++ b/modules/mastodon/defaults.py
@@ -5,6 +5,7 @@ URLS = {
     'Kevin Beaumont':           'https://cyberplace.social/@GossiTheDog.rss',
     'Troy Hunt':                'https://infosec.exchange/@troyhunt.rss',
     'Virus Bulletin':           'https://infosec.exchange/@VirusBulletin.rss',
+    'Malicious Browser Bot':    'https://infosec.exchange/@malicious_browser_bot.rss',
 }
 CHANNELS = (
     "newsfeed",


### PR DESCRIPTION
## Summary

[@malicious_browser_bot](https://infosec.exchange/@malicious_browser_bot) on infosec.exchange posts a JSON blob per detection like:

```json
{"id": "lkoieahfcjekjmbdmhgkeokahiknbjhc", "score": 75, "platform": "chrome", "name": "NGT Ava"}
```

Adding it to the existing `modules/mastodon/defaults.py` `URLS` dict is the minimum-surface integration — operators get the raw posts (JSON blob included) in the configured newsfeed channel without needing a dedicated parser module or new dependency.

A future enhancement could extract the JSON into typed alerts; this PR just gets the signal flowing.

Closes #149

## Test plan

- [ ] Restart matterfeed; confirm `Malicious Browser Bot` shows up alongside the other mastodon sources in the newsfeed channel within one poll cycle.
- [ ] Manually check that `https://infosec.exchange/@malicious_browser_bot.rss` is still publicly reachable (no 403 from infosec.exchange edge).