### PR TITLE
honeydb: add @honeydb command for HoneyDB IP threat lookups

### DIFF
--- a/commands/honeydb/command.py
+++ b/commands/honeydb/command.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+import ipaddress
+import re
+import requests
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+import logging
+
+log = logging.getLogger('MatterBot')
+_pkg = __package__ or Path(__file__).parent.name
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+# IP-only validator — HoneyDB endpoints accept IPv4/IPv6 addresses, no CIDR.
+def _normalize_ip(raw):
+    if not raw:
+        return None
+    q = raw.strip().lower()
+    q = q.replace('[.]', '.').replace('(.)', '.').replace('[:]', ':')
+    q = re.sub(r'^(?:https?|hxxps?)://', '', q)
+    q = q.split('/', 1)[0]
+    try:
+        return str(ipaddress.ip_address(q))
+    except ValueError:
+        return None
+
+
+def _cell(value):
+    """Escape pipe and backtick so the markdown table stays well-formed."""
+    return str(value).replace('`', '').replace('|', '/')
+
+
+def _format_threat_info(ip, data):
+    """Render the /threat-info/{ip} response.
+
+    HoneyDB returns either a JSON object or a single-element list of objects
+    depending on the deployment — handle both.
+    """
+    if isinstance(data, list):
+        if not data:
+            return None
+        data = data[0]
+    if not isinstance(data, dict):
+        return None
+
+    count = data.get('count', '?')
+    last_seen = data.get('last_seen', '?')
+    ports = data.get('ports') or []
+    services = data.get('services') or []
+
+    lines = [f"HoneyDB threat-info for `{ip}`:"]
+    lines.append('| Field | Value |')
+    lines.append('| :- | :- |')
+    lines.append(f"| **Hits** | `{_cell(count)}` |")
+    lines.append(f"| **Last seen** | `{_cell(last_seen)}` |")
+    if ports:
+        ports_str = ', '.join(str(p) for p in ports[:50])
+        if len(ports) > 50:
+            ports_str += f", …(+{len(ports) - 50})"
+        lines.append(f"| **Ports** | `{_cell(ports_str)}` |")
+    if services:
+        svc_str = ', '.join(str(s) for s in services[:50])
+        if len(services) > 50:
+            svc_str += f", …(+{len(services) - 50})"
+        lines.append(f"| **Services** | `{_cell(svc_str)}` |")
+    lines.append(f"| Reference | [HoneyDB IP report](https://honeydb.io/explore/{ip}) |")
+    return '\n'.join(lines)
+
+
+def _format_history(ip, data, max_rows):
+    """Render the /ip-history/{ip} response (list of per-day records)."""
+    if not isinstance(data, list) or not data:
+        return None
+    total = len(data)
+    truncated = total > max_rows
+    rows = data[:max_rows]
+
+    lines = [f"HoneyDB IP history for `{ip}` — showing {len(rows)} of {total} record{'s' if total != 1 else ''}:"]
+    lines.append('| Date | Count | Ports | Services |')
+    lines.append('| :- | :- | :- | :- |')
+    for rec in rows:
+        if not isinstance(rec, dict):
+            continue
+        date = _cell(rec.get('date', '?'))
+        count = _cell(rec.get('count', '?'))
+        ports = rec.get('ports') or []
+        services = rec.get('services') or []
+        ports_str = ', '.join(str(p) for p in ports[:20]) or '—'
+        svc_str = ', '.join(str(s) for s in services[:20]) or '—'
+        lines.append(f"| `{date}` | `{count}` | `{_cell(ports_str)}` | `{_cell(svc_str)}` |")
+    if truncated:
+        lines.append(f"_…truncated; {total - max_rows} earlier day(s) not shown._")
+    lines.append(f"Reference: [HoneyDB IP report](https://honeydb.io/explore/{ip})")
+    return '\n'.join(lines)
+
+
+def process(command, channel, username, params, files, conn):
+    messages = []
+    if not params:
+        return {'messages': messages}
+
+    # Subcommand parsing: `<ip>` or `history <ip>` or `<ip> history`.
+    args = [p for p in params if p]
+    mode = 'threat-info'
+    if args and args[0].lower() in ('history', 'hist', 'iphistory'):
+        mode = 'history'
+        args = args[1:]
+    elif len(args) >= 2 and args[1].lower() in ('history', 'hist'):
+        mode = 'history'
+        args = [args[0]]
+
+    if not args:
+        return {'messages': messages}
+
+    ip = _normalize_ip(args[0])
+    if not ip:
+        # Silent no-op on shape mismatch — convention shared with the rest of
+        # the TI modules so `@ioc <hash>` doesn't spam rejections.
+        return {'messages': messages}
+
+    cfg = getattr(settings, 'APIURL', {}).get('honeydb', {})
+    api_id = cfg.get('id') or ''
+    api_key = cfg.get('key') or ''
+    base = (cfg.get('url') or '').rstrip('/') + '/'
+    max_history = int(getattr(settings, 'MAX_HISTORY_ROWS', 30))
+    max_chars = int(getattr(settings, 'MAX_OUTPUT_CHARS', 8000))
+
+    if not api_id or not api_key or api_id.startswith('<') or api_key.startswith('<'):
+        return {'messages': [{'text': 'HoneyDB is not configured. Set `id` and `key` in `settings.py` (free at https://honeydb.io/).'}]}
+
+    endpoint = 'ip-history' if mode == 'history' else 'threat-info'
+    url = base + endpoint + '/' + requests.utils.quote(ip, safe='')
+
+    headers = {
+        'X-HoneyDb-ApiId': api_id,
+        'X-HoneyDb-ApiKey': api_key,
+        'Accept': settings.CONTENTTYPE,
+        'User-Agent': 'MatterBot HoneyDB module',
+    }
+
+    try:
+        resp = requests.get(
+            url,
+            headers=headers,
+            allow_redirects=False,
+            timeout=(10, 30),
+        )
+    except requests.RequestException as e:
+        log.exception("honeydb request failed")
+        return {'messages': [{'text': f"HoneyDB request failed: `{e}`"}]}
+
+    if resp.status_code == 401:
+        return {'messages': [{'text': 'HoneyDB: authentication failed — check `id`/`key`.'}]}
+    if resp.status_code == 403:
+        return {'messages': [{'text': 'HoneyDB: forbidden (rate-limited, or account not authorised for this query?).'}]}
+    if resp.status_code == 404:
+        return {'messages': [{'text': f"HoneyDB: no `{mode}` records for `{ip}`."}]}
+    if resp.status_code != 200:
+        return {'messages': [{'text': f"HoneyDB returned HTTP {resp.status_code} for `{mode}`."}]}
+
+    try:
+        data = resp.json()
+    except ValueError:
+        log.exception("honeydb response was not valid JSON")
+        return {'messages': [{'text': 'HoneyDB returned a non-JSON response.'}]}
+
+    if mode == 'history':
+        text = _format_history(ip, data, max_history)
+    else:
+        text = _format_threat_info(ip, data)
+
+    if not text:
+        return {'messages': [{'text': f"HoneyDB: no `{mode}` records for `{ip}`."}]}
+
+    if len(text) > max_chars:
+        text = text[:max_chars - 32].rsplit('\n', 1)[0] + '\n_…output truncated._'
+
+    messages.append({'text': text})
+    return {'messages': messages}

--- a/commands/honeydb/defaults.py
+++ b/commands/honeydb/defaults.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+BINDS = ['@honeydb', '@hdb', '@ioc']
+CHANS = ['debug']
+APIURL = {
+    'honeydb': {
+        # API root — endpoints used: /threat-info/<ip> and /ip-history/<ip>.
+        'url': 'https://honeydb.io/api/',
+        # Free registration required (https://honeydb.io/) — both fields needed.
+        'id':  '<your-honeydb-api-id-here>',
+        'key': '<your-honeydb-api-key-here>',
+    },
+}
+CONTENTTYPE = 'application/json'
+MAX_HISTORY_ROWS = 30
+MAX_OUTPUT_CHARS = 8000
+HELP = {
+    'DEFAULT': {
+        'args': '<IPv4|IPv6> [history]',
+        'desc': 'Query HoneyDB for honeypot activity on an IP address. Default returns aggregated threat info (last seen, hit count, ports, services). Add `history` for the per-day history endpoint. Requires a free HoneyDB account (https://honeydb.io/).',
+    },
+}


### PR DESCRIPTION
## Summary

Adds the `@honeydb` (alias `@hdb`) command. Queries [HoneyDB](https://honeydb.io/) for honeypot activity on an IPv4/IPv6 address — returns aggregate hit count, last-seen date, observed ports, and observed services. Two subcommands:

- `@honeydb <ip>` — `/threat-info/<ip>` rendered as a key/value table (default).
- `@honeydb history <ip>` — `/ip-history/<ip>` rendered as a per-day table capped at `MAX_HISTORY_ROWS` (30).

Free HoneyDB registration required. Two custom auth headers (`X-HoneyDb-ApiId` + `X-HoneyDb-ApiKey`) are configured via `APIURL['honeydb']['id'/'key']` in `settings.py`.

Bindings include `@ioc` so the generic IoC dispatch fans out a honeypot lookup for IP queries.

Closes #81.

## Hardening

- **IP-only validator** via `ipaddress.ip_address()` (HoneyDB doesn't accept CIDR). A trailing `/path` or `/CIDR` is stripped so cut-and-paste from URLs / CIDR notation still resolves to the base IP — the operator sees what was actually queried in the response header.
- **Defang restore** for `[.]`, `(.)`, `[:]`, `hxxp(s)://` before validation.
- **Both response shapes handled** — HoneyDB occasionally returns a single dict or a single-element list depending on endpoint/version; the formatter accepts both.
- **`_cell()` markdown-table escape** — strips backticks, replaces pipes, so a long ports/services list can't break the table.
- **Silent no-op on shape mismatch** — matches the malwarebazaar / urlhaus / threatfox convention so `@ioc <hash>` doesn't echo a rejection from every module that only handles IPs.
- **Distinct error messages** per 401 / 403 / 404 — auth, rate-limit, no-data are unambiguous in-channel.
- **`allow_redirects=False`**, explicit `(10, 30)` timeout.
- **Output cap** at `MAX_OUTPUT_CHARS` (8000), well under Mattermost's 16K ceiling.

## Files

- `commands/honeydb/defaults.py` (new)
- `commands/honeydb/command.py` (new)

## Test plan

- [x] `py_compile` clean on both module files.
- [x] `_normalize_ip()` unit-tested across 10 cases: IPv4, IPv6, defanged (`1[.]2[.]3[.]4`), URL-prefixed (`hxxp://1.2.3.4/path`), CIDR-suffix coercion (`1.2.3.4/24` → `1.2.3.4`), junk strings, empty input.
- [x] `_format_threat_info()` renders both dict shape and single-element-list shape; returns `None` for empty list.
- [x] `_format_history()` renders the per-day table with truncation footer when row count exceeds `MAX_HISTORY_ROWS`.
- [ ] Smoke test in a live bot with a valid HoneyDB account:
  - `@honeydb 1.1.1.1` → threat-info table.
  - `@honeydb history 1.1.1.1` → per-day history table.
  - `@honeydb 8.8.8.8` against an IP with no records → "no records" message.
  - `@honeydb not-an-ip` → silent no-op.
  - `@honeydb 1.1.1.1` with unconfigured credentials → "not configured" message.
- [ ] Verify `@ioc 1.1.1.1` includes honeydb in the fan-out.