### PR TITLE
watch: sanitise snippet in DM alert to prevent @-mention amplification

### DIFF
--- a/commands/watch/command.py
+++ b/commands/watch/command.py
@@ -288,11 +288,19 @@ def _send_alert(conn, myid, watcher_userid, watcher_keyword, post_data):
     if len(snippet) > settings.SNIPPET_CHARS:
         snippet = snippet[: settings.SNIPPET_CHARS] + "…"
 
+    # The snippet is another user's chat message. Without sanitisation, any
+    # channel user could embed `@channel`/`@here` in a post that triggers
+    # someone's watcher and the bot would faithfully render the mention as
+    # a live ping inside the DM alert. Strip backticks/pipes/newlines so
+    # the inline-code wrap below holds, then render inside it so Mattermost
+    # suppresses @-mentions and markdown-link interpretation.
+    safe_snippet = snippet.replace('`', '').replace('|', '/').replace('\n', ' ').replace('\r', '')
+
     text = (
         f"🔔 Watch hit: `{watcher_keyword}`\n"
         f"Channel: ~{post_data['channame']}\n"
         f"From:    @{post_data['author']}\n\n"
-        f"> {snippet}"
+        f"> `{safe_snippet}`"
     )
 
     try:


### PR DESCRIPTION
## Summary

Hotfix for a markdown-injection vulnerability in `commands/watch/_send_alert()` discovered during a cross-PR review of the in-flight `@command` feature batch (#211–#230).

## The bug

`_send_alert()` renders the literal text of the post that triggered a watcher as a Mattermost blockquote in the DM sent to the watcher:

```python
text = (
    f"🔔 Watch hit: `{watcher_keyword}`\n"
    f"Channel: ~{post_data['channame']}\n"
    f"From:    @{post_data['author']}\n\n"
    f"> {snippet}"
)
```

With no sanitisation, any user in a watched channel can post a message containing `@channel` / `@here` / `@username` (or `[click](url)`, RTL override unicode, etc.) that matches another user's watcher keyword. The bot then faithfully renders the mention as a live ping in the DM under the bot's trusted identity.

## Exploit

User A sets up `@watch <keyword>`. User B (or anyone) posts a message in any channel where the bot is present, containing both the keyword and `@channel`. User A's DM from the bot pings @channel. Generalises to arbitrary @-username pings and clickable phishing links targeting whoever set the watcher.

## Fix

Strip backticks/pipes/newlines from the snippet so the inline-code wrap holds, then render inside it. Mattermost suppresses @-mention and markdown-link interpretation inside inline code.

## Test plan

- [x] `py_compile` clean.
- [ ] Live test: set up a watcher, have another user post `@channel <keyword>`; confirm the DM alert renders `@channel` as plain text rather than as a live mention.

## Out of scope (follow-up)

Five more sites on `main` have the same bug class — `vulncheck`, `dnstwist`, `hackertarget`, `holehe`, plus the 8 in-flight PRs already patched. The cleaner fix is a shared `commands/_render.py` helper for `_cell()` + `_safe()` + fence neutralisation. Tracking separately; this PR is the immediate-priority hotfix for `watch` because it's the only site exploitable by any low-privilege chat user with no API content needed.