### PR TITLE
chore: add pyproject package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "matterbot"
+version = "0.0.0"
+description = "Mattermost bot and threat-intel feed automation"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "GPL-3.0-only" }
+authors = [{ name = "MatterBot contributors" }]
+dynamic = ["dependencies"]
+
+[project.urls]
+Homepage = "https://github.com/uforia/matterbot/"
+Repository = "https://github.com/uforia/matterbot/"
+Issues = "https://github.com/uforia/matterbot/issues"
+
+[tool.setuptools]
+py-modules = ["matterbot", "matterfeed"]
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["commands*", "modules*"]
+namespaces = true


### PR DESCRIPTION
## What this PR brings

- Adds a minimal `pyproject.toml` with project metadata.
- Declares the setuptools build backend.
- Points dynamic dependencies at the existing `requirements.txt`.
- Configures package discovery for the current `commands*` and `modules*` layout.

## Why it matters

The project currently only has `requirements.txt`. Adding `pyproject.toml` gives tooling a standard place to discover project metadata, Python version support, build backend, dependency source, license, and repository links.

This is intentionally minimal and does not change runtime code or introduce tests/CI. It lays groundwork for future packaging, linting, and dependency management work.

## Validation

```bash
python3 -m py_compile matterbot.py matterfeed.py
```
