### PR TITLE
refactor: introduce shared feed helpers

### DIFF
--- a/modules/abb/feed.py
+++ b/modules/abb/feed.py
@@ -12,42 +12,33 @@
 # <channel>: basically the destination channel in Mattermost, e.g. 'Newsfeed', 'Incident', etc.
 # <content>: the content of the message, MD format possible
 
-import bs4
+import os
+import sys
+
 import feedparser
-import re
+
+try:
+    from feedutils import clean_description, load_settings
+except ImportError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    from feedutils import clean_description, load_settings
+
 
 def query(settings=None):
-    if settings:
-        try:
-            from types import SimpleNamespace
-            settings = SimpleNamespace(**settings)
-        except:
-            pass
-    else:
-        import defaults as settings
-        try:
-            import settings as _override
-            settings.__dict__.update({k: v for k, v in vars(_override).items() if not k.startswith('__')})
-        except ImportError:
-            pass
+    settings = load_settings(settings)
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title[27:] + '](' + link + ')'
             if len(feed.entries[count].description):
-                description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                if len(description)>400:
-                    description = description[:396]+' ...'
-                content += '\n>'+description+'\n'
+                content += '\n>' + clean_description(feed.entries[count].description) + '\n'
             for channel in settings.CHANNELS:
                 items.append([channel, content])
-            count+=1
+            count += 1
         except IndexError:
             return items # No more items
     return items

--- a/modules/akamai/feed.py
+++ b/modules/akamai/feed.py
@@ -12,29 +12,23 @@
 # <channel>: basically the destination channel in Mattermost, e.g. 'Newsfeed', 'Incident', etc.
 # <content>: the content of the message, MD format possible
 
-import bs4
+import os
+import sys
+
 import feedparser
-import re
+
+try:
+    from feedutils import clean_description, load_settings
+except ImportError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    from feedutils import clean_description, load_settings
+
 
 def query(settings=None):
-    if settings:
-        try:
-            from types import SimpleNamespace
-            settings = SimpleNamespace(**settings)
-        except:
-            pass
-    else:
-        import defaults as settings
-        try:
-            import settings as _override
-            settings.__dict__.update({k: v for k, v in vars(_override).items() if not k.startswith('__')})
-        except ImportError:
-            pass
+    settings = load_settings(settings)
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
@@ -42,13 +36,10 @@ def query(settings=None):
             if "security" in link:
                 content = settings.NAME + ': [' + title + '](' + link + ')'
                 if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
+                    content += '\n>' + clean_description(feed.entries[count].description) + '\n'
                 for channel in settings.CHANNELS:
                     items.append([channel, content])
-            count+=1
+            count += 1
         except IndexError:
             return items # No more items
     return items

--- a/modules/feedutils.py
+++ b/modules/feedutils.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import importlib
+import re
+from types import SimpleNamespace
+
+import bs4
+
+_STRIPCHARS = '`\\[\\]\'\"'
+_DESCRIPTION_RX = re.compile('[%s]' % _STRIPCHARS)
+
+
+def load_settings(settings=None, defaults_module='defaults', overrides_module='settings'):
+    if settings:
+        return SimpleNamespace(**settings)
+
+    defaults = importlib.import_module(defaults_module)
+    try:
+        overrides = importlib.import_module(overrides_module)
+    except ImportError:
+        return defaults
+
+    defaults.__dict__.update({k: v for k, v in vars(overrides).items() if not k.startswith('__')})
+    return defaults
+
+
+def clean_description(description, max_length=400):
+    text = _DESCRIPTION_RX.sub('', bs4.BeautifulSoup(description, 'lxml').get_text("\n"))
+    text = text.strip().replace('\n', '. ')
+    if len(text) > max_length:
+        return text[:max_length - 4] + ' ...'
+    return text


### PR DESCRIPTION
## What this PR brings

- Adds `modules/feedutils.py` with shared helpers for common feed-module behavior:
  - loading default/override settings
  - converting dict settings to an object-like namespace
  - cleaning and truncating HTML descriptions
- Migrates the `abb` and `akamai` RSS feed modules to use the shared helpers.

## Why it matters

Many feed modules duplicate the same settings-loading and description-cleaning logic. That makes behavior drift likely and increases the cost of fixing bugs across feeds.

This PR introduces a small shared utility module and migrates two representative feeds as a safe first step. It keeps behavior equivalent while creating a pattern future PRs can apply incrementally to the rest of the RSS modules.

## Validation

```bash
python3 -m py_compile modules/feedutils.py modules/abb/feed.py modules/akamai/feed.py
```
