### PR TITLE
ghunt: drop from requirements.txt — pillow==9.3.0 pin breaks Python 3.12+

### DIFF
--- a/commands/ghunt/command.py
+++ b/commands/ghunt/command.py
@@ -133,13 +133,16 @@ def process(command, channel, username, params, files, conn):
     ghunt_path = shutil.which("ghunt")
     if not ghunt_path:
         log.warning(
-            "ghunt module: ghunt binary not on PATH; install with `pip install ghunt`"
+            "ghunt module: ghunt binary not on PATH; install with `pip install ghunt` "
+            "(Python <=3.11 only — ghunt pins pillow==9.3.0 which does not build on 3.12+)"
         )
         return {
             "messages": [
                 {
                     "text": "Ghunt is not installed on this host. Run "
-                    "`pip install ghunt`, then `ghunt login`, then restart the bot."
+                    "`pip install ghunt` (requires Python ≤3.11 — ghunt pins "
+                    "`pillow==9.3.0`, which does not build on 3.12+), then "
+                    "`ghunt login`, then restart the bot."
                 }
             ]
         }

--- a/commands/ghunt/defaults.py
+++ b/commands/ghunt/defaults.py
@@ -3,11 +3,22 @@
 BINDS = ["@ghunt"]
 CHANS = ["debug"]
 
-# Ghunt requires an authenticated Google session to call the internal
-# endpoints it scrapes. The bot host operator must run `ghunt login` once
-# (interactive) and have the resulting `creds.m` cookie file persisted on
-# disk before this command will return anything useful. See
-# https://github.com/mxrch/GHunt for the auth bootstrap flow.
+# Ghunt is intentionally NOT in the top-level requirements.txt. Reasons:
+#   1. It pins `pillow==9.3.0`, which fails to build on Python 3.12+
+#      (Pillow 9.x predates the newer setuptools metadata format and
+#      raises `KeyError: '__version__'` during get_requires_for_build_wheel).
+#      Forcing every operator's `pip install -r` to hit this is hostile;
+#      operators on Python <=3.11 can still install ghunt themselves.
+#   2. Ghunt needs an authenticated Google session to do anything useful —
+#      the operator MUST run `ghunt login` (interactive) and persist the
+#      resulting `creds.m` cookie file before this command returns
+#      anything. There is no "just install and go" path.
+#
+# Operator install (Python <=3.11):
+#     pip install ghunt
+#     ghunt login          # interactive cookie/OAuth bootstrap
+#
+# See https://github.com/mxrch/GHunt for the upstream README.
 #
 # Ghunt subcommand to invoke. Currently only `email` is wired; switching this
 # to `gaia` or another subcommand would also need a different positional-arg

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ chardet
 ConfigArgParse
 dfir-unfurl[all]
 feedparser
-ghunt
 graphviz
 holehe
 lxml


### PR DESCRIPTION
## Summary

`pip install -r requirements.txt` fails on Python 3.12+ because `ghunt` transitively pins `pillow==9.3.0`, and Pillow 9.x doesn't build on newer Python:

```
File "<string>", line 26, in get_version
KeyError: '__version__'
```

This is the well-known Pillow 9 / newer-setuptools metadata-format incompatibility — Pillow 9 predates the `__version__` attribute being required during `get_requires_for_build_wheel`.

### Why drop rather than work around

1. The bot has no other Python-version constraint. Pinning the interpreter for one optional OSINT module is the tail wagging the dog.
2. ghunt is useless without an interactive `ghunt login` step anyway, so a plain `pip install -r` was never going to produce a working `@ghunt` command without operator action.
3. The `@ghunt` command already has a `shutil.which("ghunt")` early-out that returns a friendly install hint when the binary is missing — removing ghunt from `requirements.txt` is a no-op for installations that don't need it.

### Changes

- `requirements.txt` — remove `ghunt` line.
- `commands/ghunt/defaults.py` — document the constraint and the operator install path (`pip install ghunt` then `ghunt login`, Python ≤3.11).
- `commands/ghunt/command.py` — extend the "not installed" runtime message so the Python-version constraint is visible the first time a user tries `@ghunt` on a host that hasn't installed it.

## Test plan

- [ ] On Python 3.12 / 3.13: `pip install -r requirements.txt` now succeeds.
- [ ] On Python ≤3.11 with `pip install ghunt && ghunt login`: `@ghunt target@gmail.com` still works.
- [ ] On any Python with no ghunt installed: `@ghunt foo@bar.com` returns the install hint message (now including the Python ≤3.11 / pillow note).