### PR TITLE
attackmatrix: filter self-referential Actors category + KeyError-safe per-actor walk (closes #17)

### DIFF
--- a/commands/attackmatrix/command.py
+++ b/commands/attackmatrix/command.py
@@ -193,7 +193,9 @@ def process(command, channel, username, params, files, conn):
                                             with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
                                                 json_response = response.json()
                                         except (requests.RequestException, ValueError) as e:
-                                            log.exception("attackmatrix per-actor follow-up failed for %s", actor)
+                                            # No module-level `log` is set up in attackmatrix yet;
+                                            # surface the failure to the operator via channel
+                                            # message and move on to the next actor.
                                             messages.append({'text': 'AttackMatrix: per-actor follow-up failed for `'+actor+'`: `'+str(e)+'`'})
                                             continue
                                         if not isinstance(json_response, dict):

--- a/commands/attackmatrix/command.py
+++ b/commands/attackmatrix/command.py
@@ -156,7 +156,16 @@ def process(command, channel, username, params, files, conn):
                                     actorttps = {}
                                     commonttps = {}
                                     for actor in json_response:
+                                        # `Actors` is in the categories tuple because the API exposes
+                                        # actor-to-actor relations on the same key. Skip it here so
+                                        # commonttps doesn't get a self-referential `Actors` bucket
+                                        # that the downstream renderer / graph code would treat as
+                                        # TTPs (closes #17 self-reference path A).
+                                        if not isinstance(json_response[actor], dict):
+                                            continue
                                         for category in categories:
+                                            if category == 'Actors':
+                                                continue
                                             if category in json_response[actor]:
                                                 commonttps[category] = {}
                                                 for entry in json_response[actor][category]:
@@ -180,14 +189,34 @@ def process(command, channel, username, params, files, conn):
                                     for actor in keywords:
                                         actorttps[actor] = {}
                                         APIENDPOINT = settings.APIURL['attackmatrix']['url']+'/explore/Actors/'+actor
-                                        with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
-                                            json_response = response.json()
-                                            for commonttpcategory in commonttps:
-                                                if commonttpcategory in commonttps:
-                                                    if len(json_response[commonttpcategory]) == 0:
-                                                        del json_response[commonttpcategory]
-                                                        continue
-                                                for commonttp in commonttps[commonttpcategory]:
+                                        try:
+                                            with requests.get(APIENDPOINT, headers=headers, timeout=(10, 30)) as response:
+                                                json_response = response.json()
+                                        except (requests.RequestException, ValueError) as e:
+                                            log.exception("attackmatrix per-actor follow-up failed for %s", actor)
+                                            messages.append({'text': 'AttackMatrix: per-actor follow-up failed for `'+actor+'`: `'+str(e)+'`'})
+                                            continue
+                                        if not isinstance(json_response, dict):
+                                            continue
+                                        # Subtract the common TTPs from the per-actor record so what
+                                        # remains is the actor's UNIQUE TTPs. Guard every step with
+                                        # `in` checks — the response shape varies (and may omit
+                                        # categories entirely) and the original code KeyErrored on
+                                        # any missing category (closes #17 self-reference path B
+                                        # / uforia's "actoroverlap sometimes errors on ttpoverlap"
+                                        # follow-up).
+                                        for commonttpcategory in commonttps:
+                                            if commonttpcategory == 'Actors':
+                                                continue
+                                            if commonttpcategory not in json_response:
+                                                continue
+                                            if not isinstance(json_response[commonttpcategory], dict):
+                                                continue
+                                            if len(json_response[commonttpcategory]) == 0:
+                                                del json_response[commonttpcategory]
+                                                continue
+                                            for commonttp in commonttps[commonttpcategory]:
+                                                if commonttp in json_response[commonttpcategory]:
                                                     del json_response[commonttpcategory][commonttp]
                                         actorttps[actor] = json_response
                                 for actor in keywords:
@@ -226,6 +255,12 @@ def process(command, channel, username, params, files, conn):
                                                fontcolor='white')
                                     # Add all TTPs to the graph
                                     for category in categories:
+                                        # Skip the self-referential Actors category — those nodes
+                                        # are already in the graph as actor-styled nodes; re-adding
+                                        # them as TTP-styled nodes would overwrite the style and
+                                        # create actor↔actor edges (closes #17 graph path).
+                                        if category == 'Actors':
+                                            continue
                                         if category in actorttps[actorid]:
                                             for ttpid in actorttps[actorid][category]:
                                                 entry = actorttps[actorid][category][ttpid]
@@ -240,6 +275,8 @@ def process(command, channel, username, params, files, conn):
                                                 graph.edge(actorid, ttpid)
                                 # Create the nodes for the TTPs they have in common
                                 for category in categories:
+                                    if category == 'Actors':
+                                        continue
                                     if category in commonttps:
                                         for ttpid in commonttps[category]:
                                             entry = commonttps[category][ttpid]


### PR DESCRIPTION
## Summary

Closes #17 — both the original bug and uforia's follow-up comment.

### Original report

> Deal with parsing self-referential categories: e.g. Actors linking to Actors in TTPOverlap queries

### Follow-up

> Additionally, actoroverlap sometimes errors on the ttpoverlap. Fix this.

## Root cause

The `categories` tuple at `commands/attackmatrix/command.py:40` lists `Actors` alongside `Techniques`, `Malwares`, etc. The AttackMatrix API uses the same `Actors` key to expose actor-to-actor relations (e.g. APT41 → APT38 via shared tooling).

`ttpoverlap` already skipped `Actors` at lines 297-298 / 338-340 / 367-369. **`actoroverlap` did not**, so:

1. **commonttps['Actors'] gets populated** with cross-referenced actor entries. Each entry happens to have a `name` field, so the table renderer produced logically-wrong "Common TTPs" rows where category=`Actors`.
2. **The graph builder adds the same actor twice** — once as a blue actor node (line 222) and once as a maroon TTP-styled box (line 234). Graphviz overwrites the first definition, so the actor's visual styling silently flips. Plus spurious actor↔actor edges appear.

The "actoroverlap sometimes errors on the ttpoverlap" follow-up was a separate `KeyError` chain in the per-actor follow-up fetch (lines 180-192):
- `len(json_response[commonttpcategory])` → `KeyError` when category absent in the re-fetched record.
- `del json_response[commonttpcategory][commonttp]` → `KeyError` on either missing key.
- `if commonttpcategory in commonttps` is a no-op (we're iterating commonttps); almost certainly meant `in json_response`.

## Fix

Surgical changes in `commands/attackmatrix/command.py`, all inside `actoroverlap`:

1. **commonttps build (line ~158):** skip `category == 'Actors'`; guard against non-dict `json_response[actor]` entries.
2. **graph builder — per-actor TTPs (line ~230):** skip Actors so the same actor isn't re-emitted as a TTP-styled box.
3. **graph builder — common TTPs (line ~245):** same Actors skip.
4. **per-actor follow-up fetch (lines ~180-205):** wrap GET in `try / except (RequestException, ValueError)`; guard every dict access with `in` checks; also skip Actors so this loop can't reintroduce the self-reference into `actorttps`.

`ttpoverlap` already had the filter — no change there.

## Test plan

- [x] `py_compile` clean on the modified file.
- [x] Diff vs `main` is bounded to lines 155-205 + 228-235 + 245-249. No unrelated changes.
- [x] Pre-commit ruff F821 (`Undefined name 'log'`) caught a real bug in the first commit — `commands/attackmatrix/command.py` has no module-level logger. Fixed in commit `d81c7ab` by dropping the `log.exception()` call; operator still gets a clear channel message via `messages.append()`.
- Manually traced failure modes through the patched code:
  - Actor response containing `Actors` category → entries silently skipped (no commonttps['Actors'], no actor-node overwriting in graph).
  - Per-actor follow-up returns 5xx → caught as `RequestException`, surfaced as a channel message, loop continues with next actor.
  - Per-actor follow-up returns category-missing payload → `in`-guarded; no `KeyError`.
  - Per-actor follow-up returns non-dict payload → `isinstance` guard skips it cleanly.
- [ ] Live smoke test:
  - `@am actoroverlap G0064 G0050` (two real actor IDs) — confirm graph renders with correct blue actor nodes and maroon TTP boxes only, no orphan actor↔actor edges.
  - Simulate the self-reference case by querying actors known to have actor-to-actor mappings in the AttackMatrix instance.

## Out of scope (follow-up potential)

- `commands/attackmatrix/command.py` doesn't have a module-level `log = logging.getLogger('MatterBot')`. Adding one (consistent with `threatfox` / `honeydb` / `pulsedive` / etc.) is a small separate PR — not blocking this fix.
- Two pre-existing `F841` unused-variable warnings (`tableheaders` at line 41, `additionalttps` at line 322) are not touched by this PR.