### PR TITLE
fix: initialize matterfeed channels before refresh

### DIFF
--- a/matterfeed.py
+++ b/matterfeed.py
@@ -45,6 +45,7 @@ class MattermostManager(object):
         })
         self.me = self.mmDriver.users.get_user( user_id='me' )
         self.my_team_id = self.mmDriver.teams.get_team_by_name(options.Matterbot['teamname'])['id']
+        self.channels = {}
         self.channels = self.update_channels()
         self.test = {}
 
@@ -255,6 +256,7 @@ class MattermostManager(object):
     def runModules(self):
         while True:
             history = None
+            pool = None
             try:
                 success = 0
                 failed = 0
@@ -301,8 +303,9 @@ class MattermostManager(object):
                     self.log.error(f"Error   :{str(e)}")
                 failed += 1
             finally:
-                pool.stop()
-                pool.join()
+                if pool is not None:
+                    pool.stop()
+                    pool.join()
             self.log.info(f"Finished : {success}/{failed+success} modules ran successfully, sleeping {options.Modules['timer']} seconds ...")
             time.sleep(options.Modules['timer'])
 


### PR DESCRIPTION
## What this PR brings

- Initializes `self.channels` before the first `update_channels()` call in `matterfeed.py`.
- Guards `pool.stop()` / `pool.join()` so cleanup only runs when a `pebble.ProcessPool` was successfully created.

## Why it matters

On startup, `update_channels()` copies `self.channels`, but `self.channels` did not exist yet. That meant the first channel refresh always failed and fell back to `{}`, making feed posting dependent on a later successful refresh.

The pool cleanup guard prevents a secondary `UnboundLocalError` from masking the original startup/runtime error if execution fails before the pool is assigned.

## Validation

```bash
python3 -m py_compile matterfeed.py
```
