### PR TITLE
fix: recover command executor after timeouts

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -47,6 +47,7 @@ Matterbot:
   logcmdparams: False
   command_workers: 8 # Max parallel module command executions. Lower (e.g. 1) effectively serializes commands
                      # if you suspect a module is not thread-safe; raise for more parallelism on a fast host.
+  command_timeout: 30 # Seconds to wait for a command module before timing out and recycling the worker pool.
   user_concurrency: 2 # Max concurrent commands per user. Raise for trusted teams, lower (e.g. 1) on
                       # public-ish deployments. Excess commands queue and may hit the 30s timeout.
 

--- a/matterbot.py
+++ b/matterbot.py
@@ -31,8 +31,10 @@ class MattermostManager(object):
         # the asyncio event loop. See call_module(). Worker count is
         # configurable via Matterbot.command_workers — set to 1 if a module
         # turns out not to be thread-safe; raise for more parallelism.
+        self._command_executor_workers = options.Matterbot.get('command_workers', 8)
+        self._command_timeout = options.Matterbot.get('command_timeout', 30)
         self._command_executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=options.Matterbot.get('command_workers', 8),
+            max_workers=self._command_executor_workers,
             thread_name_prefix='mb-cmd',
         )
         # Maximum number of in-flight module dispatches per user. Prevents a
@@ -136,6 +138,15 @@ class MattermostManager(object):
                 self.commands[module_name]['process'] = getattr(module, 'process')
                 self.commands[module_name]['help'] = HELP
         self.binds = sorted(list(set(self.binds)))
+
+    def _recycle_command_executor(self):
+        old_executor = self._command_executor
+        self._command_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=self._command_executor_workers,
+            thread_name_prefix='mb-cmd',
+        )
+        old_executor.shutdown(wait=False, cancel_futures=True)
+        log.warning("Recycled command executor after a command timeout")
 
     def run_forever(self):
         """Drive the Mattermost websocket, reconnecting on disconnect with
@@ -913,9 +924,10 @@ class MattermostManager(object):
 
                             async def _run_module(module):
                                 try:
-                                    async with asyncio.timeout(30):
+                                    async with asyncio.timeout(self._command_timeout):
                                         await self.call_module(module, command, channame, rootid, username, params, files, self.mmDriver)
                                 except asyncio.TimeoutError:
+                                    self._recycle_command_executor()
                                     log.warning(
                                         f"Command timed out: module={module} command={command} "
                                         f"user={username} channel={channame}"


### PR DESCRIPTION
## What this PR brings

- Adds a configurable `Matterbot.command_timeout` setting, defaulting to 30 seconds.
- Uses that setting instead of the hard-coded command timeout.
- Recycles the command thread pool after a command timeout.

## Why it matters

`asyncio.timeout()` stops waiting for a command result, but it cannot forcibly stop the underlying thread running a synchronous module. If enough modules hang, the command worker pool can become exhausted.

Recycling the executor after a timeout gives new commands a fresh worker pool and prevents timed-out work from permanently starving future commands. This is not full hard-kill isolation, but it is a practical recovery improvement for the current thread-based design.

## Validation

```bash
python3 -m py_compile matterbot.py
```
