### PR TITLE
fullhunt: add @fullhunt command for domain details + subdomain enum (refs #46)

### DIFF
--- a/commands/fullhunt/command.py
+++ b/commands/fullhunt/command.py
@@ -130,11 +130,13 @@ def _format_subdomains(domain, payload, max_subdomains):
     truncated = total > max_subdomains
     shown = hosts[:max_subdomains]
 
-    lines = [f"FullHunt subdomains for `{domain}` — {len(shown)} of {total}:"]
+    lines = [f"FullHunt subdomains for `{_cell(domain)}` — {len(shown)} of {total}:"]
     lines.append('```')
     for h in shown:
         if isinstance(h, str):
-            lines.append(h)
+            # Neutralise ``` so an upstream host string can't terminate
+            # the fenced block.
+            lines.append(re.sub(r'`{3,}', '``', h))
         elif isinstance(h, dict):
             # Some FullHunt response variants nest each host as
             # {host: "...", ip: "...", ports: [...]}.
@@ -146,7 +148,8 @@ def _format_subdomains(domain, payload, max_subdomains):
             ports = h.get('ports')
             if isinstance(ports, list) and ports:
                 extras.append('ports=' + ','.join(str(p) for p in ports[:8]))
-            lines.append(host + (f" [{' | '.join(extras)}]" if extras else ''))
+            row = str(host) + (f" [{' | '.join(extras)}]" if extras else '')
+            lines.append(re.sub(r'`{3,}', '``', row))
     lines.append('```')
     if truncated:
         lines.append(f"_…{total - max_subdomains} more subdomain(s) not shown._")

--- a/commands/fullhunt/command.py
+++ b/commands/fullhunt/command.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+
+import re
+import requests
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+import logging
+
+log = logging.getLogger('MatterBot')
+_pkg = __package__ or Path(__file__).parent.name
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+HOSTNAME_RE = re.compile(
+    r'^(?=.{1,253}$)'
+    r'(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)\.)+'
+    r'[a-zA-Z]{2,63}$'
+)
+
+
+def _normalize_domain(raw):
+    if not raw:
+        return None
+    q = raw.strip().lower()
+    q = q.replace('[.]', '.').replace('(.)', '.')
+    q = re.sub(r'^(?:https?|hxxps?)://', '', q)
+    q = q.split('/', 1)[0]
+    return q if HOSTNAME_RE.match(q) else None
+
+
+def _cell(value):
+    return str(value).replace('`', '').replace('|', '/').replace('\n', ' ').replace('\r', '')
+
+
+def _capped_list(values, cap, label):
+    if not values:
+        return None
+    capped = values[:cap]
+    s = ', '.join(_cell(v) for v in capped)
+    if len(values) > cap:
+        s += f", …(+{len(values) - cap} more)"
+    return s
+
+
+def _format_details(domain, payload, max_tags, max_tech, max_countries):
+    if not isinstance(payload, dict):
+        return None
+
+    meta = payload.get('metadata') or {}
+    # FullHunt sometimes returns the metadata fields at the payload root too;
+    # try both layers.
+    def _g(k):
+        return meta.get(k) if isinstance(meta, dict) and k in meta else payload.get(k)
+
+    rows = [('Domain', domain)]
+
+    exists = _g('exists')
+    if exists is not None:
+        rows.append(('Exists', 'yes' if exists else 'no'))
+
+    host_count = _g('host_count') or _g('hosts_count')
+    if host_count is not None:
+        rows.append(('Host count', host_count))
+
+    first = _g('first_seen') or _g('first_observed')
+    last = _g('last_seen') or _g('last_observed')
+    if first:
+        rows.append(('First seen', first))
+    if last:
+        rows.append(('Last seen', last))
+
+    tags = _g('tags') or []
+    tags_str = _capped_list(tags if isinstance(tags, list) else [tags], max_tags, 'tags')
+    if tags_str:
+        rows.append(('Tags', tags_str))
+
+    tech = _g('tech') or _g('technologies') or []
+    tech_str = _capped_list(tech if isinstance(tech, list) else [tech], max_tech, 'tech')
+    if tech_str:
+        rows.append(('Tech', tech_str))
+
+    countries = _g('country') or _g('countries') or []
+    if isinstance(countries, str):
+        countries = [countries]
+    country_str = _capped_list(countries, max_countries, 'countries')
+    if country_str:
+        rows.append(('Countries', country_str))
+
+    lines = [f"FullHunt details for `{domain}`:"]
+    lines.append('| Field | Value |')
+    lines.append('| :- | :- |')
+    for k, v in rows:
+        lines.append(f"| **{_cell(k)}** | `{_cell(v)}` |")
+
+    lines.append(f"| Reference | [FullHunt domain page](https://fullhunt.io/domain/{domain}) |")
+    return '\n'.join(lines)
+
+
+def _format_subdomains(domain, payload, max_subdomains):
+    if not isinstance(payload, dict):
+        return None
+    hosts = payload.get('hosts') or payload.get('subdomains') or []
+    if not isinstance(hosts, list):
+        return None
+
+    total = len(hosts)
+    if total == 0:
+        return f"FullHunt: no subdomains found for `{domain}`."
+
+    truncated = total > max_subdomains
+    shown = hosts[:max_subdomains]
+
+    lines = [f"FullHunt subdomains for `{domain}` — {len(shown)} of {total}:"]
+    lines.append('```')
+    for h in shown:
+        if isinstance(h, str):
+            lines.append(h)
+        elif isinstance(h, dict):
+            # Some FullHunt response variants nest each host as
+            # {host: "...", ip: "...", ports: [...]}.
+            host = h.get('host') or h.get('hostname') or '?'
+            ip = h.get('ip')
+            extras = []
+            if ip:
+                extras.append(str(ip))
+            ports = h.get('ports')
+            if isinstance(ports, list) and ports:
+                extras.append('ports=' + ','.join(str(p) for p in ports[:8]))
+            lines.append(host + (f" [{' | '.join(extras)}]" if extras else ''))
+    lines.append('```')
+    if truncated:
+        lines.append(f"_…{total - max_subdomains} more subdomain(s) not shown._")
+    return '\n'.join(lines)
+
+
+def process(command, channel, username, params, files, conn):
+    messages = []
+    if not params:
+        return {'messages': [{
+            'text': "Usage: `@fullhunt [details|subdomains] <domain>` — bare `@fullhunt <domain>` defaults to `details`."
+        }]}
+
+    sub = 'details'
+    target = params[0]
+    if params[0].lower() in ('details', 'subdomains') and len(params) >= 2:
+        sub = params[0].lower()
+        target = params[1]
+
+    domain = _normalize_domain(target)
+    if not domain:
+        if params[0].lower() in ('details', 'subdomains'):
+            return {'messages': [{'text': f"fullhunt {sub}: `{_cell(target)}` is not a valid domain."}]}
+        return {'messages': messages}
+
+    cfg = getattr(settings, 'APIURL', {}).get('fullhunt', {})
+    key = cfg.get('key') or ''
+    base = (cfg.get('url') or '').rstrip('/') + '/'
+    max_subdomains = int(getattr(settings, 'MAX_SUBDOMAINS', 60))
+    max_tags = int(getattr(settings, 'MAX_TAGS', 20))
+    max_tech = int(getattr(settings, 'MAX_TECH', 20))
+    max_countries = int(getattr(settings, 'MAX_COUNTRIES', 10))
+    max_chars = int(getattr(settings, 'MAX_OUTPUT_CHARS', 8000))
+
+    if not key or key.startswith('<'):
+        return {'messages': [{'text': 'FullHunt is not configured. Set `key` in `settings.py` (free registration at https://fullhunt.io/).'}]}
+
+    endpoint = f"domain/{requests.utils.quote(domain, safe='')}/{'subdomains' if sub == 'subdomains' else 'details'}"
+    url = base + endpoint
+    headers = {
+        'X-API-KEY': key,
+        'Accept': settings.CONTENTTYPE,
+        'User-Agent': 'MatterBot FullHunt module',
+    }
+
+    try:
+        resp = requests.get(url, headers=headers, allow_redirects=False, timeout=(10, 30))
+    except requests.RequestException as e:
+        log.exception("fullhunt request failed")
+        return {'messages': [{'text': f"FullHunt request failed: `{e}`"}]}
+
+    if resp.status_code == 401 or resp.status_code == 403:
+        return {'messages': [{'text': 'FullHunt: authentication failed — check `key`.'}]}
+    if resp.status_code == 429:
+        return {'messages': [{'text': 'FullHunt: rate-limited (HTTP 429). Free-tier quota may be exhausted.'}]}
+    if resp.status_code == 404:
+        return {'messages': [{'text': f"FullHunt: no record for `{domain}` ({sub})."}]}
+    if resp.status_code != 200:
+        return {'messages': [{'text': f"FullHunt returned HTTP {resp.status_code}."}]}
+
+    try:
+        payload = resp.json()
+    except ValueError:
+        log.exception("fullhunt returned non-JSON")
+        return {'messages': [{'text': 'FullHunt returned a non-JSON response.'}]}
+
+    if sub == 'subdomains':
+        text = _format_subdomains(domain, payload, max_subdomains)
+    else:
+        text = _format_details(domain, payload, max_tags, max_tech, max_countries)
+
+    if not text:
+        return {'messages': [{'text': f"FullHunt: unrecognised response shape for `{domain}` ({sub})."}]}
+
+    if len(text) > max_chars:
+        text = text[:max_chars - 32].rsplit('\n', 1)[0] + '\n_…output truncated._'
+
+    messages.append({'text': text})
+    return {'messages': messages}

--- a/commands/fullhunt/defaults.py
+++ b/commands/fullhunt/defaults.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+BINDS = ['@fullhunt', '@fh']
+CHANS = ['debug']
+APIURL = {
+    'fullhunt': {
+        # Free-tier registration at https://fullhunt.io/. Key sent via
+        # X-API-KEY header. `auth/status` returns remaining quota.
+        'url': 'https://fullhunt.io/api/v1/',
+        'key': '<your-fullhunt-api-key-here>',
+    },
+}
+CONTENTTYPE = 'application/json'
+MAX_SUBDOMAINS = 60
+MAX_TAGS = 20
+MAX_TECH = 20
+MAX_COUNTRIES = 10
+MAX_OUTPUT_CHARS = 8000
+HELP = {
+    'DEFAULT': {
+        'args': '[details|subdomains] <domain>',
+        'desc': (
+            'FullHunt attack-surface lookup: bare `@fullhunt <domain>` → '
+            'asset details (host count, tech fingerprints, countries, tags); '
+            '`subdomains <domain>` → subdomain enumeration. Requires a free '
+            'FullHunt account (https://fullhunt.io/).'
+        ),
+    },
+}


### PR DESCRIPTION
## Summary

Adds the `@fullhunt` (alias `@fh`) command. Wraps the [FullHunt](https://fullhunt.io/) attack-surface management API.

| Form | Endpoint | What you get |
| :- | :- | :- |
| `@fullhunt <domain>` (bare) | `/domain/<d>/details` | host count, first/last seen, tags, tech fingerprints, country distribution |
| `@fullhunt details <domain>` | `/domain/<d>/details` | same |
| `@fullhunt subdomains <domain>` | `/domain/<d>/subdomains` | hostname list (with IP + observed ports per host when available) |

Free-tier registration required. API key sent via `X-API-KEY` header — configured at `APIURL['fullhunt']['key']`.

No `@ioc` binding — surface-management is domain-only and the rendered subdomain list is large; explicit invocation only.

References #46.

## Defensive parsing

FullHunt has been observed returning the fields-of-interest either **nested under `metadata`** or **hoisted to the payload root**. `_format_details()` tries metadata first, falls back to root for each field independently.

Subdomain rendering tolerates two shapes:
- Plain string list: `["www.example.com", "api.example.com"]`
- Dict-per-host: `[{"host": "...", "ip": "...", "ports": [...]}]`

## Hardening

- Domain-only validator (RFC-1123 hostname + defang restore + scheme-strip + path-strip). IPs and shell metachars rejected.
- **Bare-target shortcut silently no-ops** on bad input. **Explicit subcommand with bad target emits a rejection** so the operator knows their subcommand didn't fire.
- Domain urlencoded via `requests.utils.quote(safe='')` before being interpolated into the URL path.
- API key in `X-API-KEY` header, never URL-interpolated. `log.exception` path doesn't echo the URL.
- `allow_redirects=False`, `(10, 30)` timeout, output capped at `MAX_OUTPUT_CHARS` (8000). Subdomains capped at `MAX_SUBDOMAINS` (60); tags / tech / countries capped at their respective settings to keep the details table readable.
- Distinct error messages per 401 / 403, 404, 429, other.
- **Subdomain list rendered in a code-fence block** — monospaced, copy-pasteable into a hunt pipeline.
- `_cell()` markdown-escape — backticks stripped, pipes replaced, `\n`/`\r` stripped so a multi-tag list with weird chars can't break the table.

## Files

- `commands/fullhunt/defaults.py` (new)
- `commands/fullhunt/command.py` (new)

## Test plan

- [x] `py_compile` clean on both files.
- [x] `_normalize_domain()` unit-tested across 7 cases: good domain, defanged, URL-prefixed, mixed-case → lowercase, IPv4 rejected, shell metachars rejected, empty.
- [x] `_format_details()` renders the canonical metadata-nested shape into a clean markdown block (Exists / Host count / First seen / tags / tech / countries / reference link).
- [x] `_format_subdomains()` renders both string-list and dict-list shapes (with per-host IP + ports formatted inline); emits clean "no subdomains found" on empty.
- [x] `_capped_list()` truncates with overflow footer.
- [ ] Smoke test in a live bot with a valid FullHunt key:
  - `@fullhunt paypal.com` → details table.
  - `@fullhunt details paypal.com` → same.
  - `@fh subdomains paypal.com` → subdomain list in code fence.
  - `@fullhunt details foo bar.com` → explicit rejection ("not a valid domain").
  - `@fullhunt subdomains 1.2.3.4` → explicit rejection.
  - `@fullhunt junk` → silent no-op (bare-target shortcut).
  - `@fullhunt paypal.com` with unconfigured key → "not configured" message.