### PR TITLE
fix: detect direct messages by channel type

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -472,7 +472,7 @@ class MattermostManager(object):
         messages = []
         if not params:
             if command in ('!feeds', '@feeds'):
-                if (self.my_id and userid) in channame:
+                if chaninfo['type'] == 'D':
                     text =  "**Feeds do not work in direct messages.**\n"
                     messages.append(text)
                 else:
@@ -603,7 +603,7 @@ class MattermostManager(object):
             if command in ('!map', '@map'):
                 if len(self.commands):
                     chans = set()
-                    if (self.my_id and userid) in channame:
+                    if chaninfo['type'] == 'D':
                         text =  "**List of modules in direct message:**\n"
                     else:
                         text =  "**List of modules for channel: `%s`**\n" % (self.channame_to_chandisplayname(channame,))


### PR DESCRIPTION
## What this PR brings

- Replaces brittle direct-message detection based on channel-name contents with Mattermost's explicit channel type field.
- Applies this to feed listing and module map rendering.

## Why it matters

The previous condition was:

```python
if (self.my_id and userid) in channame:
```

In Python, `(self.my_id and userid)` evaluates to `userid`, so this only checked whether the user's ID appeared in the channel name. That is fragile and does not clearly express the intent.

Mattermost already exposes channel type, where `D` means direct message. Checking `chaninfo['type'] == 'D'` is clearer and more reliable.

## Validation

```bash
python3 -m py_compile matterbot.py
```
