### PR TITLE
fix: preserve configured module and feedmap paths

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -72,7 +72,7 @@ class MattermostManager(object):
         self.my_team_name = options.Matterbot['teamname']
         self.my_team_id = self.mmDriver.teams.get_team_by_name(self.my_team_name)['id']
         # Load an existing module channel binding map if present
-        modulepath = options.Modules['commanddir'].strip('/')
+        modulepath = str(Path(options.Modules['commanddir']).expanduser().resolve())
         # Put the PARENT of the command directory on sys.path so modules can
         # be imported as `<dirname>.<command>.command` — the fully-qualified
         # dotted path avoids name collisions with installed PyPI packages
@@ -81,7 +81,7 @@ class MattermostManager(object):
         # otherwise resolve `import unfurl.command` against the installed
         # distribution and fail because it has no `command` submodule. Same
         # collision shape applies to commands/holehe/ vs the holehe pkg.
-        _mp = Path(modulepath).resolve()
+        _mp = Path(modulepath)
         _pkg_prefix = _mp.name
         if str(_mp.parent) not in sys.path:
             sys.path.insert(0, str(_mp.parent))

--- a/matterfeed.py
+++ b/matterfeed.py
@@ -76,7 +76,7 @@ class MattermostManager(object):
 
     def update_feedmap(self):
         try:
-            with open(options.Matterbot['feedmap'],'w') as f:
+            with open(options.Modules['feedmap'],'w') as f:
                 json.dump(self.feedmap,f)
         except Exception:
             self.log.exception("An error occurred updating the `%s` feedmap file; config changes were not successfully saved!" % (options.Matterbot['feedmap'],))
@@ -435,7 +435,7 @@ if __name__ == '__main__' :
         log.info('>>> Debug logging disabled ...')
     try:
         current_dir = os.path.dirname(__file__)
-        module_path = options.Modules['moduledir'].strip('/')
+        module_path = os.path.abspath(os.path.expanduser(options.Modules['moduledir']))
         main(log)
     except KeyboardInterrupt:
         log.info('<<< Stopping matterfeed ...')


### PR DESCRIPTION
## What this PR brings

- Preserves absolute configured command/module paths instead of stripping leading and trailing `/` characters.
- Makes `matterfeed.py` write the feedmap back to the same config key it reads from: `Modules.feedmap`.

## Why it matters

Using `.strip('/')` on configured paths silently breaks absolute paths. For example, `/opt/matterbot/modules` becomes `opt/matterbot/modules`, changing it into a relative path.

Also, `matterfeed.py` read from `options.Modules['feedmap']` but wrote to `options.Matterbot['feedmap']`. The defaults make those values the same today, but custom configs can diverge. This PR makes the read/write path consistent and avoids surprising writes to a different file.

## Validation

```bash
python3 -m py_compile matterbot.py matterfeed.py
```
