### PR TITLE
fix: avoid mutating feedmap when listing feeds

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -485,7 +485,7 @@ class MattermostManager(object):
                         text += "\n| :- | :- |"
                         if 'TOPICS' in self.feedmap:
                             for topic in sorted(self.feedmap['TOPICS']):
-                                availablefeeds = self.feedmap['TOPICS'][topic]
+                                availablefeeds = list(self.feedmap['TOPICS'][topic])
                                 for module_name in self.feedmap['MODULES']:
                                     if 'NAME' in self.feedmap['MODULES'][module_name]:
                                         if channame in self.feedmap['MODULES'][module_name]['CHANNELS']:


### PR DESCRIPTION
## What this PR brings

- Changes the `!feeds` / `@feeds` rendering path to work on a copy of each topic's feed list.

## Why it matters

The previous code assigned:

```python
availablefeeds = self.feedmap['TOPICS'][topic]
```

and then removed enabled feeds from `availablefeeds` while building the display table. Because that variable referenced the real list inside `self.feedmap`, simply viewing the feed list could mutate in-memory feed state.

This PR makes feed listing read-only by using `list(...)` before removing entries for display purposes.

## Validation

```bash
python3 -m py_compile matterbot.py
```
