### PR TITLE
watch: add @watch command + scan hook for keyword notifications

### DIFF
--- a/commands/watch/command.py
+++ b/commands/watch/command.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+
+import logging
+import re
+import time
+
+log = logging.getLogger("MatterBot")
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+
+_pkg = __package__ or Path(__file__).parent.name
+
+
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+
+
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+# Import the store under the same package-aware loader so it works whether
+# matterbot is launched from the project root (commands on sys.path as a
+# flat namespace) or as a package (commands.watch.store).
+_store = _load("store")
+if _store is None:
+    # Should never happen — store.py ships in the same directory as this
+    # module. If it does, the command degrades to "no-op with clear error"
+    # rather than crashing module load.
+    log.error("watch: store.py could not be imported; @watch will be a no-op")
+
+# Duration grammar: <integer><unit> where unit is s/m/h/d/w.
+_DURATION_RE = re.compile(r"^(\d{1,7})([smhdw])$")
+_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 7 * 86400}
+
+# Keyword sanity check. Allow alnum + a handful of OSINT-friendly punctuation
+# (cve identifiers, hashes-as-strings, hyphenated names). Rejects whitespace,
+# wildcards, and shell metacharacters so the store can never carry a regex
+# special by accident — match is plain `in` substring, but defensive shape
+# keeps the JSON file inspectable.
+_KEYWORD_RE = re.compile(r"^[A-Za-z0-9._\-:/+@]+$")
+
+
+def _parse_duration(token):
+    """Return (seconds, error_message). seconds=None means 'never'."""
+    if token is None:
+        return None, None
+    token = token.strip().lower()
+    if token in ("never", "permanent", "infinite", "0"):
+        return None, None
+    m = _DURATION_RE.match(token)
+    if not m:
+        return False, (
+            f"`{token}` is not a duration. Use `<number><unit>` where unit is "
+            "`s`/`m`/`h`/`d`/`w`, or `never`. Example: `7d`."
+        )
+    value = int(m.group(1))
+    unit = m.group(2)
+    seconds = value * _UNIT_SECONDS[unit]
+    if seconds <= 0:
+        return False, "Duration must be positive."
+    if seconds > settings.MAX_DURATION_SECONDS:
+        max_days = settings.MAX_DURATION_SECONDS // 86400
+        return False, f"Duration too long. Max is {max_days}d."
+    return seconds, None
+
+
+def _format_relative(target_ts, now=None):
+    if target_ts is None:
+        return "never expires"
+    if now is None:
+        now = int(time.time())
+    delta = target_ts - now
+    if delta <= 0:
+        return "expired"
+    if delta < 60:
+        return f"expires in {delta}s"
+    if delta < 3600:
+        return f"expires in {delta // 60}m"
+    if delta < 86400:
+        h = delta // 3600
+        m = (delta % 3600) // 60
+        return f"expires in {h}h {m:02d}m"
+    days = delta // 86400
+    hours = (delta % 86400) // 3600
+    return f"expires in {days}d {hours}h"
+
+
+def _validate_keyword(raw):
+    if len(raw) < settings.MIN_KEYWORD_LEN:
+        return None, (
+            f"Keyword must be at least {settings.MIN_KEYWORD_LEN} characters."
+        )
+    if len(raw) > settings.MAX_KEYWORD_LEN:
+        return None, (
+            f"Keyword must be at most {settings.MAX_KEYWORD_LEN} characters."
+        )
+    if not _KEYWORD_RE.match(raw):
+        return None, (
+            "Keyword may only contain letters, digits, and `._-:/+@`. "
+            "Wildcards and whitespace are not supported."
+        )
+    return raw.lower(), None
+
+
+def _resolve_userid(username, conn):
+    """Map @username (with or without leading @) to a Mattermost userid.
+
+    process() receives username as a string only; the bot does not pass us
+    the userid. We look it up via mmDriver so the store key is the stable
+    opaque id, not the mutable username.
+    """
+    try:
+        clean = username.lstrip("@")
+        return conn.users.get_user_by_username(clean)["id"]
+    except Exception:
+        log.exception("watch: failed to resolve userid for %r", username)
+        return None
+
+
+def _cmd_list(userid):
+    rows = _store.list_for_user(userid)
+    if not rows:
+        return "You have no active watches. Add one with `@watch add <keyword> [duration]`."
+    now = int(time.time())
+    lines = [f"## Your active watches ({len(rows)})"]
+    for kw, exp in rows:
+        lines.append(f"  {kw:<32}  {_format_relative(exp, now)}")
+    return "```\n" + "\n".join(lines) + "\n```"
+
+
+def _cmd_add(userid, params):
+    if not params:
+        return (
+            "Usage: `@watch add <keyword> [duration]`. "
+            "Example: `@watch add ransomware 7d`."
+        )
+    keyword_raw = params[0]
+    keyword, err = _validate_keyword(keyword_raw)
+    if err:
+        return err
+    duration_token = params[1] if len(params) > 1 else settings.DEFAULT_DURATION
+    seconds, err = _parse_duration(duration_token)
+    if err is not None and seconds is False:
+        return err
+    expiry = None if seconds is None else int(time.time()) + seconds
+    ok, reason = _store.add(userid, keyword, expiry, settings.MAX_WATCHES_PER_USER)
+    if not ok:
+        return f"Could not add `{keyword}`: {reason}."
+    when = _format_relative(expiry)
+    verb = "Updated" if reason == "replaced" else "Watching"
+    return f"{verb} `{keyword}` ({when})."
+
+
+def _cmd_del(userid, params):
+    if not params:
+        return "Usage: `@watch del <keyword>`."
+    keyword, err = _validate_keyword(params[0])
+    if err:
+        return err
+    if _store.delete(userid, keyword):
+        return f"Stopped watching `{keyword}`."
+    return f"You were not watching `{keyword}`."
+
+
+def _cmd_clear(userid):
+    count = _store.clear(userid)
+    if not count:
+        return "You had no active watches."
+    return f"Cleared {count} watch(es)."
+
+
+def process(command, channel, username, params, files, conn):
+    if _store is None:
+        return {
+            "messages": [
+                {
+                    "text": "Watch store is not available — module deployment "
+                    "is incomplete (store.py missing)."
+                }
+            ]
+        }
+
+    userid = _resolve_userid(username, conn)
+    if userid is None:
+        return {
+            "messages": [
+                {
+                    "text": "Could not resolve your Mattermost user id. "
+                    "Cannot manage watches. Check bot logs."
+                }
+            ]
+        }
+
+    if not params:
+        reply = _cmd_list(userid)
+    else:
+        sub = params[0].lower()
+        rest = params[1:]
+        if sub == "list":
+            reply = _cmd_list(userid)
+        elif sub == "add":
+            reply = _cmd_add(userid, rest)
+        elif sub in ("del", "delete", "remove", "rm"):
+            reply = _cmd_del(userid, rest)
+        elif sub == "clear":
+            reply = _cmd_clear(userid)
+        else:
+            # Bare `@watch <keyword>` shorthand for `add <keyword>` — convenient
+            # for the common case where the user just wants to add one thing
+            # without remembering the subcommand.
+            reply = _cmd_add(userid, params)
+
+    return {"messages": [{"text": reply}]}
+
+
+# ---------------------------------------------------------------------------
+# Scan hook — called by matterbot.py for every non-self channel post.
+# Runs in the bot's ThreadPoolExecutor (see matterbot.py:_command_executor)
+# so blocking on the Mattermost REST API here is fine; it will not stall
+# the asyncio event loop.
+# ---------------------------------------------------------------------------
+
+
+def _channel_member_ids(conn, chanid):
+    """Page through channel members, returning a set of user ids.
+
+    Mattermost's get_channel_members caps at 200 per page. Channels with
+    more than a few hundred members will pay multiple round trips, which is
+    why this is on the threadpool path.
+    """
+    members = set()
+    page = 0
+    while True:
+        try:
+            chunk = conn.channels.get_channel_members(
+                chanid, params={"page": page, "per_page": 200}
+            )
+        except Exception:
+            log.exception("watch: get_channel_members failed for %s", chanid)
+            return members
+        if not chunk:
+            break
+        for m in chunk:
+            uid = m.get("user_id")
+            if uid:
+                members.add(uid)
+        if len(chunk) < 200:
+            break
+        page += 1
+    return members
+
+
+def _send_alert(conn, myid, watcher_userid, watcher_keyword, post_data):
+    """Open (or fetch) the DM channel with the watcher and post the alert."""
+    try:
+        dm = conn.channels.create_direct_message_channel([myid, watcher_userid])
+    except Exception:
+        log.exception(
+            "watch: could not open DM with %s for alert on %r",
+            watcher_userid,
+            watcher_keyword,
+        )
+        return
+
+    dm_chanid = dm.get("id")
+    if not dm_chanid:
+        return
+
+    snippet = post_data["message"]
+    if len(snippet) > settings.SNIPPET_CHARS:
+        snippet = snippet[: settings.SNIPPET_CHARS] + "…"
+
+    text = (
+        f"🔔 Watch hit: `{watcher_keyword}`\n"
+        f"Channel: ~{post_data['channame']}\n"
+        f"From:    @{post_data['author']}\n\n"
+        f"> {snippet}"
+    )
+
+    try:
+        conn.posts.create_post(options={"channel_id": dm_chanid, "message": text})
+    except Exception:
+        log.exception(
+            "watch: failed to post alert DM for %s on %r",
+            watcher_userid,
+            watcher_keyword,
+        )
+
+
+def scan_message(conn, myid, author_userid, chanid, channame, author_username, message):
+    """Fire-and-forget scanner. Called by matterbot.handle_post.
+
+    Args mirror the welcome.on_join hook style — bare primitives so this can
+    be invoked through run_in_executor without pickling any module state.
+    """
+    if _store is None or not message:
+        return
+    if author_userid == myid:
+        # Bot's own messages are already excluded by handle_post's recursion
+        # guard for most installs, but be defensive — alerting yourself on
+        # your own bot posts is a feedback loop waiting to happen.
+        return
+
+    active = _store.iter_active()
+    if not active:
+        return
+
+    message_lower = message.lower()
+    # Collect distinct watchers whose keyword matched; one alert per watcher
+    # even if they have multiple keywords in the same message.
+    hits: dict[str, str] = {}
+    for watcher_userid, keyword in active:
+        if watcher_userid == author_userid:
+            # Don't alert someone on their own messages.
+            continue
+        if keyword in message_lower and watcher_userid not in hits:
+            hits[watcher_userid] = keyword
+
+    if not hits:
+        return
+
+    # Only alert watchers who can actually see this channel — never leak
+    # private/restricted-channel content to someone not in the channel.
+    members = _channel_member_ids(conn, chanid)
+
+    post_data = {
+        "channame": channame,
+        "author": author_username,
+        "message": message,
+    }
+
+    for watcher_userid, keyword in hits.items():
+        if watcher_userid not in members:
+            continue
+        _send_alert(conn, myid, watcher_userid, keyword, post_data)

--- a/commands/watch/defaults.py
+++ b/commands/watch/defaults.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+BINDS = ["@watch"]
+# Watch is intentionally lenient on CHANS — the actual privacy boundary is
+# the DM that matterbot sends when a keyword fires, not where the user
+# configures their list. Most installs will want to add @watch to the
+# debug channel and to whatever general channel users hang out in.
+CHANS = ["debug"]
+
+# Minimum keyword length. Sub-3-character substrings produce too much noise
+# (every "is", "to", "a") to be useful as alerts.
+MIN_KEYWORD_LEN = 3
+
+# Maximum keyword length. Anything longer is almost certainly a paste of a
+# whole sentence and not a useful watch.
+MAX_KEYWORD_LEN = 64
+
+# Maximum watches per user. Caps the per-message scan cost (we walk every
+# active watch on every message) and bounds the JSON file size.
+MAX_WATCHES_PER_USER = 50
+
+# Default expiry when the user does not pass a duration. `None` = never
+# expires. Set to a duration string like "30d" in settings.py if you want
+# the bot to auto-prune stale watches.
+DEFAULT_DURATION = None
+
+# Maximum allowed expiry duration in seconds (default: 365 days). Prevents
+# accidental year-long watches set with typos like "10000d".
+MAX_DURATION_SECONDS = 365 * 24 * 60 * 60
+
+# Length of the message snippet included in the alert DM. Long enough to
+# give context, short enough that the alert stays scannable.
+SNIPPET_CHARS = 240
+
+HELP = {
+    "DEFAULT": {
+        "args": "[list|add|del|clear] ...",
+        "desc": "Watch channel messages for keywords and get DM'd when they "
+        "match. Like Mattermost's built-in keyword notifications, but "
+        "with per-keyword expiry. Without args, lists your active watches.",
+    },
+    "add": {
+        "args": "<keyword> [duration]",
+        "desc": "Add a keyword to watch. Optional duration like `7d`, `24h`, "
+        "`30m`. No duration = never expires. "
+        "Example: `@watch add ransomware 7d`",
+    },
+    "del": {
+        "args": "<keyword>",
+        "desc": "Stop watching a keyword. "
+        "Example: `@watch del ransomware`",
+    },
+    "list": {
+        "args": None,
+        "desc": "List your active watches and their expiry times.",
+    },
+    "clear": {
+        "args": None,
+        "desc": "Remove all of your active watches.",
+    },
+}

--- a/commands/watch/store.py
+++ b/commands/watch/store.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Persistent per-user keyword watch store.
+
+Loaded both by `commands/watch/command.py` (user-facing CLI) and by the
+matterbot.py scan hook (notification path). All mutations go through a
+single threading.RLock because mattermost dispatches command modules in a
+ThreadPoolExecutor while the scan hook also runs in the same executor —
+two threads can race on the same shelf otherwise.
+
+Storage shape (JSON-on-disk):
+
+  {
+    "<mattermost_userid>": {
+      "<keyword_lower>": <expiry_unix_ts_int> | null,
+      ...
+    },
+    ...
+  }
+"""
+
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+log = logging.getLogger("MatterBot")
+
+_STATE_FILE = Path(__file__).parent / "watchlist.json"
+_LOCK = threading.RLock()
+_DATA: dict | None = None
+
+
+def _load() -> dict:
+    global _DATA
+    if _DATA is not None:
+        return _DATA
+    if not _STATE_FILE.is_file():
+        _DATA = {}
+        return _DATA
+    try:
+        with _STATE_FILE.open("r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except (OSError, ValueError):
+        log.exception("watch: could not load %s; starting with empty store", _STATE_FILE)
+        _DATA = {}
+        return _DATA
+    if not isinstance(raw, dict):
+        log.warning("watch: %s root is not an object; resetting", _STATE_FILE)
+        _DATA = {}
+        return _DATA
+    # Lightly validate the schema so a hand-edited file with garbage doesn't
+    # break the whole store. Unknown shapes are dropped, not crashed on.
+    cleaned: dict = {}
+    for userid, watches in raw.items():
+        if not isinstance(userid, str) or not isinstance(watches, dict):
+            continue
+        kept: dict = {}
+        for kw, expiry in watches.items():
+            if not isinstance(kw, str):
+                continue
+            if expiry is not None and not isinstance(expiry, int):
+                continue
+            kept[kw] = expiry
+        if kept:
+            cleaned[userid] = kept
+    _DATA = cleaned
+    return _DATA
+
+
+def _persist_locked() -> None:
+    """Caller must hold _LOCK."""
+    data = _load()
+    # Atomic write so a crash mid-flush doesn't leave a half-written file.
+    fd, tmp_path = tempfile.mkstemp(
+        prefix="watchlist-", suffix=".json", dir=str(_STATE_FILE.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, sort_keys=True)
+        os.replace(tmp_path, _STATE_FILE)
+    except Exception:
+        log.exception("watch: failed to persist watchlist")
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _sweep_user_locked(userid: str, now: int) -> None:
+    """Caller must hold _LOCK. Drops expired watches for one user."""
+    data = _load()
+    watches = data.get(userid)
+    if not watches:
+        return
+    expired = [kw for kw, exp in watches.items() if exp is not None and exp <= now]
+    for kw in expired:
+        del watches[kw]
+    if not watches:
+        del data[userid]
+
+
+def list_for_user(userid: str) -> list[tuple[str, int | None]]:
+    """Return [(keyword, expiry_ts_or_None), ...] sorted by keyword."""
+    now = int(time.time())
+    with _LOCK:
+        _sweep_user_locked(userid, now)
+        watches = _load().get(userid, {})
+        return sorted(watches.items())
+
+
+def add(userid: str, keyword: str, expiry_ts: int | None, max_per_user: int) -> tuple[bool, str]:
+    """Return (success, reason). Caller has already validated keyword shape."""
+    keyword = keyword.lower()
+    now = int(time.time())
+    with _LOCK:
+        data = _load()
+        _sweep_user_locked(userid, now)
+        watches = data.setdefault(userid, {})
+        is_replace = keyword in watches
+        if not is_replace and len(watches) >= max_per_user:
+            return False, f"limit of {max_per_user} watches per user reached"
+        watches[keyword] = expiry_ts
+        try:
+            _persist_locked()
+        except Exception as e:
+            # Roll back the in-memory mutation so reload doesn't silently
+            # show a watch that didn't actually persist.
+            if is_replace:
+                # We don't have the prior value handy; this is rare enough
+                # that "user re-adds" is an acceptable degradation.
+                pass
+            else:
+                del watches[keyword]
+            return False, f"persistence failed: {e}"
+    return True, "replaced" if is_replace else "added"
+
+
+def delete(userid: str, keyword: str) -> bool:
+    keyword = keyword.lower()
+    with _LOCK:
+        data = _load()
+        watches = data.get(userid)
+        if not watches or keyword not in watches:
+            return False
+        del watches[keyword]
+        if not watches:
+            del data[userid]
+        try:
+            _persist_locked()
+        except Exception:
+            return False
+    return True
+
+
+def clear(userid: str) -> int:
+    with _LOCK:
+        data = _load()
+        watches = data.pop(userid, None)
+        count = len(watches) if watches else 0
+        if count:
+            try:
+                _persist_locked()
+            except Exception:
+                # Best-effort: in-memory state is now divergent from disk, but
+                # the next successful mutation will reconverge.
+                pass
+    return count
+
+
+def iter_active() -> list[tuple[str, str]]:
+    """Return a flat list of (userid, keyword) for all non-expired watches.
+
+    Snapshot copy — safe to iterate without holding the lock.
+    """
+    now = int(time.time())
+    out: list[tuple[str, str]] = []
+    with _LOCK:
+        data = _load()
+        for userid, watches in list(data.items()):
+            for kw, exp in list(watches.items()):
+                if exp is None or exp > now:
+                    out.append((userid, kw))
+    return out

--- a/matterbot.py
+++ b/matterbot.py
@@ -831,6 +831,24 @@ class MattermostManager(object):
         # We're probably handling a regular message; make sure to check we're allowed to respond our own messages too (see config file)
         # Additionally, check if we're not self-triggering on the display of the bind map
         if options.Matterbot['recursion'] or userid != self.my_id:
+            # Watch-module hook: scan the post against active keyword watches
+            # and DM matched watchers. Fire-and-forget on the command pool so
+            # we don't stall the event loop or command dispatch below.
+            # ImportError = watch module not in this deployment; silently skip.
+            try:
+                from watch.command import scan_message as _watch_scan
+                loop = asyncio.get_running_loop()
+                loop.run_in_executor(
+                    self._command_executor,
+                    _watch_scan,
+                    self.mmDriver, self.my_id,
+                    userid, chanid, channame, username,
+                    post.get('message') or '',
+                )
+            except ImportError:
+                pass
+            except Exception:
+                log.exception("watch.scan_message hook failed")
             messages = list()
             for mline in messagelines:
                 addparams = False


### PR DESCRIPTION
## Summary

Native bot feature analogous to Mattermost's built-in keyword notifications, but with per-keyword expiry and per-user limits — closes the gap the upstream feature leaves: stale keywords never get cleaned up, no way to set a "watch this for 7d" temporary alert, no per-user cap.

Three pieces:

1. **`commands/watch/store.py`** — JSON-on-disk store at `commands/watch/watchlist.json`.
   - `threading.RLock` around mutations (command-pool and scan-hook race on the same shelf).
   - Atomic `tempfile + os.replace` persist so a crash mid-flush doesn't truncate.
   - Lazy expiry sweep on every read/write — the store self-cleans, no separate cron needed.
   - Schema validated on load; garbage entries are dropped, not crashed on.

2. **`commands/watch/command.py`** — `@watch` user-facing CLI.
   - Subcommands: `list` (default), `add <keyword> [duration]`, `del <keyword>`, `clear`.
   - Bare `@watch <keyword>` is shorthand for `add` (common case).
   - Duration grammar: `<int><unit>` where unit is `s`/`m`/`h`/`d`/`w` (e.g. `7d`, `24h`), or `never` / no arg.
   - Strict keyword regex (alnum + `._-:/+@`) — keeps the JSON inspectable, rejects wildcards.
   - Per-user limit (`MAX_WATCHES_PER_USER=50`), keyword length bounds (`MIN_KEYWORD_LEN=3`, `MAX_KEYWORD_LEN=64`), max duration (1 year).
   - Also exports `scan_message()` — the public hook the bot calls per post.

3. **`matterbot.py`** — fire-and-forget scan hook inside `handle_post`.
   - Same shape as the existing welcome hook: lazy import (ImportError = module not deployed, silently skip), `run_in_executor` so the asyncio loop never blocks on Mattermost REST API calls.
   - Inserted right after the recursion guard, before bind tokenization — fires on every non-self message.

### Privacy

- Alerts only fire for watchers who are members of the channel where the keyword matched (`get_channel_members` lookup). Never leaks private-channel content to outsiders.
- Author of the matched message is excluded from notifications (no self-alerts).
- Bot self-messages are always skipped regardless of the global `recursion` setting.

### Known limitations / future work

- Typing `@watch add ransomware` will itself match watchers for `ransomware`. Could filter out messages that start with `@watch` if this proves annoying.
- Channel membership is fetched fresh per matched message — could be cached with a short TTL if alerting scales up.
- Match is case-insensitive substring; no word-boundary mode yet.

Closes #141

## Test plan

- [ ] Restart bot, `@watch` in the debug channel → "no active watches" reply.
- [ ] `@watch add ransomware 7d` → "Watching `ransomware` (expires in 6d 23h ...)".
- [ ] `@watch list` → shows the added watch with relative expiry.
- [ ] Have a second user type "look at this ransomware sample" in a channel both are in → first user gets a DM alert.
- [ ] Same scenario but second user types it in a channel the first user is NOT in → no DM (privacy guarantee).
- [ ] `@watch del ransomware` → "Stopped watching `ransomware`".
- [ ] `@watch add x` → rejected (too short).
- [ ] `@watch add foo 99999d` → rejected (duration too long).
- [ ] `@watch add bar wildcard*` → rejected (illegal chars).
- [ ] Add 51 watches → 51st rejected with "limit reached".
- [ ] Restart bot mid-session → watches survive (persisted JSON).
- [ ] Delete `commands/watch/watchlist.json` while bot is running → next mutation recreates it.