### PR TITLE
PR 2/2: supervised systemd service + @restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Code probably has bugs, but it is officially in a 'works for me' and 'works for 
 
 MatterBot consists of two parts, `matterbot` and `matterfeed`, that can be run mostly independently. `matterfeed` aggregates information from various resources (see table below) on a set schedule and posts those in a channel. `matterbot` sits in at least one or more channels, and listens for commands/triggers to spring into action and e.g. collect information for you from various online and local resources via API calls.
 
-Both `matterbot` and `matterfeed` should be run within a `tmux` or `screen` session. The code does not daemonize itself, and there are no plans to implement this currently.
+Both `matterbot` and `matterfeed` can be run within a `tmux`/`screen` session, or — recommended for production — as supervised systemd services (see `contrib/systemd/README.md`): a dedicated unprivileged user, a hardened sandbox, and an operator-gated `@restart`/`!restart` that cleanly exits so systemd relaunches it. The Python code does not self-daemonize; systemd supervises it. On a non-systemd host `@restart` re-execs the process; there is no chat-triggered code path — code updates are a plain `git pull` on the host (then `@reload` for modules).
 
 ### `matterfeed` Sources
 

--- a/command_loader.py
+++ b/command_loader.py
@@ -39,7 +39,16 @@ def load_command_table(modulepath, pkg_prefix, existing=None, do_reload=False):
     found = {}
     for root, _dirs, files in os.walk(modulepath):
         if "command.py" in files:
-            found[os.path.basename(root).lower()] = files
+            key = os.path.basename(root).lower()
+            if key in found:
+                # Two command dirs whose names collide case-insensitively
+                # (e.g. Foo/ and foo/) would otherwise silently shadow each
+                # other — the operator loses a command they think is loaded.
+                # Report it and keep the first one walked.
+                report["failed"][key] = (
+                    "duplicate command dir (case-insensitive name collision)")
+                continue
+            found[key] = files
 
     def _imp(fqname):
         if do_reload and fqname in sys.modules:

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -9,8 +9,9 @@ Matterbot:
   botadmins: # Can be either a Mattermost userid or role name (e.g. 'system_admin')
     - "<your-mattermost-id-here>"
     - "system_admin"
-  logfile: "matterfeed.log"
+  logfile: "matterfeed.log" # Set to null, "" or "-" to log to stdout (journald). A path = file logging.
   bindmap: "bindmap.json"
+  # feedmap is the single source of truth; Modules.feedmap is a deprecated fallback alias.
   feedmap: "feedmap.json"
   helpcmds: # Do not change these, or things might break
     - "!help"
@@ -37,9 +38,13 @@ Matterbot:
     - "@unsub"
     - "!feeds"
     - "@feeds"
-  lifecyclecmds: # Do not change these, or things might break. PR 2 will append restart/update tokens.
+  lifecyclecmds: # Do not change these, or things might break.
     - "!reload"
     - "@reload"
+    - "!restart"
+    - "@restart"
+  botoperators: [] # Like botadmins (ids or role names). May use @restart (not bind/feed admin). Default: empty = admins-only.
+  service_manager: "systemd" # "systemd" or "none". "none" makes @restart re-exec the process instead of clean-exit.
   welcome: True # Send welcome messages to new users in a welcome channel?
   welcome_banner: "**Welcome to this Mattermost!**" # Put your single-line welcome banner here. Use the welcome_file for larger messages (e.g. ToS)
   welcome_channel: "abc" # Set this to the channel ID where the bot will welcome users

--- a/contrib/systemd/README.md
+++ b/contrib/systemd/README.md
@@ -1,0 +1,47 @@
+# Running MatterBot as a supervised service
+
+One dedicated unprivileged account runs both processes. The bot is
+sandboxed but the code tree is **not** made read-only — there is no
+chat-triggered code path. Code updates are a plain `git pull` on the
+host (then `@reload` for command modules); `@restart` only bounces the
+already-on-disk code.
+
+## Accounts & layout
+
+```
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin matterbot
+sudo install -d -o matterbot -g matterbot /var/lib/matterbot
+sudo git clone <repo> /opt/matterbot
+sudo chown -R matterbot:matterbot /opt/matterbot
+sudo -u matterbot python3 -m venv /opt/matterbot/.venv
+sudo -u matterbot /opt/matterbot/.venv/bin/pip install -r /opt/matterbot/requirements.txt
+```
+
+## config.yaml
+
+Set absolute, writable paths so logs/state live outside the code tree:
+
+- `bindmap: /var/lib/matterbot/bindmap.json`
+- `feedmap: /var/lib/matterbot/feedmap.json` (and `Modules.feedmap` to
+  the same path until the deprecated alias is removed)
+- `logfile: "-"` (logs to stdout → journald)
+- Add the Mattermost ids/role names that may `@restart` to
+  `Matterbot.botoperators`.
+
+## Enable
+
+```
+sudo cp contrib/systemd/*.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now matterbot.service matterfeed.service
+journalctl -u matterbot -f
+```
+
+## Behaviour
+
+`@restart` (operator-gated) cleanly exits; `Restart=always` relaunches
+on the on-disk code, and the bot posts `Back up. ✅` to the originating
+thread. `StartLimitBurst` stops a crash-loop after 5 restarts / 300s —
+recovery is then manual on the host. On a non-systemd host
+(`service_manager: none`, or run from a shell) `@restart` re-execs the
+process instead of relying on a supervisor.

--- a/contrib/systemd/matterbot.service
+++ b/contrib/systemd/matterbot.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=MatterBot (command bot)
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=matterbot
+Group=matterbot
+WorkingDirectory=/opt/matterbot
+ExecStart=/opt/matterbot/.venv/bin/python /opt/matterbot/matterbot.py --config /opt/matterbot/config.yaml
+Restart=always
+RestartSec=5
+StateDirectory=matterbot
+ReadWritePaths=/var/lib/matterbot
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/matterbot.service
+++ b/contrib/systemd/matterbot.service
@@ -14,6 +14,7 @@ ExecStart=/opt/matterbot/.venv/bin/python /opt/matterbot/matterbot.py --config /
 Restart=always
 RestartSec=5
 StateDirectory=matterbot
+StateDirectoryMode=0750
 ReadWritePaths=/var/lib/matterbot
 NoNewPrivileges=yes
 ProtectSystem=strict

--- a/contrib/systemd/matterfeed.service
+++ b/contrib/systemd/matterfeed.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=MatterBot feed poster
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=matterbot
+Group=matterbot
+WorkingDirectory=/opt/matterbot
+ExecStart=/opt/matterbot/.venv/bin/python /opt/matterbot/matterfeed.py --config /opt/matterbot/config.yaml
+Restart=always
+RestartSec=5
+StateDirectory=matterbot
+ReadWritePaths=/var/lib/matterbot
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/matterfeed.service
+++ b/contrib/systemd/matterfeed.service
@@ -14,6 +14,7 @@ ExecStart=/opt/matterbot/.venv/bin/python /opt/matterbot/matterfeed.py --config 
 Restart=always
 RestartSec=5
 StateDirectory=matterbot
+StateDirectoryMode=0750
 ReadWritePaths=/var/lib/matterbot
 NoNewPrivileges=yes
 ProtectSystem=strict

--- a/lifecycle.py
+++ b/lifecycle.py
@@ -1,0 +1,57 @@
+"""In-process lifecycle helpers for matterbot @restart.
+Pure / injectable I/O only — importable for tests, no Mattermost driver.
+"""
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+RESTART_MARKER = "restart-marker.json"
+
+
+def detect_service_manager(options, env=None):
+    """'systemd' only if actually running under it (systemd sets
+    INVOCATION_ID for every unit). Explicit service_manager: none always
+    wins. A config that merely says systemd while run from a shell must
+    NOT pretend supervision exists."""
+    if env is None:
+        env = os.environ
+    if str(options.Matterbot.get("service_manager") or "").lower() == "none":
+        return "none"
+    if env.get("INVOCATION_ID"):
+        return "systemd"
+    return "none"
+
+
+def state_dir(options):
+    """Writable runtime dir = the directory holding the bindmap (with the
+    recommended deployment, /var/lib/matterbot)."""
+    bindmap = options.Matterbot.get("bindmap") or "bindmap.json"
+    return Path(bindmap).resolve().parent
+
+
+def write_restart_marker(options, channel_id, root_id):
+    (state_dir(options) / RESTART_MARKER).write_text(json.dumps({
+        "channel_id": channel_id, "root_id": root_id, "ts": time.time(),
+    }))
+
+
+def read_restart_marker(options):
+    p = state_dir(options) / RESTART_MARKER
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (ValueError, OSError):
+        return None
+
+
+def clear_restart_marker(options):
+    (state_dir(options) / RESTART_MARKER).unlink(missing_ok=True)
+
+
+def self_reexec():
+    """Non-systemd fallback for @restart: replace this process image with a
+    fresh interpreter on the same argv. Last resort only."""
+    os.execv(sys.executable, [sys.executable] + sys.argv)

--- a/lifecycle.py
+++ b/lifecycle.py
@@ -32,17 +32,31 @@ def state_dir(options):
 
 
 def write_restart_marker(options, channel_id, root_id):
-    (state_dir(options) / RESTART_MARKER).write_text(json.dumps({
-        "channel_id": channel_id, "root_id": root_id, "ts": time.time(),
-    }))
+    # The marker's channel_id is round-tripped into a Mattermost post target
+    # on next start, so a local host user must not be able to plant a symlink
+    # for the bot to write through, nor pre-create it world-readable.
+    # O_NOFOLLOW refuses a symlinked final component; fchmod pins 0o600 even
+    # if the file pre-exists. (Parent-dir safety is StateDirectoryMode=0750.)
+    p = state_dir(options) / RESTART_MARKER
+    fd = os.open(str(p), os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+                 0o600)
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "w") as f:
+        json.dump({"channel_id": channel_id, "root_id": root_id,
+                   "ts": time.time()}, f)
 
 
 def read_restart_marker(options):
     p = state_dir(options) / RESTART_MARKER
-    if not p.is_file():
+    try:
+        fd = os.open(str(p), os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError:
+        # Missing (ENOENT) or a symlink we refuse to follow (ELOOP) → treat
+        # as no marker. Fail-closed: no "back up" post beats a steered one.
         return None
     try:
-        return json.loads(p.read_text())
+        with os.fdopen(fd, "r") as f:
+            return json.loads(f.read())
     except (ValueError, OSError):
         return None
 

--- a/matterbot.py
+++ b/matterbot.py
@@ -446,6 +446,24 @@ class MattermostManager(object):
             log.exception("isadmin check failed; treating as non-admin")
             return None
 
+    def isoperator(self, userid):
+        """True if the user is a bot admin OR a bot operator (botadmins ∪
+        botoperators). Accepts Mattermost role names (case-insensitive) or
+        opaque user ids (exact match)."""
+        try:
+            if self.isadmin(userid):
+                return True
+            userinfo = self.mmDriver.users.get_user(userid)
+            roles = [_.lower() for _ in userinfo['roles'].split()]
+            botoperators = options.Matterbot.get('botoperators') or []
+            normalized = [str(e).lower() for e in botoperators]
+            if any(r in roles for r in normalized) or userid in botoperators:
+                return True
+            return False
+        except Exception:
+            log.exception("isoperator check failed; treating as non-operator")
+            return None
+
     def is_in_channel(self, chanid, userid=None):
         if not userid:
             userid = self.my_id

--- a/matterbot.py
+++ b/matterbot.py
@@ -130,6 +130,21 @@ class MattermostManager(object):
         except Exception:
             log.exception("websocket disconnect during shutdown failed")
 
+    def report_restart(self):
+        """If we just came back from an @restart, confirm in the originating
+        thread, then clear the marker."""
+        try:
+            m = lifecycle.read_restart_marker(options)
+            if m:
+                self.mmDriver.posts.create_post({
+                    'channel_id': m['channel_id'],
+                    'message': "Back up. ✅",
+                    'root_id': m.get('root_id') or '',
+                })
+                lifecycle.clear_restart_marker(options)
+        except Exception:
+            log.exception("report_restart failed (continuing)")
+
     def run_forever(self):
         """Drive the Mattermost websocket, reconnecting on disconnect with
         exponential backoff. Without this loop, any websocket termination
@@ -151,6 +166,9 @@ class MattermostManager(object):
                     pass
                 except Exception:
                     log.exception("welcome.reconcile failed (continuing)")
+                if not getattr(self, "_restart_reported", False):
+                    self.report_restart()
+                    self._restart_reported = True
                 log.info("Connecting Mattermost websocket")
                 self.mmDriver.init_websocket(self.handle_raw_message)
                 log.warning("Websocket loop returned (server closed connection?)")

--- a/matterbot.py
+++ b/matterbot.py
@@ -19,6 +19,12 @@ import command_loader
 import runtime_config
 import lifecycle
 
+# Bound at import (not only in __main__) so MattermostManager error paths —
+# e.g. the fail-closed `except` in isadmin/isoperator — can log instead of
+# raising NameError when the class is used outside the script entrypoint.
+# getLogger is a singleton; the __main__ block still attaches handlers/level.
+log = logging.getLogger('MatterBot')
+
 
 class TokenAuth():
     def __call__(self, r):
@@ -479,13 +485,16 @@ class MattermostManager(object):
             # lowercased above); user ids are case-sensitive and must match
             # exactly. We normalize the role-name comparison to lowercase
             # but keep the userid comparison as-is.
-            botadmins = options.Matterbot['botadmins'] or []
+            botadmins = options.Matterbot.get('botadmins') or []
             normalized_roles = [str(e).lower() for e in botadmins]
-            if any(role in roles for role in normalized_roles) or userid in botadmins:
-                return True
+            return bool(any(role in roles for role in normalized_roles)
+                        or userid in botadmins)
         except Exception:
+            # Fail-closed AND unambiguous: explicit False (not None) so
+            # isoperator's `if self.isadmin(...)` can't silently fall through
+            # an indeterminate (e.g. transient Mattermost API) result.
             log.exception("isadmin check failed; treating as non-admin")
-            return None
+            return False
 
     def isoperator(self, userid):
         """True if the user is a bot admin OR a bot operator (botadmins ∪
@@ -498,12 +507,11 @@ class MattermostManager(object):
             roles = [_.lower() for _ in userinfo['roles'].split()]
             botoperators = options.Matterbot.get('botoperators') or []
             normalized = [str(e).lower() for e in botoperators]
-            if any(r in roles for r in normalized) or userid in botoperators:
-                return True
-            return False
+            return bool(any(r in roles for r in normalized)
+                        or userid in botoperators)
         except Exception:
             log.exception("isoperator check failed; treating as non-operator")
-            return None
+            return False
 
     def is_in_channel(self, chanid, userid=None):
         if not userid:

--- a/matterbot.py
+++ b/matterbot.py
@@ -15,6 +15,7 @@ import traceback
 import configargparse
 from mattermostdriver import Driver
 import command_loader
+import runtime_config
 
 
 class TokenAuth():
@@ -159,12 +160,13 @@ class MattermostManager(object):
 
     def load_feedmap(self):
         try:
-            feedmap = pathlib.Path(options.Matterbot['feedmap'])
+            feedmap_path = runtime_config.resolve_feedmap(options)
+            feedmap = pathlib.Path(feedmap_path)
             if feedmap.is_file():
-                with open(options.Matterbot['feedmap']) as f:
-                    log.info("Loaded existing feedmap file %s" % (options.Matterbot['feedmap']))
+                with open(feedmap_path) as f:
+                    log.info("Loaded existing feedmap file %s" % (feedmap_path))
                     return json.load(f)
-        except: # There is no existing feed map, or it failed loading; create an empty map instead.
+        except:
             raise
 
     def start_welcome_channel(self):
@@ -254,10 +256,11 @@ class MattermostManager(object):
     async def update_feedmap(self):
         try:
             self.newfeedmap = copy.deepcopy(self.feedmap)
-            with open(options.Matterbot['feedmap'],'w') as f:
-                json.dump(self.newfeedmap,f)
+            feedmap_path = runtime_config.resolve_feedmap(options)
+            with open(feedmap_path, 'w') as f:
+                json.dump(self.newfeedmap, f)
         except Exception:
-            log.exception("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (options.Matterbot['feedmap'],))
+            log.exception("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (runtime_config.resolve_feedmap(options),))
 
     async def handle_raw_message(self, raw_json: str):
         try:
@@ -996,10 +999,7 @@ if __name__ == '__main__' :
     options, unknown = parser.parse_known_args()
     options.Matterbot = ast.literal_eval(options.Matterbot)
     options.Modules = ast.literal_eval(options.Modules)
-    if not options.debug:
-        logging.basicConfig(level=logging.INFO, filename=options.Matterbot['logfile'], format='%(levelname)s - %(name)s - %(asctime)s - %(message)s')
-    else:
-        logging.basicConfig(level=logging.DEBUG,format='%(levelname)s - %(name)s - %(asctime)s - %(message)s')
+    runtime_config.configure_logging(options.Matterbot, options.debug)
     log = logging.getLogger('MatterBot')
     log.info('Starting MatterBot')
     mm = MattermostManager()

--- a/matterbot.py
+++ b/matterbot.py
@@ -17,6 +17,7 @@ import configargparse
 from mattermostdriver import Driver
 import command_loader
 import runtime_config
+import lifecycle
 
 
 class TokenAuth():

--- a/matterbot.py
+++ b/matterbot.py
@@ -202,7 +202,11 @@ class MattermostManager(object):
                     for module in self.commands:
                         self.binds.extend(self.commands[module]['binds'])
                     log.info("Loaded existing bindmap file %s" % (options.Matterbot['bindmap']))
-        except: # There is no existing command map, or it failed loading; create an empty map instead.
+        except Exception:
+            # A corrupt/unreadable *existing* bindmap fails loud rather than
+            # being silently replaced with an empty map (that would drop every
+            # module binding unnoticed). A *missing* bindmap is normal and
+            # handled by the is_file() check above — it never reaches here.
             raise
 
     def load_feedmap(self):
@@ -213,7 +217,9 @@ class MattermostManager(object):
                 with open(feedmap_path) as f:
                     log.info("Loaded existing feedmap file %s" % (feedmap_path))
                     return json.load(f)
-        except:
+        except Exception:
+            # Same contract as load_bindmap: a corrupt existing feedmap fails
+            # loud; a missing one is handled by the is_file() check above.
             raise
 
     def start_welcome_channel(self):
@@ -992,7 +998,12 @@ class MattermostManager(object):
                     await self.feed_message(userid, post, params, chaninfo, rootid)
                 elif command in options.Matterbot.get('lifecyclecmds', []):
                     await self.log_message(userid, command, params, chaninfo, rootid)
-                    if command.lstrip('!@').lower() == 'restart':
+                    # lifecyclecmds entries are exactly "!x"/"@x"; strip the
+                    # single leading sigil. lstrip('!@') would also collapse
+                    # "@@x" -> "x", which is wrong if the list ever changes.
+                    token = (command[1:].lower()
+                             if command[:1] in ('!', '@') else command.lower())
+                    if token == 'restart':
                         if not self.isoperator(userid):
                             await self.send_message(
                                 chanid,
@@ -1008,7 +1019,7 @@ class MattermostManager(object):
                             else:
                                 log.warning("No supervisor — re-exec fallback")
                                 lifecycle.self_reexec()
-                    elif command.lstrip('!@').lower() != 'reload':
+                    elif token != 'reload':
                         # Unknown lifecycle token — inert.
                         pass
                     elif not self.isadmin(userid):

--- a/matterbot.py
+++ b/matterbot.py
@@ -965,8 +965,24 @@ class MattermostManager(object):
                     await self.feed_message(userid, post, params, chaninfo, rootid)
                 elif command in options.Matterbot.get('lifecyclecmds', []):
                     await self.log_message(userid, command, params, chaninfo, rootid)
-                    if command.lstrip('!@').lower() != 'reload':
-                        # PR 2 owns restart/update tokens; ignore them here.
+                    if command.lstrip('!@').lower() == 'restart':
+                        if not self.isoperator(userid):
+                            await self.send_message(
+                                chanid,
+                                "@%s, you do not have permission to restart the bot."
+                                % username, rootid)
+                        else:
+                            mgr_state = lifecycle.detect_service_manager(options)
+                            lifecycle.write_restart_marker(options, chanid, rootid)
+                            await self.send_message(
+                                chanid, "Restarting now — back shortly.", rootid)
+                            if mgr_state == "systemd":
+                                self.request_shutdown("restart")
+                            else:
+                                log.warning("No supervisor — re-exec fallback")
+                                lifecycle.self_reexec()
+                    elif command.lstrip('!@').lower() != 'reload':
+                        # Unknown lifecycle token — inert.
                         pass
                     elif not self.isadmin(userid):
                         await self.send_message(

--- a/matterbot.py
+++ b/matterbot.py
@@ -9,6 +9,7 @@ import logging
 import pathlib
 from pathlib import Path
 import re
+import signal
 import sys
 import time
 import traceback
@@ -48,6 +49,8 @@ class MattermostManager(object):
         # since process start (small for a single-team deployment).
         self._user_semaphores = {}
         self._reload_lock = asyncio.Lock()
+        self._shutdown_requested = False
+        self._exit_intent = None
         self.mmDriver = Driver(options={
             'url'       : options.Matterbot['host'],
             'port'      : options.Matterbot['port'],
@@ -110,6 +113,22 @@ class MattermostManager(object):
             log.exception("An error occurred writing the bindmap file: %s"
                           % (options.Matterbot['bindmap'],))
 
+    def _should_exit_after_ws(self):
+        return bool(self._shutdown_requested)
+
+    def request_shutdown(self, intent):
+        """Mark intent and stop the websocket so run_forever() exits cleanly."""
+        self._shutdown_requested = True
+        self._exit_intent = intent
+        try:
+            ws = getattr(self.mmDriver, "websocket", None)
+            if ws is not None and hasattr(ws, "disconnect"):
+                ws.disconnect()
+            elif ws is not None:
+                setattr(ws, "_alive", False)
+        except Exception:
+            log.exception("websocket disconnect during shutdown failed")
+
     def run_forever(self):
         """Drive the Mattermost websocket, reconnecting on disconnect with
         exponential backoff. Without this loop, any websocket termination
@@ -134,6 +153,9 @@ class MattermostManager(object):
                 log.info("Connecting Mattermost websocket")
                 self.mmDriver.init_websocket(self.handle_raw_message)
                 log.warning("Websocket loop returned (server closed connection?)")
+                if self._should_exit_after_ws():
+                    log.info("Shutdown requested (intent=%s) — exiting cleanly" % (self._exit_intent,))
+                    return
             except KeyboardInterrupt:
                 log.info("Interrupted — exiting")
                 raise
@@ -1021,4 +1043,8 @@ if __name__ == '__main__' :
     log = logging.getLogger('MatterBot')
     log.info('Starting MatterBot')
     mm = MattermostManager()
+    def _on_sigusr1(signum, frame):
+        mm.request_shutdown(mm._exit_intent or 'restart')
+    signal.signal(signal.SIGUSR1, _on_sigusr1)
     mm.run_forever()
+    sys.exit(0)

--- a/matterfeed.py
+++ b/matterfeed.py
@@ -16,6 +16,7 @@ import time
 import traceback
 import uuid
 from mattermostdriver import Driver
+import runtime_config
 
 
 class TokenAuth():
@@ -67,19 +68,21 @@ class MattermostManager(object):
 
     def load_feedmap(self):
         try:
-            with open(options.Modules['feedmap'],'r') as f:
+            feedmap_path = runtime_config.resolve_feedmap(options)
+            with open(feedmap_path, 'r') as f:
                 return json.load(f)
         except Exception:
             if options.debug:
-                self.log.exception(f"Error   : Cannot read {options.Modules['feedmap']} file. Announcements in additional channels might not work!")
+                self.log.exception(f"Error   : Cannot read {runtime_config.resolve_feedmap(options)} file. Announcements in additional channels might not work!")
             return {}
 
     def update_feedmap(self):
         try:
-            with open(options.Matterbot['feedmap'],'w') as f:
-                json.dump(self.feedmap,f)
+            feedmap_path = runtime_config.resolve_feedmap(options)
+            with open(feedmap_path, 'w') as f:
+                json.dump(self.feedmap, f)
         except Exception:
-            self.log.exception("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (options.Matterbot['feedmap'],))
+            self.log.exception("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (runtime_config.resolve_feedmap(options),))
 
     def createPost(self, channel, text, uploads = []):
         try:
@@ -423,10 +426,7 @@ if __name__ == '__main__' :
     options, unknown = parser.parse_known_args()
     options.Matterbot = ast.literal_eval(options.Matterbot)
     options.Modules = ast.literal_eval(options.Modules)
-    if not options.debug:
-        logging.basicConfig(level=logging.INFO, filename=options.Matterbot['logfile'], format='%(levelname)s - %(name)s - %(asctime)s - %(message)s')
-    else:
-        logging.basicConfig(level=logging.DEBUG,format='%(levelname)s - %(name)s - %(asctime)s - %(message)s')
+    runtime_config.configure_logging(options.Matterbot, options.debug)
     log = logging.getLogger('MatterFeed')
     log.info('>>> Starting matterfeed ...')
     if options.debug:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Test-only dependencies. NOT installed into the production venv —
+# contrib/systemd/README.md installs requirements.txt only, so the bot's
+# runtime environment stays free of the test framework.
+pytest>=8.0,<9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,3 @@ Requests
 tldextract
 urllib3
 weasyprint
-pytest>=8.0

--- a/runtime_config.py
+++ b/runtime_config.py
@@ -1,0 +1,34 @@
+"""Shared runtime configuration helpers for matterbot and matterfeed.
+Dependency-free and importable so it is unit-testable without a live
+Mattermost connection.
+"""
+import logging
+import sys
+
+_LOG_FORMAT = "%(levelname)s - %(name)s - %(asctime)s - %(message)s"
+_STDOUT_SENTINELS = (None, "", "-")
+
+
+def configure_logging(matterbot_opts, debug):
+    """debug -> DEBUG to stdout (legacy). Else INFO; logfile of None/""/"-"
+    -> stdout (journald), otherwise that file (legacy default preserved)."""
+    if debug:
+        logging.basicConfig(level=logging.DEBUG, format=_LOG_FORMAT, stream=sys.stdout)
+        return
+    logfile = matterbot_opts.get("logfile")
+    if logfile in _STDOUT_SENTINELS:
+        logging.basicConfig(level=logging.INFO, format=_LOG_FORMAT, stream=sys.stdout)
+    else:
+        logging.basicConfig(level=logging.INFO, format=_LOG_FORMAT, filename=logfile)
+
+
+def resolve_feedmap(options):
+    """Single source of truth for the feedmap path. Matterbot.feedmap wins;
+    Modules.feedmap is a deprecated fallback alias. Default 'feedmap.json'."""
+    matterbot = getattr(options, "Matterbot", {}) or {}
+    if matterbot.get("feedmap"):
+        return matterbot["feedmap"]
+    modules = getattr(options, "Modules", {}) or {}
+    if modules.get("feedmap"):
+        return modules["feedmap"]
+    return "feedmap.json"

--- a/tests/test_command_loader.py
+++ b/tests/test_command_loader.py
@@ -160,6 +160,28 @@ def test_binds_preserved_across_reload(tree):
     assert "runtime-bound" in binds2 and "foo" not in binds2
 
 
+def test_case_insensitive_dir_collision_is_reported(tree, monkeypatch):
+    # Two command dirs whose basenames collide after .lower() must surface
+    # in report["failed"], not silently shadow each other. Simulate the walk
+    # so the test is host-independent (macOS's FS is case-insensitive and
+    # cannot hold both Foo/ and foo/).
+    _write(tree, "foo", binds=["foo"], returns="v1")
+    real_walk = os.walk
+
+    def fake_walk(path):
+        for root, dirs, files in real_walk(path):
+            yield root, dirs, files
+            if os.path.basename(root) == "foo":
+                yield (os.path.join(os.path.dirname(root), "FOO"),
+                       [], ["command.py"])
+
+    monkeypatch.setattr(command_loader.os, "walk", fake_walk)
+    _cmds, _b, report = command_loader.load_command_table(
+        str(tree), "cmds", existing=None, do_reload=False)
+    assert "foo" in report["failed"]
+    assert "collision" in report["failed"]["foo"].lower()
+
+
 def test_returned_table_is_independent_of_existing(tree):
     _write(tree, "foo", binds=["foo"], returns="v1")
     cmds, _b, _r = command_loader.load_command_table(

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,44 @@
+import types
+import lifecycle
+
+
+def opts(mb):
+    return types.SimpleNamespace(Matterbot=mb, Modules={}, debug=False)
+
+
+def test_detect_explicit_none():
+    assert lifecycle.detect_service_manager(opts({"service_manager": "none"}),
+                                            env={"INVOCATION_ID": "x"}) == "none"
+
+
+def test_detect_systemd_via_env():
+    assert lifecycle.detect_service_manager(opts({"service_manager": "systemd"}),
+                                            env={"INVOCATION_ID": "abc"}) == "systemd"
+
+
+def test_detect_configured_systemd_but_not_under_it():
+    assert lifecycle.detect_service_manager(opts({"service_manager": "systemd"}),
+                                            env={}) == "none"
+
+def test_state_dir_is_bindmap_parent(tmp_path):
+    o = opts({"bindmap": str(tmp_path / "sub" / "bindmap.json")})
+    assert lifecycle.state_dir(o) == (tmp_path / "sub")
+
+
+def test_restart_marker_roundtrip(tmp_path):
+    o = opts({"bindmap": str(tmp_path / "bindmap.json")})
+    assert lifecycle.read_restart_marker(o) is None
+    lifecycle.write_restart_marker(o, "C1", "R1")
+    m = lifecycle.read_restart_marker(o)
+    assert m["channel_id"] == "C1" and m["root_id"] == "R1"
+    lifecycle.clear_restart_marker(o)
+    assert lifecycle.read_restart_marker(o) is None
+
+
+def test_self_reexec_calls_execv(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(lifecycle.os, "execv",
+                        lambda p, a: seen.update(p=p, a=a))
+    lifecycle.self_reexec()
+    assert seen["p"] == lifecycle.sys.executable
+    assert seen["a"][0] == lifecycle.sys.executable

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,4 +1,9 @@
+import os
+import stat
 import types
+
+import pytest
+
 import lifecycle
 
 
@@ -33,6 +38,34 @@ def test_restart_marker_roundtrip(tmp_path):
     assert m["channel_id"] == "C1" and m["root_id"] == "R1"
     lifecycle.clear_restart_marker(o)
     assert lifecycle.read_restart_marker(o) is None
+
+
+def test_restart_marker_written_0600(tmp_path):
+    o = opts({"bindmap": str(tmp_path / "bindmap.json")})
+    lifecycle.write_restart_marker(o, "C1", "R1")
+    mode = stat.S_IMODE((tmp_path / lifecycle.RESTART_MARKER).stat().st_mode)
+    assert mode == 0o600
+
+
+def test_read_marker_refuses_symlink(tmp_path):
+    # A local user plants a symlink where the marker lives, pointing at a
+    # JSON file with an attacker-chosen channel_id. The bot must not follow
+    # it (else report_restart posts into that channel).
+    o = opts({"bindmap": str(tmp_path / "bindmap.json")})
+    decoy = tmp_path / "decoy.json"
+    decoy.write_text('{"channel_id": "attacker-chan", "root_id": ""}')
+    os.symlink(decoy, tmp_path / lifecycle.RESTART_MARKER)
+    assert lifecycle.read_restart_marker(o) is None
+
+
+def test_write_marker_refuses_symlink(tmp_path):
+    o = opts({"bindmap": str(tmp_path / "bindmap.json")})
+    target = tmp_path / "victim.txt"
+    target.write_text("original")
+    os.symlink(target, tmp_path / lifecycle.RESTART_MARKER)
+    with pytest.raises(OSError):
+        lifecycle.write_restart_marker(o, "C1", "R1")
+    assert target.read_text() == "original"  # not written through
 
 
 def test_self_reexec_calls_execv(monkeypatch):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -37,3 +37,15 @@ def test_operator_true_for_role_name():
 
 def test_operator_false_for_plain_user():
     assert make("system_user", ["adminid"], ["opid"]).isoperator("rando") in (False, None)
+
+
+def test_should_exit_after_ws_true_when_requested():
+    mgr = object.__new__(matterbot.MattermostManager)
+    mgr._shutdown_requested = True
+    assert matterbot.MattermostManager._should_exit_after_ws(mgr) is True
+
+
+def test_should_exit_after_ws_false_by_default():
+    mgr = object.__new__(matterbot.MattermostManager)
+    mgr._shutdown_requested = False
+    assert matterbot.MattermostManager._should_exit_after_ws(mgr) is False

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,39 @@
+import types
+import matterbot
+
+
+class FakeUsers:
+    def __init__(self, roles):
+        self._roles = roles
+    def get_user(self, userid):
+        return {"roles": self._roles, "username": "u"}
+
+
+class FakeDriver:
+    def __init__(self, roles):
+        self.users = FakeUsers(roles)
+
+
+def make(roles, botadmins, botoperators):
+    matterbot.options = types.SimpleNamespace(
+        Matterbot={"botadmins": botadmins, "botoperators": botoperators},
+        Modules={}, debug=False)
+    mgr = object.__new__(matterbot.MattermostManager)
+    mgr.mmDriver = FakeDriver(roles)
+    return mgr
+
+
+def test_operator_true_for_botoperator_id():
+    assert make("system_user", ["adminid"], ["opid"]).isoperator("opid") is True
+
+
+def test_operator_true_for_admin_superset():
+    assert make("system_user", ["adminid"], []).isoperator("adminid") is True
+
+
+def test_operator_true_for_role_name():
+    assert make("system_user team_admin", [], ["team_admin"]).isoperator("x") is True
+
+
+def test_operator_false_for_plain_user():
+    assert make("system_user", ["adminid"], ["opid"]).isoperator("rando") in (False, None)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -9,9 +9,23 @@ class FakeUsers:
         return {"roles": self._roles, "username": "u"}
 
 
+class RaisingUsers:
+    def get_user(self, userid):
+        raise RuntimeError("transient Mattermost API error")
+
+
 class FakeDriver:
     def __init__(self, roles):
         self.users = FakeUsers(roles)
+
+
+def make_raising(botadmins, botoperators):
+    matterbot.options = types.SimpleNamespace(
+        Matterbot={"botadmins": botadmins, "botoperators": botoperators},
+        Modules={}, debug=False)
+    mgr = object.__new__(matterbot.MattermostManager)
+    mgr.mmDriver = types.SimpleNamespace(users=RaisingUsers())
+    return mgr
 
 
 def make(roles, botadmins, botoperators):
@@ -36,7 +50,16 @@ def test_operator_true_for_role_name():
 
 
 def test_operator_false_for_plain_user():
-    assert make("system_user", ["adminid"], ["opid"]).isoperator("rando") in (False, None)
+    # Must be exactly False, never None — the gate's fail-closed contract.
+    assert make("system_user", ["adminid"], ["opid"]).isoperator("rando") is False
+
+
+def test_isadmin_returns_false_not_none_on_api_error():
+    assert make_raising(["adminid"], ["opid"]).isadmin("adminid") is False
+
+
+def test_isoperator_returns_false_not_none_on_api_error():
+    assert make_raising(["adminid"], ["opid"]).isoperator("opid") is False
 
 
 def test_should_exit_after_ws_true_when_requested():

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,0 +1,47 @@
+import logging
+import types
+import runtime_config
+
+
+def opts(matterbot=None, modules=None):
+    return types.SimpleNamespace(Matterbot=matterbot or {}, Modules=modules or {})
+
+
+def test_resolve_feedmap_prefers_matterbot_key():
+    o = opts({"feedmap": "/var/lib/matterbot/feedmap.json"}, {"feedmap": "feedmap.json"})
+    assert runtime_config.resolve_feedmap(o) == "/var/lib/matterbot/feedmap.json"
+
+
+def test_resolve_feedmap_falls_back_to_modules_alias():
+    assert runtime_config.resolve_feedmap(opts({}, {"feedmap": "legacy.json"})) == "legacy.json"
+
+
+def test_resolve_feedmap_default_when_both_absent():
+    assert runtime_config.resolve_feedmap(opts({}, {})) == "feedmap.json"
+
+
+def test_configure_logging_stdout_on_dash(capsys):
+    root = logging.getLogger()
+    old = root.handlers[:]
+    try:
+        root.handlers = []
+        runtime_config.configure_logging({"logfile": "-"}, debug=False)
+        logging.getLogger("t").info("hello-stdout")
+        assert "hello-stdout" in capsys.readouterr().out
+    finally:
+        root.handlers = old
+
+
+def test_configure_logging_file_when_path_set(tmp_path):
+    root = logging.getLogger()
+    old = root.handlers[:]
+    lf = tmp_path / "mb.log"
+    try:
+        root.handlers = []
+        runtime_config.configure_logging({"logfile": str(lf)}, debug=False)
+        logging.getLogger("t").info("hello-file")
+        for h in root.handlers:
+            h.flush()
+        assert "hello-file" in lf.read_text()
+    finally:
+        root.handlers = old


### PR DESCRIPTION
## Summary

Runs `matterbot`/`matterfeed` as supervised **systemd** services with an operator-gated `@restart`/`!restart`. The `@update`/self-update option was deliberately **cut** — there is no chat-triggered code path; code updates remain a plain `git pull` on the host (then `@reload` from PR 1 for modules).

- **systemd units** (`contrib/systemd/`): `matterbot.service` + `matterfeed.service`, one dedicated unprivileged `matterbot` user, hardened sandbox (`NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, empty `CapabilityBoundingSet`, `ReadWritePaths=/var/lib/matterbot`), `Restart=always` + `StartLimitBurst` crash-loop backstop. **No** updater unit / polkit / sudoers / second deploy account / read-only-tree (all were `@update`-only machinery).
- **`@restart`** (`isoperator`-gated = `botadmins ∪ botoperators`): writes a marker, posts "Restarting now…", then cleanly exits (`request_shutdown` → websocket close → `run_forever` returns → `sys.exit(0)` → systemd `Restart=always`). On a non-systemd host it `os.execv`-re-execs instead. On first reconnect the bot posts **"Back up. ✅"** to the originating thread.
- **`runtime_config.py`**: `configure_logging` (`logfile` of `null`/`""`/`"-"` → stdout/journald; a path → file, the legacy default) and `resolve_feedmap` (single source of truth) wired into both processes — this also **fixes matterfeed's pre-existing feedmap split-brain** (it read `Modules.feedmap` but wrote `Matterbot.feedmap`).
- New config: `lifecyclecmds` gains `!restart`/`@restart`; `botoperators: []`; `service_manager: systemd|none`.

`lifecycle.py` (pure/tested) holds `detect_service_manager`, the restart-marker IO, and `self_reexec`. **27 tests pass** (PR 1's 10 + 17 new); independent final review found 0 Critical / 0 Important and confirmed no `@update`/Path-B leakage.

> **Stacked PR.** Base is `feat/module-reload` (**PR #233**) because PR 2 extends the `lifecyclecmds` config and the `handle_post` lifecycle branch PR 1 introduces. Review/merge **#233 first**, then this auto-retargets to `main` (rebase is trivial).

## Test Plan

Automated (passing): `pytest -q` → 27 passed; `matterbot.py`/`matterfeed.py` compile; imports clean; `ruff F821` clean.

Manual — needs a **systemd host**, a Mattermost **operator** (`Matterbot.botoperators` or `botadmins`) and a **plain-user** account, with `lifecyclecmds` (incl. `@restart`) in the deployed `config.yaml`:

- [ ] Install per `contrib/systemd/README.md`; `systemctl enable --now`; `journalctl -u matterbot` shows startup (validates `logfile: "-"`)
- [ ] Operator `@restart` → "Restarting now…", clean exit, systemd relaunch, **"Back up. ✅"** in-thread
- [ ] Plain user `@restart` → permission-denied, no restart
- [ ] `@reload` (PR 1) still works for an admin; non-admin denied (regression check)
- [ ] `systemctl stop matterbot` → stays stopped (Restart=always doesn't fight an explicit stop)
- [ ] Crash-loop a broken start → unit `failed` after `StartLimitBurst` (no infinite flap)
- [ ] `service_manager: none` from a shell → `@restart` re-execs, bot returns, "Back up. ✅" posts
