### PR TITLE
feat: add shared formatting helpers

### DIFF
--- a/matterbot_formatting.py
+++ b/matterbot_formatting.py
@@ -1,0 +1,43 @@
+"""Shared formatting helpers for MatterBot output.
+
+The PR27 structured renderer will need centralized defanging and Markdown-safe
+cell formatting. These helpers are dependency-free and can be adopted by legacy
+modules gradually before the renderer lands.
+"""
+
+
+def defang_ioc(value, stixtype=None):
+    """Return a safely defanged IOC string for known semantic types.
+
+    Only the first dot is replaced to preserve readability and to match the
+    defanging convention already used in the PR27 proposal. Unknown types are
+    returned unchanged as strings.
+    """
+    if value is None:
+        return ""
+
+    text = str(value)
+    if stixtype in ("ipv4-addr", "ipv6-addr", "domain-name"):
+        return text.replace(".", "[.]", 1)
+    if stixtype == "url":
+        if text.startswith("https"):
+            text = "hxxps" + text[5:]
+        elif text.startswith("http"):
+            text = "hxxp" + text[4:]
+        return text.replace(".", "[.]", 1)
+    return text
+
+
+def safe_markdown_cell(value):
+    """Return text safe to place inside a Markdown table cell."""
+    if value is None:
+        return ""
+    return str(value).replace("\r", " ").replace("\n", " ").replace("|", "\\|")
+
+
+def format_scalar(value, stixtype=None):
+    """Format a scalar value for Mattermost Markdown output."""
+    text = safe_markdown_cell(defang_ioc(value, stixtype))
+    if not text:
+        return "-"
+    return f"`{text}`"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,44 @@
+import unittest
+
+from matterbot_formatting import defang_ioc, format_scalar, safe_markdown_cell
+
+
+class DefangIocTests(unittest.TestCase):
+    def test_defangs_domain_name(self):
+        self.assertEqual("example[.]com", defang_ioc("example.com", "domain-name"))
+
+    def test_defangs_ipv4(self):
+        self.assertEqual("1[.]2.3.4", defang_ioc("1.2.3.4", "ipv4-addr"))
+
+    def test_defangs_url_scheme_and_first_dot(self):
+        self.assertEqual("hxxps://example[.]com/a", defang_ioc("https://example.com/a", "url"))
+
+    def test_unknown_type_passes_through_as_string(self):
+        self.assertEqual("example.com", defang_ioc("example.com", "x-example"))
+
+    def test_none_becomes_empty_string(self):
+        self.assertEqual("", defang_ioc(None, "domain-name"))
+
+
+class MarkdownFormattingTests(unittest.TestCase):
+    def test_safe_markdown_cell_escapes_table_delimiter(self):
+        self.assertEqual("a\\|b", safe_markdown_cell("a|b"))
+
+    def test_safe_markdown_cell_collapses_newlines(self):
+        self.assertEqual("a b", safe_markdown_cell("a\nb"))
+
+    def test_safe_markdown_cell_handles_none(self):
+        self.assertEqual("", safe_markdown_cell(None))
+
+    def test_format_scalar_wraps_values_in_backticks(self):
+        self.assertEqual("`abc`", format_scalar("abc"))
+
+    def test_format_scalar_empty_value_is_dash(self):
+        self.assertEqual("-", format_scalar(""))
+
+    def test_format_scalar_defangs_before_formatting(self):
+        self.assertEqual("`example[.]com`", format_scalar("example.com", "domain-name"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds shared, dependency-free formatting helpers for IOC defanging and Markdown-safe scalar/table output.

## Why

The structured-output renderer proposed for PR27 needs centralized formatting so every module does not separately implement IOC defanging, Markdown table escaping, and scalar rendering. This PR lands those helpers independently, with tests, before any renderer or module migration work.

## What changed

- Added `matterbot_formatting.py`
- Added `tests/test_formatting.py`

New helpers:

- `defang_ioc(value, stixtype=None)`
- `safe_markdown_cell(value)`
- `format_scalar(value, stixtype=None)`

Covered behavior includes:

- domain/IP defanging
- URL `http`/`https` to `hxxp`/`hxxps` defanging
- Markdown table pipe escaping
- newline collapsing for table cells
- empty scalar rendering as `-`

## Runtime behavior

No runtime behavior changes. The helpers are introduced but not yet wired into modules or the core renderer.

## Validation

```bash
python3 -m unittest tests.test_formatting -v
python3 -m unittest discover -s tests -v
```
