### PR TITLE
kaspersky: add @kaspersky command for OpenTIP reputation lookups (refs #46)

### DIFF
--- a/commands/kaspersky/command.py
+++ b/commands/kaspersky/command.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+
+import ipaddress
+import re
+import requests
+
+### Dynamic configuration loader (do not change/edit)
+from importlib import import_module
+from types import SimpleNamespace
+from pathlib import Path
+import logging
+
+log = logging.getLogger('MatterBot')
+_pkg = __package__ or Path(__file__).parent.name
+def _load(module_name):
+    try:
+        return import_module(f".{module_name}", package=_pkg)
+    except ModuleNotFoundError:
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError:
+            return None
+_defaults = _load("defaults")
+_settings = _load("settings")
+_settings_dict = {
+    k: v
+    for mod in (_defaults, _settings)
+    if mod
+    for k, v in vars(mod).items()
+    if not k.startswith("__")
+}
+settings = SimpleNamespace(**_settings_dict)
+### Loader end, actual module functionality starts here
+
+HOSTNAME_RE = re.compile(
+    r'^(?=.{1,253}$)'
+    r'(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)\.)+'
+    r'[a-zA-Z]{2,63}$'
+)
+MD5_RE = re.compile(r'^[A-Fa-f0-9]{32}$')
+SHA1_RE = re.compile(r'^[A-Fa-f0-9]{40}$')
+SHA256_RE = re.compile(r'^[A-Fa-f0-9]{64}$')
+
+
+def _is_ip(value):
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _classify(raw):
+    """Return (normalized, endpoint, label) or (None, None, None).
+
+    Kaspersky OpenTIP exposes /search/{ip,domain,url,hash}.
+    """
+    if not raw:
+        return None, None, None
+    q = raw.strip()
+
+    # Hash family is checked first (case-insensitive, normalised to lower).
+    if SHA256_RE.match(q):
+        return q.lower(), 'hash', 'SHA256'
+    if SHA1_RE.match(q):
+        return q.lower(), 'hash', 'SHA1'
+    if MD5_RE.match(q):
+        return q.lower(), 'hash', 'MD5'
+
+    # URL detection — requires explicit scheme (defang-restored).
+    norm = q.replace('[.]', '.').replace('(.)', '.').replace('[:]', ':')
+    if re.match(r'^hxxps?://', norm, re.IGNORECASE):
+        norm = re.sub(r'^hxxps?://', lambda m: m.group(0).lower().replace('hxxp', 'http'), norm, flags=re.IGNORECASE)
+    if norm.lower().startswith(('http://', 'https://')):
+        return norm, 'url', 'URL'
+
+    # IP / domain — strip URL path before hostname check (CIDR rejected).
+    norm_l = norm.lower()
+    if _is_ip(norm_l):
+        return norm_l, 'ip', 'IP'
+    norm_l = norm_l.split('/', 1)[0]
+    if HOSTNAME_RE.match(norm_l):
+        return norm_l, 'domain', 'domain'
+    return None, None, None
+
+
+def _cell(value):
+    return str(value).replace('`', '').replace('|', '/').replace('\n', ' ').replace('\r', '')
+
+
+def _format_zone_emoji(zone):
+    """Map Kaspersky verdict zone to a short prefix. Kept ASCII so the
+    table cell renders cleanly across Mattermost themes."""
+    return {
+        'Green': 'safe',
+        'Yellow': 'suspicious',
+        'Red': 'malicious',
+        'Grey': 'unknown',
+        'Unknown': 'unknown',
+    }.get(zone, str(zone) if zone else 'unknown')
+
+
+def _format(query, label, endpoint, payload, max_detections, max_categories):
+    if not isinstance(payload, dict):
+        return None
+
+    zone = payload.get('Zone')
+    rows = [
+        ('Query', f"{query} ({label})"),
+        ('Verdict zone', f"{zone or 'Unknown'} ({_format_zone_emoji(zone)})"),
+    ]
+
+    # Endpoint-specific summary fields.
+    if endpoint == 'hash':
+        info = payload.get('FileGeneralInfo') or {}
+        if isinstance(info, dict):
+            for k_in, k_out in [
+                ('FileStatus', 'File status'),
+                ('Type', 'File type'),
+                ('Size', 'File size'),
+                ('Signer', 'Signer'),
+                ('Packer', 'Packer'),
+                ('FirstSeen', 'First seen'),
+                ('LastSeen', 'Last seen'),
+                ('HitsCount', 'Hits count'),
+                ('Md5', 'MD5'),
+                ('Sha1', 'SHA1'),
+                ('Sha256', 'SHA256'),
+            ]:
+                v = info.get(k_in)
+                if v is not None and v != '':
+                    rows.append((k_out, v))
+    elif endpoint == 'ip':
+        info = payload.get('IpGeneralInfo') or {}
+        if isinstance(info, dict):
+            for k_in, k_out in [
+                ('CountryCode', 'Country'),
+                ('Ip', 'IP'),
+                ('Status', 'Status'),
+                ('HitsCount', 'Hits count'),
+                ('FirstSeen', 'First seen'),
+                ('LastSeen', 'Last seen'),
+            ]:
+                v = info.get(k_in)
+                if v is not None and v != '':
+                    rows.append((k_out, v))
+    elif endpoint == 'domain':
+        info = payload.get('DomainGeneralInfo') or {}
+        if isinstance(info, dict):
+            for k_in, k_out in [
+                ('Domain', 'Domain'),
+                ('Ipv4Count', 'IPv4 count'),
+                ('FilesCount', 'File count'),
+                ('UrlsCount', 'URL count'),
+                ('HitsCount', 'Hits count'),
+                ('FirstSeen', 'First seen'),
+                ('LastSeen', 'Last seen'),
+            ]:
+                v = info.get(k_in)
+                if v is not None and v != '':
+                    rows.append((k_out, v))
+    elif endpoint == 'url':
+        info = payload.get('UrlGeneralInfo') or {}
+        if isinstance(info, dict):
+            for k_in, k_out in [
+                ('Url', 'URL'),
+                ('Host', 'Host'),
+                ('Ipv4Count', 'Resolved IP count'),
+                ('FilesCount', 'Linked file count'),
+            ]:
+                v = info.get(k_in)
+                if v is not None and v != '':
+                    rows.append((k_out, v))
+
+    # Categories — flat string list across all endpoints when present.
+    categories = payload.get('Categories') or []
+    if isinstance(categories, list) and categories:
+        shown_cats = categories[:max_categories]
+        cats_str = ', '.join(_cell(c) for c in shown_cats)
+        if len(categories) > max_categories:
+            cats_str += f", …(+{len(categories) - max_categories} more)"
+        rows.append(('Categories', cats_str))
+
+    lines = [f"Kaspersky OpenTIP record for `{query}`:"]
+    lines.append('| Field | Value |')
+    lines.append('| :- | :- |')
+    for k, v in rows:
+        lines.append(f"| **{_cell(k)}** | `{_cell(v)}` |")
+
+    # Detections sub-table (hash endpoint, sometimes URL too).
+    detections = payload.get('DetectionsInfo') or payload.get('Detections') or []
+    if isinstance(detections, list) and detections:
+        total = len(detections)
+        shown = detections[:max_detections]
+        lines.append('')
+        lines.append(f"**Detections ({len(shown)} of {total}):**")
+        lines.append('| Type | Description | LastDetectDate |')
+        lines.append('| :- | :- | :- |')
+        for d in shown:
+            if not isinstance(d, dict):
+                continue
+            dtype = d.get('DetectionMethod') or d.get('Type') or '?'
+            desc = d.get('DescriptionUrl') or d.get('Name') or d.get('Description') or ''
+            date = d.get('LastDetectDate') or d.get('Date') or ''
+            lines.append(f"| `{_cell(dtype)}` | `{_cell(desc)}` | `{_cell(date)}` |")
+        if total > max_detections:
+            lines.append(f"_…{total - max_detections} more detection(s) not shown._")
+
+    return '\n'.join(lines)
+
+
+def process(command, channel, username, params, files, conn):
+    messages = []
+    if not params:
+        return {'messages': messages}
+
+    query, endpoint, label = _classify(params[0])
+    if not query:
+        # Silent no-op on shape mismatch (matches the rest of the TI modules).
+        return {'messages': messages}
+
+    cfg = getattr(settings, 'APIURL', {}).get('kaspersky', {})
+    key = cfg.get('key') or ''
+    base = (cfg.get('url') or '').rstrip('/') + '/'
+    max_detections = int(getattr(settings, 'MAX_DETECTIONS', 10))
+    max_categories = int(getattr(settings, 'MAX_CATEGORIES', 10))
+    max_chars = int(getattr(settings, 'MAX_OUTPUT_CHARS', 8000))
+
+    if not key or key.startswith('<'):
+        return {'messages': [{'text': 'Kaspersky OpenTIP is not configured. Set `key` in `settings.py` (free at https://opentip.kaspersky.com/).'}]}
+
+    url = base + 'search/' + endpoint
+    headers = {
+        'x-api-key': key,
+        'Accept': settings.CONTENTTYPE,
+        'User-Agent': 'MatterBot Kaspersky OpenTIP module',
+    }
+
+    try:
+        resp = requests.get(
+            url,
+            params={'request': query},
+            headers=headers,
+            allow_redirects=False,
+            timeout=(10, 30),
+        )
+    except requests.RequestException as e:
+        log.exception("kaspersky request failed")
+        return {'messages': [{'text': f"Kaspersky OpenTIP request failed: `{e}`"}]}
+
+    if resp.status_code == 401 or resp.status_code == 403:
+        return {'messages': [{'text': 'Kaspersky OpenTIP: authentication failed — check `key`.'}]}
+    if resp.status_code == 429:
+        return {'messages': [{'text': 'Kaspersky OpenTIP: rate-limited (HTTP 429). Free tier daily quota may be exhausted.'}]}
+    if resp.status_code == 404:
+        return {'messages': [{'text': f"Kaspersky OpenTIP: no record for `{query}` ({label})."}]}
+    if resp.status_code != 200:
+        return {'messages': [{'text': f"Kaspersky OpenTIP returned HTTP {resp.status_code}."}]}
+
+    try:
+        payload = resp.json()
+    except ValueError:
+        log.exception("kaspersky returned non-JSON")
+        return {'messages': [{'text': 'Kaspersky OpenTIP returned a non-JSON response.'}]}
+
+    text = _format(query, label, endpoint, payload, max_detections, max_categories)
+    if not text:
+        return {'messages': [{'text': f"Kaspersky OpenTIP: unrecognised response shape for `{query}`."}]}
+
+    if len(text) > max_chars:
+        text = text[:max_chars - 32].rsplit('\n', 1)[0] + '\n_…output truncated._'
+
+    messages.append({'text': text})
+    return {'messages': messages}

--- a/commands/kaspersky/defaults.py
+++ b/commands/kaspersky/defaults.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+# NOTE: Kaspersky OpenTIP is intentionally NOT bound to @ioc by default.
+# US BIS June-2024 entity-list action + NCSC-NL / multiple EU CSIRT
+# advisories against Kaspersky-in-CNI mean integrating Kaspersky into a
+# SOC tool is a compliance/audit call the operator should make
+# explicitly. To enable Kaspersky on the generic IoC fan-out, add
+# '@ioc' to BINDS in settings.py.
+BINDS = ['@kaspersky', '@kt']
+CHANS = ['debug']
+APIURL = {
+    'kaspersky': {
+        # OpenTIP community endpoint. Free key at
+        # https://opentip.kaspersky.com/. Sent via x-api-key header.
+        'url': 'https://opentip.kaspersky.com/api/v1/',
+        'key': '<your-kaspersky-opentip-api-key-here>',
+    },
+}
+CONTENTTYPE = 'application/json'
+MAX_DETECTIONS = 10
+MAX_CATEGORIES = 10
+MAX_OUTPUT_CHARS = 8000
+HELP = {
+    'DEFAULT': {
+        'args': '<IP|domain|URL|MD5|SHA1|SHA256>',
+        'desc': (
+            'Kaspersky OpenTIP community reputation lookup. Auto-detects '
+            'resource type (IP / domain / URL / file hash) and returns the '
+            'verdict zone (Green / Yellow / Red / Grey) plus key metadata. '
+            'Requires a free Kaspersky OpenTIP account '
+            '(https://opentip.kaspersky.com/).'
+        ),
+    },
+}


### PR DESCRIPTION
## Summary

Adds the `@kaspersky` (alias `@kt`) command. Queries [Kaspersky OpenTIP](https://opentip.kaspersky.com/) community API for IP / domain / URL / file-hash reputation. Auto-detects the resource shape and routes to the matching endpoint:

| Input | Endpoint |
| :- | :- |
| IPv4 / IPv6 | `/api/v1/search/ip` |
| domain | `/api/v1/search/domain` |
| URL (`http(s)://`) | `/api/v1/search/url` |
| MD5 / SHA1 / SHA256 | `/api/v1/search/hash` |

Free community-tier registration required; API key sent via `x-api-key` header.

References #46.

## Why this module is **not** bound to `@ioc` by default

`BINDS = ['@kaspersky', '@kt']` — deliberately **without** `@ioc`. Rationale captured at the top of `defaults.py`:

- US BIS designated Kaspersky Lab on the Entity List (June 2024, banning US sale).
- NCSC-NL and several EU CSIRTs have published advisories against Kaspersky in CNI / government workflows.
- Integrating Kaspersky into a SOC tool is therefore a **compliance / audit call the operator should make explicitly**, not a default fan-out behaviour shipped upstream.

Operators who want Kaspersky on the generic IoC fan-out just add `'@ioc'` to `BINDS` in their `settings.py` — one-line, fully reversible. The module ships **enabled** for direct `@kaspersky <…>` use; the geopolitical gating only affects auto-fan-out, not the bot's ability to query Kaspersky when the operator asks for it directly.

## Output

- Verdict zone (`Green` / `Yellow` / `Red` / `Grey` / `Unknown`) translated to an ASCII label (`safe` / `suspicious` / `malicious` / `unknown`) so the cell renders cleanly across Mattermost themes.
- Endpoint-specific summary fields:
  - **Hash:** FileStatus, file type, size, signer, packer, first/last seen, hits count, cross-hash (MD5/SHA1/SHA256).
  - **IP:** country, status, hits count, first/last seen.
  - **Domain:** Ipv4Count, FilesCount, UrlsCount, hits count, first/last seen.
  - **URL:** host, resolved-IP count, linked-file count.
- Flat `Categories` list (capped at `MAX_CATEGORIES` 10).
- Per-detection sub-table when the endpoint surfaces `DetectionsInfo` (hash, occasionally URL), capped at `MAX_DETECTIONS` 10.

## Hardening

- Strict per-shape regex (MD5 / SHA1 / SHA256), IP via `ipaddress.ip_address()`, RFC-1123 hostname regex. Hash family checked first.
- URL detection requires explicit `http://` or `https://` scheme; bare hostnames fall through to the domain endpoint.
- Defang restore for `[.]` / `(.)` / `[:]` / `hxxp(s)://` before classification.
- Silent no-op on shape mismatch (matches the rest of the TI modules even though this one isn't on `@ioc` — keeps UX consistent).
- API key in `x-api-key` request header, never URL-interpolated; `log.exception` path doesn't echo the URL.
- Resource value passed via `params={'request': query}` — `requests` handles urlencoding; nothing the operator types ever reshapes the URL.
- `allow_redirects=False`, `(10, 30)` timeout, output capped at `MAX_OUTPUT_CHARS` (8000).
- Distinct error messages per 401/403, 404, 429, other.
- `_cell()` markdown-escape — backticks stripped, pipes replaced, `\n` / `\r` stripped.
- All four endpoint formatters tolerate missing fields independently — never crashes if Kaspersky omits an unexpected key.

## Files

- `commands/kaspersky/defaults.py` (new)
- `commands/kaspersky/command.py` (new)

## Test plan

- [x] `py_compile` clean on both files.
- [x] `_classify()` unit-tested across 10 cases (MD5, SHA1, SHA256, IPv4, IPv6, defanged domain, `https://` URL, `hxxps://` defanged URL with mixed defang, junk, empty).
- [x] `_format_zone_emoji()` maps all five documented Kaspersky zones plus `None` / unknown.
- [x] `_format()` renders hash (Red verdict, two-detection sub-table) and domain (Green verdict, categories) shapes cleanly.
- [ ] Smoke test in a live bot with a valid OpenTIP key:
  - `@kaspersky 44d88612fea8a8f36de82e1278abb02f` (EICAR MD5) → hash table with Red verdict + detections.
  - `@kt google.com` → domain table with Green verdict.
  - `@kaspersky 8.8.8.8` → IP table.
  - `@kaspersky https://example.com/x` → URL table.
  - `@kaspersky nothing` → silent no-op.
  - `@kaspersky 8.8.8.8` with unconfigured key → "not configured" message.
- [ ] Verify `@ioc 8.8.8.8` does **not** include kaspersky in the fan-out (since it's not in default BINDS).