### PR TITLE
feat: add legacy response contract validator

### DIFF
--- a/matterbot_contracts.py
+++ b/matterbot_contracts.py
@@ -1,0 +1,76 @@
+"""Contract helpers for MatterBot module responses.
+
+These helpers are intentionally dependency-free so they can be used by tests,
+future diagnostics, and eventually PR27 structured-output migration work without
+pulling in Mattermost or any command module dependencies.
+"""
+
+
+def validate_legacy_response(result):
+    """Return a list of contract errors for the legacy module response shape.
+
+    Valid legacy command modules return either ``None`` for no output or a dict
+    shaped like ``{'messages': [{'text': '...'}]}``. Messages may optionally
+    include an ``uploads`` list, where each upload contains ``filename`` and
+    ``bytes`` keys. This validator reports all obvious shape errors instead of
+    raising so callers can show useful diagnostics.
+    """
+    if result is None:
+        return []
+
+    if not isinstance(result, dict):
+        return ["response must be a dict or None"]
+
+    if "messages" not in result or not isinstance(result.get("messages"), list):
+        if "messages" not in result:
+            return ["response missing required 'messages' list"]
+        return ["response 'messages' must be a list"]
+
+    errors = []
+    for message_index, message in enumerate(result["messages"]):
+        prefix = f"messages[{message_index}]"
+        if not isinstance(message, dict):
+            errors.append(f"{prefix} must be a dict")
+            continue
+
+        if "text" not in message and "uploads" not in message:
+            errors.append(f"{prefix} must contain 'text' or 'uploads'")
+
+        if "text" in message and not isinstance(message["text"], str):
+            errors.append(f"{prefix}.text must be a string")
+
+        if "uploads" in message:
+            errors.extend(_validate_uploads(message["uploads"], f"{prefix}.uploads"))
+
+    return errors
+
+
+def is_valid_legacy_response(result):
+    """Return True when ``result`` satisfies the legacy response contract."""
+    return not validate_legacy_response(result)
+
+
+def _validate_uploads(uploads, prefix):
+    if uploads is None:
+        return []
+
+    if not isinstance(uploads, list):
+        return [f"{prefix} must be a list or None"]
+
+    errors = []
+    for upload_index, upload in enumerate(uploads):
+        upload_prefix = f"{prefix}[{upload_index}]"
+        if not isinstance(upload, dict):
+            errors.append(f"{upload_prefix} must be a dict")
+            continue
+
+        filename = upload.get("filename")
+        if not isinstance(filename, str) or not filename:
+            errors.append(f"{upload_prefix}.filename must be a non-empty string")
+
+        if "bytes" not in upload:
+            errors.append(f"{upload_prefix} missing required 'bytes'")
+        elif not isinstance(upload["bytes"], (bytes, bytearray, str)):
+            errors.append(f"{upload_prefix}.bytes must be bytes, bytearray, or string")
+
+    return errors

--- a/tests/test_response_contracts.py
+++ b/tests/test_response_contracts.py
@@ -1,0 +1,78 @@
+import unittest
+
+from matterbot_contracts import is_valid_legacy_response, validate_legacy_response
+
+
+class LegacyResponseContractTests(unittest.TestCase):
+    def test_none_is_valid_noop_response(self):
+        self.assertEqual([], validate_legacy_response(None))
+        self.assertTrue(is_valid_legacy_response(None))
+
+    def test_minimal_legacy_message_is_valid(self):
+        result = {"messages": [{"text": "ok"}]}
+        self.assertEqual([], validate_legacy_response(result))
+
+    def test_upload_message_is_valid(self):
+        result = {
+            "messages": [
+                {
+                    "text": "attached",
+                    "uploads": [{"filename": "report.txt", "bytes": "hello"}],
+                }
+            ]
+        }
+        self.assertEqual([], validate_legacy_response(result))
+
+    def test_result_must_be_dict_or_none(self):
+        self.assertEqual(["response must be a dict or None"], validate_legacy_response("bad"))
+
+    def test_messages_key_is_required(self):
+        self.assertEqual(["response missing required 'messages' list"], validate_legacy_response({}))
+
+    def test_messages_must_be_list(self):
+        self.assertEqual(["response 'messages' must be a list"], validate_legacy_response({"messages": "bad"}))
+
+    def test_message_must_be_dict(self):
+        self.assertEqual(["messages[0] must be a dict"], validate_legacy_response({"messages": ["bad"]}))
+
+    def test_text_must_be_string_when_present(self):
+        self.assertEqual(
+            ["messages[0].text must be a string"],
+            validate_legacy_response({"messages": [{"text": 123}]}),
+        )
+
+    def test_message_needs_text_or_uploads(self):
+        self.assertEqual(
+            ["messages[0] must contain 'text' or 'uploads'"],
+            validate_legacy_response({"messages": [{}]}),
+        )
+
+    def test_uploads_must_be_list_or_none(self):
+        self.assertEqual(
+            ["messages[0].uploads must be a list or None"],
+            validate_legacy_response({"messages": [{"text": "x", "uploads": "bad"}]}),
+        )
+
+    def test_upload_must_have_filename_and_bytes(self):
+        self.assertEqual(
+            [
+                "messages[0].uploads[0].filename must be a non-empty string",
+                "messages[0].uploads[0] missing required 'bytes'",
+            ],
+            validate_legacy_response({"messages": [{"text": "x", "uploads": [{}]}]}),
+        )
+
+    def test_upload_bytes_must_be_bytes_or_string(self):
+        self.assertEqual(
+            ["messages[0].uploads[0].bytes must be bytes, bytearray, or string"],
+            validate_legacy_response(
+                {"messages": [{"text": "x", "uploads": [{"filename": "x", "bytes": object()}]}]}
+            ),
+        )
+
+    def test_is_valid_legacy_response_returns_false_for_errors(self):
+        self.assertFalse(is_valid_legacy_response({"messages": [{}]}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds dependency-free helpers for validating the current legacy MatterBot command response shape.

## Why

PR27 structured output should land behind clear compatibility checks. Today command modules generally return:

```python
{"messages": [{"text": "..."}]}
```

This PR documents that existing contract in executable code without changing runtime behavior. Later diagnostics, smoke tests, and structured-output migration work can reuse this validator.

## What changed

- Added `matterbot_contracts.py`
- Added `tests/test_response_contracts.py`

New helpers:

- `validate_legacy_response(result) -> list[str]`
- `is_valid_legacy_response(result) -> bool`

The validator accepts:

- `None` for no-op responses
- legacy `{"messages": [...]}` responses
- optional `uploads` entries with `filename` and `bytes`

It reports human-readable errors for malformed responses instead of raising.

## Runtime behavior

No runtime behavior changes. The validator is introduced but not yet wired into `matterbot.py`.

## Validation

```bash
python3 -m unittest tests.test_response_contracts -v
python3 -m unittest discover -s tests -v
```
