### PR TITLE
fix: log feed module failures outside debug mode

### DIFF
--- a/matterfeed.py
+++ b/matterfeed.py
@@ -242,6 +242,8 @@ class MattermostManager(object):
         except Exception as e:
             if options.debug:
                 self.log.error(f"Error   : {str(e)}\nTraceback: {traceback.format_exc()}")
+            else:
+                self.log.error(f"Error   : Cannot discover feed modules: {str(e)}")
         finally:
             sys.path.remove(module_path)
 
@@ -357,9 +359,11 @@ class MattermostManager(object):
                                 self.log.info(f"DbgCache : {module_name} => {channel} => {logcontent} ...")
             if options.debug:
                 self.log.info(f"Complete : {module_name} module ...")
-        except Exception:
+        except Exception as e:
             if options.debug:
                 self.log.error(f"Error   : {module_name} ...\nTraceback: {traceback.format_exc()}")
+            else:
+                self.log.error(f"Error   : {module_name} module failed: {str(e)}")
         finally:
             if history:
                 history.sync()
@@ -392,6 +396,8 @@ class MattermostManager(object):
         except Exception as e:
             if options.debug:
                 self.log.error(f"Error   :{str(e)}\nTraceback: {traceback.format_exc()}")
+            else:
+                self.log.error(f"Error   : {module_name} module call failed: {str(e)}")
             return None
         finally:
             if spec and spec.name in sys.modules:


### PR DESCRIPTION
## What this PR brings

- Logs feed discovery, feed execution, and feed module call failures even when debug mode is disabled.
- Keeps full tracebacks in debug mode, while adding concise operational errors in normal mode.

## Why it matters

Before this change, several important feed failures were only visible when `debug: True`. In production, that can make broken feeds look like they are simply quiet, with no useful indication of what failed.

This PR improves operability without flooding normal logs with tracebacks.

## Validation

```bash
python3 -m py_compile matterfeed.py
```
