### PR TITLE
ghunt: clarify the Pillow constraint applies to ghunt's venv, not the bot

### DIFF
--- a/commands/ghunt/command.py
+++ b/commands/ghunt/command.py
@@ -133,16 +133,20 @@ def process(command, channel, username, params, files, conn):
     ghunt_path = shutil.which("ghunt")
     if not ghunt_path:
         log.warning(
-            "ghunt module: ghunt binary not on PATH; install with `pip install ghunt` "
-            "(Python <=3.11 only — ghunt pins pillow==9.3.0 which does not build on 3.12+)"
+            "ghunt module: ghunt binary not on PATH; install via pipx "
+            "(`pipx install ghunt`) or any package manager that lands the "
+            "binary on PATH — the bot only needs the executable, not the lib"
         )
         return {
             "messages": [
                 {
-                    "text": "Ghunt is not installed on this host. Run "
-                    "`pip install ghunt` (requires Python ≤3.11 — ghunt pins "
-                    "`pillow==9.3.0`, which does not build on 3.12+), then "
-                    "`ghunt login`, then restart the bot."
+                    "text": "Ghunt is not on this host's PATH. The bot shells "
+                    "out to the `ghunt` binary, so any install method works — "
+                    "pipx is the cleanest: `pipx install ghunt && ghunt login`. "
+                    "(Ghunt pins `pillow==9.3.0`, which fails to build on "
+                    "Python 3.12+, so pipx with `--python python3.11` keeps "
+                    "that constraint out of the bot's own venv.) Restart the "
+                    "bot once `ghunt` is on PATH."
                 }
             ]
         }

--- a/commands/ghunt/defaults.py
+++ b/commands/ghunt/defaults.py
@@ -7,16 +7,23 @@ CHANS = ["debug"]
 #   1. It pins `pillow==9.3.0`, which fails to build on Python 3.12+
 #      (Pillow 9.x predates the newer setuptools metadata format and
 #      raises `KeyError: '__version__'` during get_requires_for_build_wheel).
-#      Forcing every operator's `pip install -r` to hit this is hostile;
-#      operators on Python <=3.11 can still install ghunt themselves.
+#      Forcing every operator's `pip install -r` to hit this is hostile.
 #   2. Ghunt needs an authenticated Google session to do anything useful —
 #      the operator MUST run `ghunt login` (interactive) and persist the
 #      resulting `creds.m` cookie file before this command returns
 #      anything. There is no "just install and go" path.
 #
-# Operator install (Python <=3.11):
-#     pip install ghunt
-#     ghunt login          # interactive cookie/OAuth bootstrap
+# This command shells out to the `ghunt` binary via subprocess; it does NOT
+# import ghunt as a Python library. The bot can therefore run on any Python
+# version — only the environment that *installs* ghunt is constrained by
+# Pillow 9.3.0. The cleanest install pattern is pipx, which isolates ghunt
+# in its own venv:
+#
+#     pipx install ghunt --python python3.11   # any Python where Pillow 9 builds
+#     ghunt login                               # interactive cookie/OAuth bootstrap
+#
+# A system package manager install, a separate venv, or anything else that
+# puts the `ghunt` binary on the bot's PATH works equally well.
 #
 # See https://github.com/mxrch/GHunt for the upstream README.
 #


### PR DESCRIPTION
## Summary

Follow-up to merged PR #194. That PR dropped `ghunt` from `requirements.txt` because `pillow==9.3.0` doesn't build on Python 3.12+. The operator-facing wording it left behind was misleading: comments and the runtime "not installed" hint said *"Python ≤3.11 only"*, which implied **the bot itself** had to run on ≤3.11.

In reality, `commands/ghunt/command.py` shells out to the `ghunt` binary via `shutil.which("ghunt")` + `subprocess.run()` — it never imports `ghunt` as a Python library. So the bot can sit on Python 3.13 while `ghunt` lives in its own pipx venv pinned to 3.11 (or wherever Pillow 9.3.0 builds).

This is a **docs/wording-only** change. No code-path changes; `shutil.which()` + `subprocess.run()` already handled the env-isolation correctly — only the operator messaging needed fixing.

> Note on branch reuse: this is the same `fix/ghunt-pillow-py313` branch that PR #194 used. The merged commits are already on `main`; only the single clarification commit `3c3bf19` is new in this PR.

## What changes

- **`commands/ghunt/defaults.py`** — re-frame the comment block: makes explicit that the command shells out to the binary, recommends `pipx install ghunt --python python3.11` as the cleanest isolation pattern, notes that **any** install method that puts `ghunt` on `$PATH` works.
- **`commands/ghunt/command.py`** — rewrite the runtime hint shown when the binary is missing so the operator sees the correct install pattern and understands the Pillow constraint applies to that venv, not the bot's.

2 files, +22 / −11.

## Files

- `commands/ghunt/defaults.py`
- `commands/ghunt/command.py`

## Test plan

- [x] No functional changes — `process()` still calls `shutil.which("ghunt")` and `subprocess.run([...ghunt...])` exactly as before.
- [ ] `@ghunt user@example.com` on a host where `ghunt` is installed in a pipx venv on Python 3.11 → command works (already does — verifying the comment matches reality).
- [ ] `@ghunt user@example.com` on a host **without** `ghunt` → new "not installed" hint mentions pipx + Python 3.11 specifically.