### PR TITLE
phishstats: add @phishstats command for phishing-report lookup

### DIFF
--- a/commands/phishstats/command.py
+++ b/commands/phishstats/command.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+
+import logging
+import re
+
+import requests
+
+log = logging.getLogger("MatterBot")
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+
+_pkg = __package__ or Path(__file__).parent.name
+
+
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+
+
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+# Strict RFC-1123 hostname check — rejects wildcards, paths, IP addresses,
+# and shell metacharacters so the operator-supplied string is safe to
+# interpolate into the PhishStats `_where` filter expression.
+_DOMAIN_RE = re.compile(
+    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
+    r"(?:\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+)
+
+
+def _format_hits(domain, hits):
+    if not hits:
+        return f"No PhishStats reports for `{domain}`."
+
+    lines = [f"**PhishStats reports for `{domain}` ({len(hits)} most recent):**"]
+    for h in hits:
+        date = h.get("date") or h.get("date_added") or "?"
+        url = h.get("url") or "?"
+        score = h.get("score")
+        title = (h.get("title") or "").strip()
+        country = h.get("countrycode") or h.get("country_code") or ""
+
+        # Defang URL display so the channel renderer doesn't auto-link or
+        # preview a known phishing destination — replace the scheme.
+        if isinstance(url, str) and url.startswith(("http://", "https://")):
+            url = url.replace("http", "hxxp", 1)
+
+        parts = [f"`{date}`", f"`{url}`"]
+        if score is not None:
+            parts.append(f"score=`{score}`")
+        if country:
+            parts.append(f"cc=`{country}`")
+        if title:
+            # Trim ultra-long titles — phishing pages occasionally spam
+            # thousands of zero-width chars into <title>.
+            t = title[:160] + "…" if len(title) > 160 else title
+            parts.append(f"title=`{t}`")
+        lines.append("- " + " | ".join(parts))
+
+    return "\n".join(lines)
+
+
+def process(command, channel, username, params, files, conn):
+    if not params:
+        return {
+            "messages": [
+                {
+                    "text": "Usage: `@phishstats <domain>` — searches PhishStats "
+                    "for recent phishing reports matching the domain or "
+                    "hostname substring."
+                }
+            ]
+        }
+
+    raw = params[0].strip().lower().strip(".")
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    domain = raw.split("/", 1)[0]
+
+    if not _DOMAIN_RE.match(domain):
+        return {
+            "messages": [
+                {
+                    "text": f"`{params[0]}` does not look like a valid domain. "
+                    "Pass a bare hostname like `example.com`."
+                }
+            ]
+        }
+
+    # PhishStats `_where` uses a SQL-like grammar; `*` is the wildcard.
+    # We've already pinned `domain` to a strict RFC-1123 shape (no quotes,
+    # no parens, no commas), so embedding it directly in the LIKE clause
+    # is safe — requests will URL-encode the final querystring.
+    params_qs = {
+        "_where": f"(host,like,*{domain}*)",
+        "_sort": "-date",
+        "_size": settings.MAX_RESULTS,
+    }
+
+    try:
+        response = requests.get(
+            settings.APIURL,
+            params=params_qs,
+            headers={"User-Agent": settings.USER_AGENT},
+            timeout=(10, settings.TIMEOUT),
+            allow_redirects=False,
+        )
+    except requests.exceptions.Timeout:
+        log.warning("phishstats: timeout after %ss", settings.TIMEOUT)
+        return {
+            "messages": [
+                {
+                    "text": f"PhishStats request timed out after {settings.TIMEOUT}s. "
+                    "Try again later."
+                }
+            ]
+        }
+    except requests.exceptions.RequestException:
+        log.exception("phishstats: request failed")
+        return {
+            "messages": [
+                {"text": "PhishStats request failed. Check bot logs for details."}
+            ]
+        }
+
+    if response.status_code != 200:
+        log.warning(
+            "phishstats: HTTP %s for %s", response.status_code, domain
+        )
+        return {
+            "messages": [
+                {
+                    "text": f"PhishStats returned HTTP {response.status_code} "
+                    f"for `{domain}`."
+                }
+            ]
+        }
+
+    try:
+        hits = response.json()
+    except ValueError:
+        log.exception("phishstats: non-JSON response")
+        return {
+            "messages": [
+                {"text": "PhishStats returned a malformed response body."}
+            ]
+        }
+
+    if not isinstance(hits, list):
+        log.warning("phishstats: unexpected JSON shape (not a list)")
+        return {
+            "messages": [
+                {"text": "PhishStats returned an unexpected JSON shape."}
+            ]
+        }
+
+    body = _format_hits(domain, hits)
+
+    truncated = False
+    if len(body) > settings.MAX_OUTPUT_CHARS:
+        body = body[: settings.MAX_OUTPUT_CHARS]
+        truncated = True
+    if truncated:
+        body += (
+            f"\n_Output truncated at {settings.MAX_OUTPUT_CHARS} characters; "
+            "see phishstats.info for the full result._"
+        )
+
+    return {"messages": [{"text": body}]}

--- a/commands/phishstats/defaults.py
+++ b/commands/phishstats/defaults.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+BINDS = ["@phishstats", "@ps"]
+CHANS = ["debug"]
+
+# PhishStats public API. No authentication required.
+# Reference: https://phishstats.info/#apidoc
+APIURL = "https://phishstats.info:2096/api/phishing"
+
+# Soft cap on results returned by the API (PhishStats default is 200; cap
+# to the most recent N so we don't render a 10-page wall of URLs).
+MAX_RESULTS = 20
+
+# Request timeout in seconds.
+TIMEOUT = 30
+
+# Soft cap on the rendered message body. Mattermost rejects very large
+# messages; anything above this is truncated with a footer note.
+MAX_OUTPUT_CHARS = 6000
+
+# User-Agent — PhishStats does not require one but identifying ourselves
+# makes the operator reachable to PhishStats abuse handlers if a deploy
+# generates anomalous query volume.
+USER_AGENT = "MatterBot-phishstats/1.0 (+https://github.com/uforia/MatterBot)"
+
+HELP = {
+    "DEFAULT": {
+        "args": "<domain|host>",
+        "desc": "Query PhishStats (https://phishstats.info) for recent phishing "
+        "reports matching a domain or hostname substring. Returns date, URL, "
+        "score, and page title for each hit. No API key required. "
+        "Example: `@phishstats example.com`",
+    },
+}


### PR DESCRIPTION
## Summary

Adds the `@phishstats` (alias `@ps`) command. Queries the public [PhishStats](https://phishstats.info/) API for recent phishing reports matching a domain or hostname substring; returns date, URL, score, title, and country for each hit.

**No authentication required** — PhishStats publishes a free public REST endpoint.

### Hardening

- Strict RFC-1123 domain regex before the value is interpolated into the PhishStats `_where` filter clause. The PhishStats grammar accepts `*` wildcards; the validator forbids them in operator input so a `_where=(host,like,*evil*)` query can't be turned into anything operator-supplied beyond the substring match itself.
- `allow_redirects=False`; identifying `User-Agent` so PhishStats abuse handlers can reach the operator on anomalous traffic.
- URLs in output are defanged (`http` → `hxxp`) so the channel renderer doesn't auto-link or preview known-bad destinations.
- Long page titles capped at 160 chars (phishing pages occasionally spam zero-width Unicode into `<title>` to break feed renderers).

Result count capped via `_size` to `MAX_RESULTS` (default 20); rendered body capped at `MAX_OUTPUT_CHARS` with truncation footer.

Closes #82

## Test plan

- [ ] `@phishstats example.com` → returns recent phishing reports (or "no reports" if none).
- [ ] `@phishstats not-a-domain` → validation error.
- [ ] `@phishstats foo*bar` → validation error (wildcard rejected).
- [ ] `@phishstats https://example.com/path` → bare host extracted, query succeeds.
- [ ] Confirm URLs in the output render as defanged `hxxp[s]://...`, not clickable links.