### PR TITLE
matterbot: load commands via fully-qualified `<commanddir>.<name>.X` path

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import pathlib
+from pathlib import Path
 import re
 import sys
 import time
@@ -72,6 +73,20 @@ class MattermostManager(object):
         self.my_team_id = self.mmDriver.teams.get_team_by_name(self.my_team_name)['id']
         # Load an existing module channel binding map if present
         modulepath = options.Modules['commanddir'].strip('/')
+        # Put the PARENT of the command directory on sys.path so modules can
+        # be imported as `<dirname>.<command>.command` — the fully-qualified
+        # dotted path avoids name collisions with installed PyPI packages
+        # that share a directory name. Concrete case: `dfir-unfurl[all]`
+        # installs a top-level `unfurl` package; `commands/unfurl/` would
+        # otherwise resolve `import unfurl.command` against the installed
+        # distribution and fail because it has no `command` submodule. Same
+        # collision shape applies to commands/holehe/ vs the holehe pkg.
+        _mp = Path(modulepath).resolve()
+        _pkg_prefix = _mp.name
+        if str(_mp.parent) not in sys.path:
+            sys.path.insert(0, str(_mp.parent))
+        # Keep the legacy commands-on-sys.path entry — some modules may rely
+        # on it for sibling imports.
         sys.path.append(modulepath)
         self.commands = {}
         self.binds = []
@@ -84,17 +99,17 @@ class MattermostManager(object):
         for root, dirs, files in os.walk(modulepath):
             for module in fnmatch.filter(files, "command.py"):
                 module_name = root.split('/')[-1].lower()
-                module = importlib.import_module(module_name + '.' + 'command')
+                module = importlib.import_module(f"{_pkg_prefix}.{module_name}.command")
                 if module_name not in self.commands:
                     module.settings.BINDS = None
                     module.settings.CHANS = None
-                    defaults = importlib.import_module(module_name + '.' + 'defaults')
+                    defaults = importlib.import_module(f"{_pkg_prefix}.{module_name}.defaults")
                     if hasattr(defaults, 'BINDS'):
                         module.settings.BINDS = defaults.BINDS
                     if hasattr(defaults, 'CHANS'):
                         module.settings.CHANS = defaults.CHANS
                     if 'settings.py' in files:
-                        overridesettings = importlib.import_module(module_name + '.' + 'settings')
+                        overridesettings = importlib.import_module(f"{_pkg_prefix}.{module_name}.settings")
                         if hasattr(overridesettings, 'BINDS'):
                             module.settings.BINDS = overridesettings.BINDS
                         if hasattr(overridesettings, 'CHANS'):
@@ -110,12 +125,12 @@ class MattermostManager(object):
         for root, dirs, files in os.walk(modulepath):
             for module in fnmatch.filter(files, "command.py"):
                 module_name = root.split('/')[-1].lower()
-                module = importlib.import_module(module_name + '.' + 'command')
-                defaults = importlib.import_module(module_name + '.' + 'defaults')
+                module = importlib.import_module(f"{_pkg_prefix}.{module_name}.command")
+                defaults = importlib.import_module(f"{_pkg_prefix}.{module_name}.defaults")
                 if hasattr(defaults, 'HELP'):
                     HELP = defaults.HELP
                 if 'settings.py' in files:
-                    overridesettings = importlib.import_module(module_name + '.' + 'settings')
+                    overridesettings = importlib.import_module(f"{_pkg_prefix}.{module_name}.settings")
                     if hasattr(overridesettings, 'HELP'):
                         HELP = overridesettings.HELP
                 self.commands[module_name]['process'] = getattr(module, 'process')


### PR DESCRIPTION
## Summary

Fixes startup `ModuleNotFoundError: No module named 'unfurl.command'`.

Reported by uforia: matterbot startup throws `ModuleNotFoundError: No module named 'unfurl.command'`. The same bug shape also affects `commands/holehe/` (just hasn't been hit visibly yet — same loader, same collision pattern).

## Root cause

The current loader does:

```python
sys.path.append(modulepath)                                # commands/ on sys.path
…
module = importlib.import_module(module_name + '.command')  # bare-name import
```

When a PyPI package shares a top-level name with a command directory, Python's import system picks the installed regular package (the one with `__init__.py`) over the namespace-style contribution from `commands/<name>/`. The submodule lookup then runs against the wrong package and raises `ModuleNotFoundError`.

Two known collisions today:

| Command dir | PyPI distribution | Installed top-level name | Symptom |
| :- | :- | :- | :- |
| `commands/unfurl/` | `dfir-unfurl[all]` | `unfurl` | `import unfurl.command` finds installed `unfurl`, no `command` submodule → fail |
| `commands/holehe/` | `holehe` | `holehe` | same shape |

Other directory matches against `requirements.txt` (`mwdb`, `reversinglabs`, `argostrans`) are false-positive — the actual PyPI import names differ (`mwdblib`, `ReversingLabs.SDK`, `argostranslate`), so no collision.

## Why qualified-path beats sys.path reordering

Python prefers regular packages (with `__init__.py`) over namespace contributions, regardless of sys.path order. Putting `commands/` at position 0 doesn't help — `import unfurl` still resolves to the installed `dfir-unfurl` distribution. The only structural fix is to import via a fully-qualified path (`commands.unfurl.command`) that doesn't share its top-level name with anything else.

## The fix

- Compute `_pkg_prefix = Path(modulepath).name` (the actual directory basename — typically `"commands"`).
- Put the **parent** of the command directory on `sys.path` so the dotted path `commands.<module_name>.X` resolves cleanly.
- Replace all six bare-name `importlib.import_module(module_name + '.X')` calls with `importlib.import_module(f"{_pkg_prefix}.{module_name}.X")`.
- Keep the existing `sys.path.append(modulepath)` for backward compatibility — some modules may rely on `commands/` being on `sys.path` for sibling-style imports, and this fix is independent of that.
- Add `from pathlib import Path` to the imports (pathlib was imported as the module, not the class).

## Verification

Reproduced the loader logic in isolation and ran it against every `commands/*/command.py`:

| | unfurl | holehe |
| :- | :- | :- |
| Pre-fix | `ModuleNotFoundError: No module named 'unfurl.command'` | same shape |
| Post-fix | ✅ loads | ✅ loads |

55 of 66 commands import cleanly after the fix. The remaining 11 `ModuleNotFoundError`s in my smoke test are dependency-related (missing pandas/bs4/OpenSSL/numpy in the bare test env) — **pre-existing** and unrelated to this loader bug. They'd load fine in any deployment with `pip install -r requirements.txt` applied.

## Files

- `matterbot.py` — loader rework (~25 line delta, 6 imports + 1 import-block tweak + new sys.path setup).

## Test plan

- [x] `py_compile matterbot.py` clean.
- [x] AST check confirms `from pathlib import Path` is now imported (was missing — bare `Path(...)` calls would NameError at runtime).
- [x] Simulated-loader smoke test against all 66 commands; `unfurl` + `holehe` now import successfully where they previously failed.
- [ ] Live bot restart — confirm no startup `ModuleNotFoundError`.
- [ ] `@unfurl https://example.com/?utm_source=test` — verify command still functional (the lazy `from unfurl.core import run` inside `process()` still resolves to the installed `dfir-unfurl` distribution; the loader fix doesn't touch that).
- [ ] `@holehe user@example.com` — likewise.