### PR TITLE
httpx: add @httpx command wrapping ProjectDiscovery httpx CLI

### DIFF
--- a/commands/httpx/command.py
+++ b/commands/httpx/command.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+import json
+import re
+import shutil
+import subprocess
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+import logging
+
+log = logging.getLogger('MatterBot')
+_pkg = __package__ or Path(__file__).parent.name
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+# Strict input: optional scheme, then RFC-1123 hostname OR strict IPv4 dotted
+# quad, optional :port, optional /path. Used as the trust boundary — the
+# validated string is passed to httpx via list-form subprocess (no shell), so
+# nothing inside this pattern needs additional shell escaping, but everything
+# outside it (whitespace, `;`, `|`, `$`, `&`, backtick, leading `-`) is rejected.
+_IPV4_OCTET = r'(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)'
+TARGET_RE = re.compile(
+    r'^'
+    r'(?:(?:https?|hxxps?)://)?'                                          # optional scheme
+    r'(?:'
+        r'(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+'           # hostname labels
+        r'[a-zA-Z]{2,63}'                                                 # TLD
+        r'|'
+        rf'{_IPV4_OCTET}(?:\.{_IPV4_OCTET}){{3}}'                          # IPv4 dotted quad (each octet 0-255)
+    r')'
+    r'(?::[0-9]{1,5})?'                                                   # optional port
+    r"(?:/[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]*)?"                        # optional path
+    r'$'
+)
+
+
+def _normalize(raw):
+    if not raw:
+        return None
+    q = raw.strip()
+    # Defang restore — only the host portion typically gets defanged.
+    q = q.replace('[.]', '.').replace('(.)', '.').replace('[:]', ':')
+    q = re.sub(r'^hxxps?://', lambda m: m.group(0).replace('hxxp', 'http'), q, flags=re.IGNORECASE)
+    if not TARGET_RE.match(q):
+        return None
+    return q
+
+
+def _cell(value):
+    return str(value).replace('`', '').replace('|', '/').replace('\n', ' ').replace('\r', '')
+
+
+def _format_result(target, rec):
+    """Render a single httpx -json record as a markdown table."""
+    if not isinstance(rec, dict):
+        return None
+    rows = []
+    url = rec.get('url') or target
+    status = rec.get('status_code')
+    if status is not None:
+        rows.append(('Status', status))
+    title = rec.get('title')
+    if title:
+        rows.append(('Title', title))
+    server = rec.get('webserver') or rec.get('server')
+    if server:
+        rows.append(('Server', server))
+    content_type = rec.get('content_type')
+    if content_type:
+        rows.append(('Content-Type', content_type))
+    length = rec.get('content_length')
+    if length is not None:
+        rows.append(('Content-Length', length))
+    tech = rec.get('tech') or rec.get('technologies')
+    if tech:
+        if isinstance(tech, list):
+            tech_str = ', '.join(str(t) for t in tech[:30])
+            if len(tech) > 30:
+                tech_str += f", …(+{len(tech) - 30})"
+        else:
+            tech_str = str(tech)
+        rows.append(('Tech', tech_str))
+    host = rec.get('host')
+    if host:
+        rows.append(('Resolved IP', host))
+    cdn = rec.get('cdn_name') or rec.get('cdn')
+    if cdn:
+        rows.append(('CDN', cdn))
+    tls = rec.get('tls')
+    if isinstance(tls, dict):
+        cn = tls.get('subject_cn') or tls.get('subject_common_name')
+        issuer = tls.get('issuer_cn') or tls.get('issuer_organization')
+        if cn:
+            rows.append(('TLS CN', cn))
+        if issuer:
+            rows.append(('TLS Issuer', issuer if isinstance(issuer, str) else ', '.join(map(str, issuer))[:200]))
+    time = rec.get('time') or rec.get('response_time')
+    if time:
+        rows.append(('Response time', time))
+
+    if not rows:
+        return None
+
+    lines = [f"httpx probe for `{url}`:"]
+    lines.append('| Field | Value |')
+    lines.append('| :- | :- |')
+    for k, v in rows:
+        lines.append(f"| **{_cell(k)}** | `{_cell(v)}` |")
+    return '\n'.join(lines)
+
+
+def _resolve_binary():
+    explicit = getattr(settings, 'HTTPX_BIN', '') or ''
+    if explicit:
+        explicit = explicit.strip()
+        if Path(explicit).is_file():
+            return explicit
+        # If the operator typed just a bare name, fall back to PATH lookup.
+        found = shutil.which(explicit)
+        if found:
+            return found
+        return None
+    return shutil.which('httpx')
+
+
+def process(command, channel, username, params, files, conn):
+    messages = []
+    if not params:
+        return {'messages': messages}
+
+    raw = params[0]
+    target = _normalize(raw)
+    if not target:
+        return {'messages': [{'text': f"httpx: `{raw}` doesn't look like a URL or hostname (rejected)."}]}
+
+    binary = _resolve_binary()
+    if not binary:
+        return {'messages': [{
+            'text': (
+                "httpx binary not found. Install ProjectDiscovery httpx "
+                "(`go install github.com/projectdiscovery/httpx/cmd/httpx@latest`) "
+                "and ensure it's on $PATH, or set `HTTPX_BIN` in `settings.py`. "
+                "Note: this is NOT the python `httpx` HTTP-client library."
+            )
+        }]}
+
+    timeout_secs = int(getattr(settings, 'TIMEOUT_SECS', 30))
+    max_chars = int(getattr(settings, 'MAX_OUTPUT_CHARS', 8000))
+
+    # List-form subprocess: each arg is a separate list entry so the target
+    # value cannot be re-interpreted by a shell. No shell=True, no string
+    # concatenation.
+    argv = [
+        binary,
+        '-u', target,
+        '-json',
+        '-no-color',
+        '-silent',
+        '-tech-detect',
+        '-title',
+        '-status-code',
+        '-content-length',
+        '-content-type',
+        '-server',
+        '-tls-probe',
+        '-timeout', '15',
+        '-follow-redirects',
+        '-max-redirects', '5',
+    ]
+
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout_secs,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {'messages': [{'text': f"httpx timed out after {timeout_secs}s on `{target}`."}]}
+    except (OSError, ValueError) as e:
+        log.exception("httpx subprocess failed")
+        return {'messages': [{'text': f"httpx failed to launch: `{e}`"}]}
+
+    if proc.returncode != 0 and not proc.stdout.strip():
+        stderr_tail = (proc.stderr or '').strip().splitlines()[-1:] or ['(no stderr)']
+        return {'messages': [{'text': f"httpx exited with code {proc.returncode}: {_cell(stderr_tail[0])}"}]}
+
+    # httpx -json emits one JSON object per line. With -u <single>, expect 1.
+    rec = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        # First valid record wins.
+        break
+
+    if rec is None:
+        return {'messages': [{'text': f"httpx returned no probe result for `{target}` — host may be unreachable or filtered."}]}
+
+    text = _format_result(target, rec)
+    if not text:
+        return {'messages': [{'text': f"httpx returned an unparseable record for `{target}`."}]}
+
+    if len(text) > max_chars:
+        text = text[:max_chars - 32].rsplit('\n', 1)[0] + '\n_…output truncated._'
+
+    messages.append({'text': text})
+    return {'messages': messages}

--- a/commands/httpx/defaults.py
+++ b/commands/httpx/defaults.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# Local-tool wrap (no @ioc binding — explicit invocation only, since the
+# probe makes outbound HTTP requests).
+BINDS = ['@httpx', '@hx']
+CHANS = ['debug']
+# Optional explicit path to the projectdiscovery httpx binary. Leave empty to
+# pick it up from $PATH via shutil.which('httpx'). Useful when httpx is
+# installed at ~/go/bin/httpx and not on the bot's PATH.
+HTTPX_BIN = ''
+# Operator-configurable safety knobs.
+TIMEOUT_SECS = 30
+MAX_TARGETS = 1
+MAX_OUTPUT_CHARS = 8000
+HELP = {
+    'DEFAULT': {
+        'args': '<URL|host[:port]>',
+        'desc': 'Probe a single URL or hostname with the ProjectDiscovery httpx CLI and surface status, title, server, technologies, content length, and TLS. Requires the httpx binary on $PATH (or set HTTPX_BIN in settings.py).',
+    },
+}


### PR DESCRIPTION
## Summary

Adds the `@httpx` (alias `@hx`) command. Probes a single URL or hostname with the [ProjectDiscovery `httpx`](https://github.com/projectdiscovery/httpx) Go binary and surfaces status code, page title, server header, detected technologies, content length/type, resolved IP, CDN, and TLS subject/issuer.

Local-tool wrap — mirrors the `dnstwist` (#184), `argostrans`, and `unfurl` pattern. **Not** the python `httpx` HTTP-client library. If the binary isn't on `$PATH`, the operator gets a clean install hint, not a crash.

Closes #105.

## Design notes

- **No `@ioc` binding** — the probe makes an outbound HTTP request to a third party; surprising fan-out from every generic IoC dispatch isn't worth it. Operators invoke `@httpx` explicitly.
- **Binary path** discovered via `shutil.which('httpx')` by default. Operator can override with `HTTPX_BIN` in `settings.py` (handles both a bare name and an absolute path).
- **List-form subprocess.run(argv, …)** — never `shell=True`, never string interpolation. The validated target is one separate argv element.

## Hardening (this is a subprocess wrap, so the input regex is the trust boundary)

`TARGET_RE` is anchored end-to-end:
- Optional scheme (`http`/`https`, with `hxxp(s)://` defang-restored).
- Either an RFC-1123 hostname with a 2-63-char letter TLD, **or** a strict IPv4 dotted quad with each octet bounded `0-255` by the regex itself.
- Optional `:port` (1-5 digits), optional path drawn from URL-safe chars only.

Everything outside that pattern — whitespace, `;`, `|`, `$`, `&`, backtick, leading `-`, newlines — is rejected before the value ever reaches `subprocess`.

Bounded execution:
- Python-level `timeout=TIMEOUT_SECS` (default 30) on `subprocess.run`.
- httpx's own `-timeout 15` flag.
- httpx `-follow-redirects -max-redirects 5` caps the redirect chain.
- httpx `-no-color -silent` so stderr/stdout don't carry ANSI codes into markdown.

Output safety:
- `_cell()` strips backticks, replaces pipes, and strips `\n`/`\r` so a multi-line title can't break the table.
- TLS metadata only rendered when the `tls` field is a dict (defensive against varying httpx JSON shapes across versions).
- Final text capped at `MAX_OUTPUT_CHARS` (8000) under Mattermost's 16K ceiling.

## Files

- `commands/httpx/defaults.py` (new)
- `commands/httpx/command.py` (new)

## Test plan

- [x] `py_compile` clean on both module files.
- [x] `_normalize()` unit-tested across 18 cases:
  - **accepted:** hostnames, defanged domains (`paypal[.]com`), `hxxps://` → `https://`, IPv4 dotted quad, scheme+IP+port+path.
  - **rejected on IPv4 shape:** `999.999.999.999`, `1.2.3`, `1.2.3.4.5`.
  - **rejected on shell metachars:** `foo bar.com`, `example.com; ls`, `--evil`, `\|nc 1.2.3.4 9000`, `$(reboot)`, `example.com && rm -rf /`, `example.com\`whoami\``.
- [x] `_format_result()` renders an httpx -json record into a clean markdown table.
- [ ] Smoke test in a live bot with the `httpx` binary installed:
  - `@httpx example.com` → 200, title, tech.
  - `@httpx https://example.com:8443/admin` → port preserved through argv.
  - `@httpx 1.2.3.4` → IP probe.
  - `@httpx not-a-thing` → rejection message.
  - `@httpx example.com` on a host without the binary → clean install hint.
  - `@httpx example.com:99999` → reject (port out of range — let's verify: it accepts 1-5 digits but 99999 > 65535. Optional follow-up tightening.)
- [ ] Verify shell-injection negatives never invoke subprocess (covered by `_normalize()` returning `None` before the `subprocess.run` call).