### PR TITLE
maltiverse: add @maltiverse command for multi-resource IoC lookup (refs #46)

### DIFF
--- a/commands/maltiverse/command.py
+++ b/commands/maltiverse/command.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+
+import ipaddress
+import re
+import requests
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+import logging
+
+log = logging.getLogger('MatterBot')
+_pkg = __package__ or Path(__file__).parent.name
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+HOSTNAME_RE = re.compile(
+    r'^(?=.{1,253}$)'
+    r'(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)\.)+'
+    r'[a-zA-Z]{2,63}$'
+)
+SHA256_RE = re.compile(r'^[A-Fa-f0-9]{64}$')
+
+
+def _is_ip(value):
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _classify(raw):
+    """Return (normalized, endpoint, label) or (None, None, None).
+
+    Maltiverse exposes resources at /ip, /hostname, /url, /sample. Other hash
+    families aren't supported by name — only SHA256 — so MD5/SHA1 are rejected.
+    """
+    if not raw:
+        return None, None, None
+    q = raw.strip()
+    if SHA256_RE.match(q):
+        return q.lower(), 'sample', 'SHA256 sample'
+
+    norm = q.lower().replace('[.]', '.').replace('(.)', '.').replace('[:]', ':')
+    if re.match(r'^hxxps?://', norm):
+        norm = norm.replace('hxxps://', 'https://', 1).replace('hxxp://', 'http://', 1)
+    if norm.startswith(('http://', 'https://')):
+        return norm, 'url', 'URL'
+
+    if _is_ip(norm):
+        return norm, 'ip', 'IP'
+
+    # Strip URL path if any before hostname check (CIDR not relevant here).
+    norm = norm.split('/', 1)[0]
+    if HOSTNAME_RE.match(norm):
+        return norm, 'hostname', 'hostname'
+    return None, None, None
+
+
+def _cell(value):
+    return str(value).replace('`', '').replace('|', '/').replace('\n', ' ').replace('\r', '')
+
+
+def _maltiverse_id_for_url(url):
+    """Maltiverse /url/<id> takes a SHA256 of the URL string as the id.
+
+    Implemented in-process so the operator just passes a URL and the module
+    figures out the lookup id.
+    """
+    import hashlib
+    return hashlib.sha256(url.encode('utf-8')).hexdigest()
+
+
+def _format(query, label, endpoint, payload, max_tags, max_blacklist):
+    if not isinstance(payload, dict):
+        return None
+
+    rows = []
+    rows.append(('Query', f"{query} ({label})"))
+
+    classification = payload.get('classification')
+    if classification:
+        rows.append(('Classification', classification))
+
+    score = payload.get('score')
+    if score is not None:
+        rows.append(('Risk score', score))
+
+    first = payload.get('creation_time') or payload.get('first_seen')
+    if first:
+        rows.append(('First seen', first))
+    last = payload.get('modification_time') or payload.get('last_seen')
+    if last:
+        rows.append(('Last updated', last))
+
+    # IP / hostname-only fields
+    if endpoint == 'ip':
+        country = payload.get('country_code')
+        as_name = payload.get('as_name')
+        asn = payload.get('asn_cidr') or payload.get('asn')
+        if country:
+            rows.append(('Country', country))
+        if as_name:
+            rows.append(('AS', as_name))
+        if asn:
+            rows.append(('ASN/CIDR', asn))
+    elif endpoint == 'hostname':
+        registrar = payload.get('registrar')
+        a_records = payload.get('resolved_ip')
+        if registrar:
+            rows.append(('Registrar', registrar))
+        if isinstance(a_records, list) and a_records:
+            ips = ', '.join(str((r.get('ip_addr') if isinstance(r, dict) else r) or '?') for r in a_records[:5])
+            extra = '' if len(a_records) <= 5 else f", …(+{len(a_records) - 5})"
+            rows.append(('Resolved IPs', ips + extra))
+    elif endpoint == 'sample':
+        file_type = payload.get('file_type') or payload.get('type')
+        md5 = payload.get('md5')
+        sha1 = payload.get('sha1')
+        if file_type:
+            rows.append(('File type', file_type))
+        if md5:
+            rows.append(('MD5', md5))
+        if sha1:
+            rows.append(('SHA1', sha1))
+
+    tags = payload.get('tag') or payload.get('tags') or []
+    if isinstance(tags, list) and tags:
+        capped = tags[:max_tags]
+        tag_str = ', '.join(_cell(t) for t in capped)
+        if len(tags) > max_tags:
+            tag_str += f", …(+{len(tags) - max_tags})"
+        rows.append(('Tags', tag_str))
+
+    lines = [f"Maltiverse record for `{query}`:"]
+    lines.append('| Field | Value |')
+    lines.append('| :- | :- |')
+    for k, v in rows:
+        lines.append(f"| **{_cell(k)}** | `{_cell(v)}` |")
+
+    ref_id = payload.get('_id') or payload.get('id')
+    if ref_id:
+        # /sample/<sha256>, /ip/<ip>, /hostname/<host>, /url/<sha256-of-url>
+        lines.append(f"| Reference | [Maltiverse {endpoint} page](https://maltiverse.com/{endpoint}/{ref_id}) |")
+
+    blacklist = payload.get('blacklist') or []
+    if isinstance(blacklist, list) and blacklist:
+        total = len(blacklist)
+        truncated = total > max_blacklist
+        shown = blacklist[:max_blacklist]
+        lines.append('')
+        lines.append(f"**Blacklist entries ({len(shown)} of {total}):**")
+        for entry in shown:
+            if not isinstance(entry, dict):
+                continue
+            src = entry.get('source') or entry.get('name') or '?'
+            desc = entry.get('description') or ''
+            first_seen = entry.get('first_seen') or ''
+            line = f"- `{_cell(src)}`"
+            if first_seen:
+                line += f" · `{_cell(first_seen)}`"
+            if desc:
+                line += f" — {_cell(desc)[:120]}"
+            lines.append(line)
+        if truncated:
+            lines.append(f"_…{total - max_blacklist} more not shown._")
+
+    return '\n'.join(lines)
+
+
+def process(command, channel, username, params, files, conn):
+    messages = []
+    if not params:
+        return {'messages': messages}
+
+    raw = params[0]
+    query, endpoint, label = _classify(raw)
+    if not query:
+        # Silent no-op on shape mismatch (matches @ioc convention).
+        return {'messages': messages}
+
+    cfg = getattr(settings, 'APIURL', {}).get('maltiverse', {})
+    token = cfg.get('key') or ''
+    base = (cfg.get('url') or '').rstrip('/') + '/'
+    max_tags = int(getattr(settings, 'MAX_TAGS', 15))
+    max_blacklist = int(getattr(settings, 'MAX_BLACKLIST', 8))
+    max_chars = int(getattr(settings, 'MAX_OUTPUT_CHARS', 8000))
+
+    if not token or token.startswith('<'):
+        return {'messages': [{'text': 'Maltiverse is not configured. Set `key` in `settings.py` (free token at https://maltiverse.com/).'}]}
+
+    # For /url, the lookup id is sha256(url). For everything else, the
+    # resource value goes in the path verbatim (urlencoded so : and / can't
+    # reshape the request URL).
+    path_id = _maltiverse_id_for_url(query) if endpoint == 'url' else query
+    url = base + endpoint + '/' + requests.utils.quote(path_id, safe='')
+
+    headers = {
+        'Authorization': f'Bearer {token}',
+        'Accept': settings.CONTENTTYPE,
+        'User-Agent': 'MatterBot Maltiverse module',
+    }
+
+    try:
+        resp = requests.get(
+            url,
+            headers=headers,
+            allow_redirects=False,
+            timeout=(10, 30),
+        )
+    except requests.RequestException as e:
+        log.exception("maltiverse request failed")
+        return {'messages': [{'text': f"Maltiverse request failed: `{e}`"}]}
+
+    if resp.status_code == 401 or resp.status_code == 403:
+        return {'messages': [{'text': 'Maltiverse: authentication failed — check the bearer token.'}]}
+    if resp.status_code == 429:
+        return {'messages': [{'text': 'Maltiverse: rate-limited (HTTP 429). Free tier quota may be exhausted.'}]}
+    if resp.status_code == 404:
+        return {'messages': [{'text': f"Maltiverse: no record for `{query}`."}]}
+    if resp.status_code != 200:
+        return {'messages': [{'text': f"Maltiverse returned HTTP {resp.status_code}."}]}
+
+    try:
+        payload = resp.json()
+    except ValueError:
+        log.exception("maltiverse returned non-JSON")
+        return {'messages': [{'text': 'Maltiverse returned a non-JSON response.'}]}
+
+    text = _format(query, label, endpoint, payload, max_tags, max_blacklist)
+    if not text:
+        return {'messages': [{'text': f"Maltiverse: unrecognised response shape for `{query}`."}]}
+
+    if len(text) > max_chars:
+        text = text[:max_chars - 32].rsplit('\n', 1)[0] + '\n_…output truncated._'
+
+    messages.append({'text': text})
+    return {'messages': messages}

--- a/commands/maltiverse/defaults.py
+++ b/commands/maltiverse/defaults.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+BINDS = ['@maltiverse', '@mv', '@ioc']
+CHANS = ['debug']
+APIURL = {
+    'maltiverse': {
+        # Free registration at https://maltiverse.com/. Bearer token required.
+        'url': 'https://api.maltiverse.com/',
+        'key': '<your-maltiverse-bearer-token-here>',
+    },
+}
+CONTENTTYPE = 'application/json'
+MAX_TAGS = 15
+MAX_BLACKLIST = 8
+MAX_OUTPUT_CHARS = 8000
+HELP = {
+    'DEFAULT': {
+        'args': '<IP|hostname|URL|SHA256>',
+        'desc': 'Query Maltiverse for classification (malicious/suspicious/neutral/whitelist), tags, blacklist entries, and first/last seen. Auto-detects the resource type. Requires a free Maltiverse account (https://maltiverse.com/).',
+    },
+}


### PR DESCRIPTION
## Summary

Adds the `@maltiverse` (alias `@mv`) command. Queries [Maltiverse](https://maltiverse.com/) for classification, tags, blacklist entries, and resource-specific metadata. Auto-routes to the matching endpoint based on input shape:

| Input | Endpoint |
| :- | :- |
| IPv4 / IPv6 | `/ip/<addr>` |
| hostname | `/hostname/<host>` |
| URL (`http://` or `https://`) | `/url/<sha256-of-url>` |
| SHA256 hash | `/sample/<hash>` |

Free-tier registration required. Bearer token configured via `APIURL['maltiverse']['key']` in `settings.py`.

Bindings include `@ioc` so all four input shapes route through Maltiverse alongside the other TI modules.

References #46.

**Note on URL lookups:** Maltiverse keys `/url` records by the SHA256 of the canonical URL string, not the URL itself. The module computes the digest in-process so the operator just passes the URL.

## Output

- Classification (`malicious` / `suspicious` / `neutral` / `whitelist`).
- Risk score, first / last seen.
- Resource-specific fields — country + AS + ASN/CIDR for IPs; registrar + resolved IPs for hostnames; file type + cross-hash for samples.
- Tag list (capped at `MAX_TAGS` 15).
- Blacklist sub-table with source + first-seen + truncated description (capped at `MAX_BLACKLIST` 8).

## Hardening

- **Strict regex per input shape.** Only **SHA256** hashes accepted — MD5 / SHA1 are explicitly rejected because Maltiverse only keys samples by SHA256; attempting a 32 or 40 hex query would 404 every time.
- IP classification happens **before** hostname check (and before path-strip) so IPv4 / IPv6 isn't accidentally classified as a domain.
- URL detection requires explicit `http://` or `https://` scheme; bare hostnames fall through to the hostname endpoint.
- Defang restore for `[.]`, `(.)`, `[:]`, `hxxp(s)://` before classification.
- **Bearer token in `Authorization` header**, never URL-interpolated. `log.exception` path in the request-failure branch does **not** echo the URL.
- **Path id urlencoded** via `requests.utils.quote(safe='')` so a stray `:` or `/` in the operator input (after validation) can't reshape the request URL.
- **Silent no-op on shape mismatch** — matches the rest of the TI modules under `@ioc`.
- `allow_redirects=False`, `(10, 30)` timeout, output capped at `MAX_OUTPUT_CHARS` (8000).
- Distinct error messages per 401 / 403, 404, 429, other.
- `_cell()` markdown-escape — backticks stripped, pipes replaced, `\n` / `\r` stripped.
- **Blacklist description trimmed to 120 chars per entry** to prevent one verbose entry from eating the whole message budget.

## Files

- `commands/maltiverse/defaults.py` (new)
- `commands/maltiverse/command.py` (new)

## Test plan

- [x] `py_compile` clean on both files.
- [x] `_classify()` unit-tested across 11 cases — IPv4, IPv6, hostname, defanged hostname, `https://` URL, `hxxps://` defanged URL with mixed defang variants, SHA256 hash all **accepted**; MD5, SHA1, junk strings, empty input all **rejected**.
- [x] `_maltiverse_id_for_url()` produces a 64-char hex digest for a test URL.
- [x] `_format()` renders the canonical IP + blacklist + tags shape into a clean markdown block with table + sub-table.
- [ ] Smoke test in a live bot with a valid Maltiverse bearer token:
  - `@maltiverse 8.8.8.8` → IP record table.
  - `@mv paypal.com` → hostname table.
  - `@maltiverse https://example.com/malware` → URL lookup via sha256(url).
  - `@maltiverse e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` → SHA256 sample.
  - `@maltiverse 44d88612fea8a8f36de82e1278abb02f` (MD5) → silent no-op (rejected — Maltiverse doesn't key by MD5).
  - `@maltiverse foo` → silent no-op.
  - `@maltiverse 8.8.8.8` with unconfigured token → "not configured" message.
- [ ] Verify `@ioc 8.8.8.8` includes maltiverse in the fan-out alongside the other TI modules.