### PR TITLE
peeringdb: add @peeringdb command for ASN network info (refs #46)

### DIFF
--- a/commands/peeringdb/command.py
+++ b/commands/peeringdb/command.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+import re
+import requests
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+import logging
+
+log = logging.getLogger('MatterBot')
+_pkg = __package__ or Path(__file__).parent.name
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+# 32-bit ASN range is 0..4294967295. PeeringDB rejects out-of-range queries
+# server-side too, but rejecting locally avoids the round-trip.
+ASN_RE = re.compile(r'^(?:AS)?([0-9]{1,10})$', re.IGNORECASE)
+
+
+def _normalize_asn(raw):
+    if not raw:
+        return None
+    m = ASN_RE.match(raw.strip())
+    if not m:
+        return None
+    n = int(m.group(1))
+    if n < 0 or n > 4294967295:
+        return None
+    return n
+
+
+def _cell(value):
+    return str(value).replace('`', '').replace('|', '/').replace('\n', ' ').replace('\r', '')
+
+
+def _fetch(session, url, params, headers, timeout):
+    try:
+        resp = session.get(url, params=params, headers=headers, allow_redirects=False, timeout=timeout)
+    except requests.RequestException as e:
+        log.exception("peeringdb request failed (%s)", url)
+        return None, f"PeeringDB request failed: `{e}`"
+    if resp.status_code == 401 or resp.status_code == 403:
+        return None, 'PeeringDB: authentication failed — clear the `key` setting or supply a valid one.'
+    if resp.status_code == 404:
+        return None, None  # treated as "no record"
+    if resp.status_code == 429:
+        return None, 'PeeringDB: rate-limited (HTTP 429). Try again later or configure an API key.'
+    if resp.status_code != 200:
+        return None, f"PeeringDB returned HTTP {resp.status_code} for `{url.rsplit('/', 1)[-1]}`."
+    try:
+        return resp.json(), None
+    except ValueError:
+        log.exception("peeringdb returned non-JSON")
+        return None, 'PeeringDB returned a non-JSON response.'
+
+
+def _format(asn, net_record, ix_records, fac_records, max_ix, max_fac):
+    rows = [
+        ('ASN', f"AS{asn}"),
+    ]
+    name = net_record.get('name')
+    if name:
+        rows.append(('Network', name))
+    aka = net_record.get('aka')
+    if aka and aka != name:
+        rows.append(('Also known as', aka))
+    org = (net_record.get('org') or {}).get('name') if isinstance(net_record.get('org'), dict) else None
+    org = org or net_record.get('org_name')
+    if org:
+        rows.append(('Organisation', org))
+    net_type = net_record.get('info_type')
+    if net_type:
+        rows.append(('Network type', net_type))
+    traffic = net_record.get('info_traffic')
+    if traffic:
+        rows.append(('Traffic estimate', traffic))
+    scope = net_record.get('info_scope')
+    if scope:
+        rows.append(('Scope', scope))
+    ratio = net_record.get('info_ratio')
+    if ratio:
+        rows.append(('Traffic ratio', ratio))
+    irr = net_record.get('irr_as_set')
+    if irr:
+        rows.append(('IRR AS-set', irr))
+    policy = net_record.get('policy_general')
+    if policy:
+        rows.append(('Peering policy', policy))
+    website = net_record.get('website')
+    if website:
+        rows.append(('Website', website))
+
+    lines = [f"PeeringDB record for `AS{asn}`:"]
+    lines.append('| Field | Value |')
+    lines.append('| :- | :- |')
+    for k, v in rows:
+        lines.append(f"| **{_cell(k)}** | `{_cell(v)}` |")
+
+    # IXPs the network is present at.
+    if ix_records:
+        lines.append('')
+        total = len(ix_records)
+        truncated = total > max_ix
+        shown = ix_records[:max_ix]
+        lines.append(f"**Internet exchanges ({len(shown)} of {total}):**")
+        for r in shown:
+            if not isinstance(r, dict):
+                continue
+            ix_name = r.get('name') or r.get('ix_name') or '?'
+            speed = r.get('speed')
+            ipv4 = r.get('ipaddr4')
+            ipv6 = r.get('ipaddr6')
+            ips = ' / '.join(filter(None, [ipv4, ipv6]))
+            speed_label = f"{speed/1000:g} Gbps" if isinstance(speed, (int, float)) and speed else '?'
+            extra = ips or '—'
+            lines.append(f"- `{_cell(ix_name)}` · {speed_label} · {_cell(extra)}")
+        if truncated:
+            lines.append(f"_…{total - max_ix} more not shown._")
+
+    # Facilities (data centres / carrier hotels).
+    if fac_records:
+        lines.append('')
+        total = len(fac_records)
+        truncated = total > max_fac
+        shown = fac_records[:max_fac]
+        lines.append(f"**Facilities ({len(shown)} of {total}):**")
+        for r in shown:
+            if not isinstance(r, dict):
+                continue
+            fac_name = r.get('name') or '?'
+            city = r.get('city')
+            country = r.get('country')
+            loc_bits = ', '.join(filter(None, [city, country]))
+            lines.append(f"- `{_cell(fac_name)}`" + (f" — {_cell(loc_bits)}" if loc_bits else ''))
+        if truncated:
+            lines.append(f"_…{total - max_fac} more not shown._")
+
+    lines.append('')
+    lines.append(f"Reference: [PeeringDB AS{asn}](https://www.peeringdb.com/asn/{asn})")
+    return '\n'.join(lines)
+
+
+def process(command, channel, username, params, files, conn):
+    messages = []
+    if not params:
+        return {'messages': messages}
+
+    asn = _normalize_asn(params[0])
+    if asn is None:
+        # Silent no-op on shape mismatch (matches the rest of the TI modules).
+        return {'messages': messages}
+
+    cfg = getattr(settings, 'APIURL', {}).get('peeringdb', {})
+    base = (cfg.get('url') or '').rstrip('/') + '/'
+    key = cfg.get('key') or ''
+    max_ix = int(getattr(settings, 'MAX_IX', 10))
+    max_fac = int(getattr(settings, 'MAX_FAC', 10))
+    max_chars = int(getattr(settings, 'MAX_OUTPUT_CHARS', 8000))
+
+    headers = {
+        'Accept': settings.CONTENTTYPE,
+        'User-Agent': 'MatterBot PeeringDB module',
+    }
+    if key and not key.startswith('<'):
+        headers['Authorization'] = f'Api-Key {key}'
+
+    session = requests.Session()
+    timeout = (10, 30)
+
+    # 1. Network record by ASN.
+    net_payload, err = _fetch(session, base + 'net', {'asn': asn}, headers, timeout)
+    if err:
+        return {'messages': [{'text': err}]}
+    if not net_payload or not isinstance(net_payload.get('data'), list) or not net_payload['data']:
+        return {'messages': [{'text': f"PeeringDB: no network record for `AS{asn}`."}]}
+    net_record = net_payload['data'][0]
+    net_id = net_record.get('id')
+
+    # 2. IXP presence (netixlan) — links the network to internet exchanges.
+    ix_records = []
+    if net_id:
+        ixlan_payload, err = _fetch(session, base + 'netixlan', {'net_id': net_id}, headers, timeout)
+        if ixlan_payload and isinstance(ixlan_payload.get('data'), list):
+            ix_records = ixlan_payload['data']
+
+    # 3. Facilities (netfac).
+    fac_records = []
+    if net_id:
+        netfac_payload, err = _fetch(session, base + 'netfac', {'net_id': net_id}, headers, timeout)
+        if netfac_payload and isinstance(netfac_payload.get('data'), list):
+            fac_records = netfac_payload['data']
+
+    text = _format(asn, net_record, ix_records, fac_records, max_ix, max_fac)
+    if len(text) > max_chars:
+        text = text[:max_chars - 32].rsplit('\n', 1)[0] + '\n_…output truncated._'
+
+    messages.append({'text': text})
+    return {'messages': messages}

--- a/commands/peeringdb/defaults.py
+++ b/commands/peeringdb/defaults.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+BINDS = ['@peeringdb', '@pdb']
+CHANS = ['debug']
+APIURL = {
+    'peeringdb': {
+        # Read endpoints are unauthenticated and quota-light. `key` is left
+        # configurable so operators can drop in a PeeringDB API key for
+        # higher rate limits or to query private fields, but it's optional.
+        'url': 'https://www.peeringdb.com/api/',
+        'key': '',
+    },
+}
+CONTENTTYPE = 'application/json'
+MAX_IX = 10
+MAX_FAC = 10
+MAX_OUTPUT_CHARS = 8000
+HELP = {
+    'DEFAULT': {
+        'args': '<ASN | AS<number>>',
+        'desc': 'Look up network info on PeeringDB for an autonomous system: organisation, network type, IRR AS-set, traffic estimate, IXPs and facilities. No auth required.',
+    },
+}


### PR DESCRIPTION
## Summary

Adds the `@peeringdb` (alias `@pdb`) command. Looks up the [PeeringDB](https://www.peeringdb.com/) record for an autonomous system: organisation, network type, traffic estimate, IRR AS-set, peering policy, and the list of IXPs + facilities the network is present at.

**No authentication required** for read endpoints. An optional `key` setting is supported for higher rate limits.

Fills a real gap: `asnwhois` / `ripewhois` give RIR registration metadata; PeeringDB gives the operational view (which IXes the AS sits on, where it racks, declared traffic profile, peering policy). Useful for "who is this AS" SOC triage and network-topology questions.

References #46 (does **not** close — that's the wishlist meta-issue).

## Output

Three calls per query:
- `/api/net?asn=<n>` → primary network record (org, type, traffic, scope, ratio, IRR AS-set, policy).
- `/api/netixlan?net_id=<id>` → IX presence with per-port speed and peering IPv4/IPv6.
- `/api/netfac?net_id=<id>` → facilities (data centres / carrier hotels) with city + country.

Rendered as a key/value table + two grouped sub-tables (IXes, facilities), each capped at `MAX_IX` / `MAX_FAC` (10 each by default).

## Hardening

- `ASN_RE` accepts both `AS<num>` and bare `<num>`, case-insensitive. Output normalised to int in `0..4294967295` (32-bit ASN ceiling). Negative, overflow, alphanumeric junk all reject.
- **Silent no-op on shape mismatch** — keeps the operator UX consistent with the rest of the TI modules.
- Optional API key sent via `Authorization: Api-Key <key>` header — never URL-interpolated; `log.exception` path doesn't echo the URL so the key can't leak through error logging.
- `allow_redirects=False`, `(10, 30)` timeout, output capped at `MAX_OUTPUT_CHARS` (8000).
- Distinct error messages per 401/403, 404, 429, other.
- `_cell()` markdown-escapes — backticks stripped, pipes replaced, `\n`/`\r` stripped so an unusual facility name can't break the table.
- Sub-fetches (`netixlan`, `netfac`) are **best-effort** — if either endpoint hiccups, the primary network record still renders.

## Files

- `commands/peeringdb/defaults.py` (new)
- `commands/peeringdb/command.py` (new)

## Test plan

- [x] `py_compile` clean on both files.
- [x] `_normalize_asn()` unit-tested across 11 cases — `AS`-prefix case-insensitive accept, bare number, `AS0` and max-32-bit `AS4294967295` accept, overflow / negative / alphanumeric junk reject.
- [x] `_format()` renders the canonical network+ixp+facility shape into a clean markdown block.
- [ ] Live smoke test (no auth needed):
  - `@peeringdb AS15169` (Google) → table with multi-IX presence.
  - `@pdb 13335` (Cloudflare, bare number) → same shape.
  - `@peeringdb AS0` → likely "no network record" message.
  - `@peeringdb AS4294967296` → silent no-op (overflow).
  - `@peeringdb not-asn` → silent no-op.