### PR TITLE
ci: fix F821-delta workflow — `git fetch --depth=0` is invalid

### DIFF
--- a/.github/workflows/f821-delta.yml
+++ b/.github/workflows/f821-delta.yml
@@ -61,7 +61,11 @@ jobs:
           set -euo pipefail
           # Use the merge-base of the PR head against the base branch tip.
           # This survives both linear PRs and PRs whose base has advanced.
-          git fetch --no-tags --depth=0 origin "$BASE_REF"
+          # `--depth=0` is invalid (git: "depth 0 is not a positive number")
+          # and was killing this step on every PR. The checkout step above
+          # already sets fetch-depth: 0, so we just need to update the
+          # remote ref for $BASE_REF without imposing a new shallow limit.
+          git fetch --no-tags origin "$BASE_REF"
           MERGE_BASE="$(git merge-base "$BASE_SHA" HEAD)"
           echo "Merge base: $MERGE_BASE"
           # `--diff-filter=AM` => only Added or Modified files. Deleted /


### PR DESCRIPTION
## Summary

The PR-time F821 check has been failing on every PR since it landed (PR #182). Looking at the failed logs (e.g. [run for #193](https://github.com/uforia/MatterBot/actions/runs/25857428132/job/75978640410)):

```
fatal: depth 0 is not a positive number
##[error]Process completed with exit code 128.
```

`git fetch --depth=0` is not a valid invocation — depth must be a positive integer. The intent was "no shallow limit", which is either `--unshallow` or simply omitting `--depth`.

The `actions/checkout@v4` step above already sets `fetch-depth: 0` (the action's idiom for "full history"), so the runner already has the full graph; this `git fetch` only needs to update `refs/remotes/origin/<base>` so the subsequent `git merge-base` resolves. Dropping the broken flag preserves intent with working syntax.

## Test plan

- [ ] Once merged, re-run the F821-delta check on any open PR; expect a successful "no F821 in changed files" outcome (or a real F821 finding, if there is one).
- [ ] Confirm PRs #193 and #194 turn green after rebase / push.