### PR TITLE
httpx: probe candidate binary; reject Python httpx[cli] CLI collision

### DIFF
--- a/commands/httpx/command.py
+++ b/commands/httpx/command.py
@@ -129,18 +129,61 @@ def _format_result(target, rec):
     return '\n'.join(lines)
 
 
+def _is_projectdiscovery_httpx(path):
+    """Probe a candidate `httpx` binary and verify it's ProjectDiscovery's.
+
+    A common collision: `pip install httpx[cli]` (or any transitive dep that
+    pulls in the python httpx HTTP-client library with its `[cli]` extra)
+    installs a script named `httpx` in the venv's bin/. `shutil.which('httpx')`
+    then finds the Python one first. Python httpx CLI expects
+    `httpx [OPTIONS] [METHOD] URL`, NOT the `-u <target> -json -tech-detect`
+    argv shape we use; the subprocess fails / returns garbage.
+
+    Filter at resolution time so the operator gets a clear "wrong binary"
+    message instead of a confusing subprocess error later.
+    """
+    try:
+        proc = subprocess.run(
+            [path, '-version'],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    blob = ((proc.stdout or '') + (proc.stderr or '')).lower()
+    # ProjectDiscovery httpx -version output contains "projectdiscovery"
+    # and/or "current version". Python httpx CLI doesn't recognise the
+    # single-dash `-version` flag and emits an argparse error, missing
+    # both signatures.
+    return 'projectdiscovery' in blob or 'current version' in blob
+
+
 def _resolve_binary():
-    explicit = getattr(settings, 'HTTPX_BIN', '') or ''
+    """Return a path to ProjectDiscovery's `httpx` binary, or None.
+
+    Probes each candidate with `_is_projectdiscovery_httpx` so a Python
+    httpx[cli] script on PATH doesn't get picked up by accident.
+    """
+    candidates = []
+    explicit = (getattr(settings, 'HTTPX_BIN', '') or '').strip()
     if explicit:
-        explicit = explicit.strip()
         if Path(explicit).is_file():
-            return explicit
-        # If the operator typed just a bare name, fall back to PATH lookup.
-        found = shutil.which(explicit)
+            candidates.append(explicit)
+        else:
+            found = shutil.which(explicit)
+            if found:
+                candidates.append(found)
+    if not candidates:
+        # Fall back to PATH lookup for the bare name.
+        found = shutil.which('httpx')
         if found:
-            return found
-        return None
-    return shutil.which('httpx')
+            candidates.append(found)
+    for path in candidates:
+        if _is_projectdiscovery_httpx(path):
+            return path
+    return None
 
 
 def process(command, channel, username, params, files, conn):
@@ -155,6 +198,22 @@ def process(command, channel, username, params, files, conn):
 
     binary = _resolve_binary()
     if not binary:
+        # Distinguish "nothing on PATH" from "wrong tool on PATH" so the
+        # operator gets actionable guidance.
+        on_path = shutil.which('httpx')
+        if on_path:
+            return {'messages': [{
+                'text': (
+                    f"httpx binary at `{on_path}` does NOT look like "
+                    "ProjectDiscovery httpx (`-version` probe failed). "
+                    "It's almost certainly the **Python httpx HTTP-client CLI** "
+                    "(installed by `pip install httpx[cli]` or pulled in as a "
+                    "transitive dep). Install ProjectDiscovery's separately — "
+                    "`go install github.com/projectdiscovery/httpx/cmd/httpx@latest` — "
+                    "and either put it earlier in `$PATH` or set `HTTPX_BIN` in "
+                    "`settings.py` to an absolute path."
+                )
+            }]}
         return {'messages': [{
             'text': (
                 "httpx binary not found. Install ProjectDiscovery httpx "


### PR DESCRIPTION
## Summary

Fixes the `@httpx` command in production. Follow-up to PR #201.

## Root cause

When `pip install httpx[cli]` runs (or any transitive dep pulls the **Python httpx HTTP-client library** with its `[cli]` extra), a script named `httpx` lands in the venv's `bin/`. `shutil.which('httpx')` finds the Python script first. Our argv shape (`-u <target> -json -tech-detect …`) is incompatible with the python httpx CLI (`httpx [OPTIONS] [METHOD] URL`), so subprocess fails or returns garbage and `@httpx` reports nothing useful.

Verified on the local mac during fix development:
```
$ shutil.which('httpx')
'/opt/homebrew/bin/httpx'
$ /opt/homebrew/bin/httpx -version
<argparse error — not the ProjectDiscovery binary>
```

## Fix

- **New helper `_is_projectdiscovery_httpx(path)`** runs `<path> -version` with a 5s timeout and checks the output for ProjectDiscovery signatures (`projectdiscovery` or `current version`). The Python httpx CLI doesn't recognise the single-dash `-version` flag and emits an argparse error containing neither signature → correctly rejected.

- **`_resolve_binary()`** now collects all candidates (operator-configured `HTTPX_BIN` first, then PATH lookup) and returns the first that passes the probe. Returns `None` when none of the candidates are ProjectDiscovery httpx.

- **`process()` distinguishes two failure modes:**
  1. Nothing named `httpx` on PATH at all → original "binary not found" message with install hint.
  2. Something named `httpx` on PATH **but probe rejected it** → new message naming the resolved path AND explaining the python-httpx[cli] collision explicitly, with fix steps (install PD's separately + reorder PATH or set `HTTPX_BIN`).

## Test plan

- [x] `py_compile` clean.
- [x] `_is_projectdiscovery_httpx()` smoke-tested against `/bin/sh`, `/bin/cat`, `/usr/bin/python3`, and a non-existent path — all correctly `False` without crashing.
- [x] `_resolve_binary()` on local mac correctly returns `None` (homebrew has python httpx[cli], not ProjectDiscovery's), so the new "wrong binary" message would fire.
- [x] 5s timeout on the probe so a hung binary can't stall module loading.
- [ ] Smoke test in the actual deployment:
  - `@httpx example.com` with **only python httpx[cli] on PATH** → expect new "wrong binary" message naming the path.
  - `@httpx example.com` with **ProjectDiscovery httpx installed** at e.g. `~/go/bin/httpx` and `HTTPX_BIN` pointed at it → expect normal probe output.
  - `@httpx example.com` with **no httpx anywhere** → original "binary not found" message with install hint.