### PR TITLE
feat: render-output sanitization helpers (1/5)

### DIFF
--- a/docs/render-sanitization-rationale.md
+++ b/docs/render-sanitization-rationale.md
@@ -1,0 +1,89 @@
+# Why command output needs Markdown sanitization
+
+## The one-sentence reason
+
+MatterBot renders **content it does not control** — third-party threat-intel feeds, external API responses, and CLI-tool output — directly into Mattermost Markdown, so anyone who controls that upstream content can inject Markdown that renders as *live formatting* in your channel.
+
+MatterBot is a security bot. The content it displays is, by definition, attacker-adjacent: IOCs, phishing URLs, ransomware-leak text, scraped profiles, LLM output. Treating that text as trusted formatting is the bug.
+
+## The trust boundary
+
+```
+   third-party feed / API / CLI tool          Mattermost channel
+   (attacker can influence this) ──►  command.py  ──►  (renders Markdown live)
+                                       ▲
+                                  no escaping here
+                                  = injection
+```
+
+Every `commands/*/command.py` builds a `{'text': ...}` string and hands it to Mattermost, which renders it as Markdown. If upstream text flows into that string without escaping, the upstream author — not MatterBot — decides how the channel message is formatted.
+
+The `render_audit.py` detector (Part 2) found this is pervasive: **100 command modules, 0 escaping the structural Markdown vectors**, with **9** interpolating content straight into a code fence, **571** into inline-code, and **29** hand-rolling an incomplete `stripchars` filter.
+
+## The four vectors, with real examples
+
+Each helper exists because a specific Markdown construct can be *broken out of* by content placed inside it.
+
+### 1. Code-fence breakout → `sanitize_block`
+
+**Real site — `commands/chatgpt/command.py:49`:**
+```python
+reply = '\n```%s\n```' % (answer['choices'][0]['message']['content'][1:],)
+```
+The model's response is dropped inside a ` ``` ` fence. A fence is closed by the next line containing ` ``` `. So if the response *contains* ` ``` `, everything after it stops being code and renders as live Markdown.
+
+**Attack.** The model (or a poisoned prompt, or a compromised API) returns:
+```
+here is your answer
+```
+# 🚨 SECURITY ALERT — click http://evil.example to re-auth
+@channel
+````
+Rendered result: the fence closes early, then a forged `<h1>` heading and a real `@channel` ping fire in the SOC channel — a convincing phishing message wearing the bot's identity.
+
+`sanitize_block` interposes a zero-width space between adjacent backticks, so no run in the content can close the fence. The visible backtick count is preserved, so legitimate code still looks right.
+
+### 2. Inline-code breakout → `sanitize_inline`
+
+**Real site — `commands/unfurl/command.py`** (URL echoed back in inline code):
+```python
+f"**Unfurl tree for `{url}`:**\n```\n{tree}\n```"
+```
+`url` comes from the user; `tree` from the unfurl tool. A backtick in either breaks the `` `…` `` wrap.
+
+**Attack.** A URL like `` http://x`**@here click http://evil**` `` closes the inline code and injects a bold `@here` mention.
+
+`sanitize_inline` strips backticks (and collapses newlines) so the wrapper can't be broken.
+
+### 3. Blockquote injection → `sanitize_blockquote`
+
+A leading `>` on a line starts a Mattermost blockquote. Feed content rendered at the start of a line (DM alerts, description fields) can forge quote structure to impersonate a "system" message. `sanitize_blockquote` escapes a leading `>` per line (`\>`), preserving indentation.
+
+### 4. Heading / query-echo injection → `sanitize_heading_echo`
+
+A leading `#` starts a heading. Modules that echo a user's query or a feed title at line start can be tricked into rendering an attacker's `# Big Official Heading`. `sanitize_heading_echo` collapses newlines to keep the echo one line and escapes a leading `#`/`>`.
+
+## Why the existing `stripchars` idiom isn't enough
+
+29 modules hand-roll this (from the module template):
+```python
+stripchars = r'\[\]\n\r\'\"|'
+```
+It removes brackets, quotes, pipes, and newlines — useful for table cells, but it **does not touch backticks, `>`, or `#`**, which are exactly the fence/blockquote/heading vectors above. So the modules that look like they're escaping are still open to the three highest-impact injections. Centralizing into `matterbot_formatting` replaces an incomplete, copy-pasted filter with one that covers the structural vectors and is unit-tested.
+
+## Impact, concretely
+
+Because this is a threat-intel bot, the injected content lands in the channel where analysts triage alerts. A feed/API/tool author (or anyone who can get a value into a feed MatterBot ingests) can:
+
+- **Forge urgency and identity** — fake headings/blockquotes that look like official bot or system messages.
+- **Fire `@channel` / `@here`** — noise, or social-engineering pressure ("click to re-auth now").
+- **Plant phishing links** that render as clean, clickable Markdown inside a trusted security channel.
+- **Corrupt formatting** so a real alert is buried or misread.
+
+None of this requires code execution — it's pure output-integrity, and it's high-leverage precisely because the audience trusts the channel.
+
+## What the three PRs do
+
+1. **#251** adds the four `sanitize_*` helpers (dependency-free, `None`-safe) + tests.
+2. **#252** adds `render_audit.py`, which finds every unsanitized site and (with `--check`) can gate the fence vector in CI.
+3. **#253** converts the two clearest fence sites (`chatgpt`, `unfurl`); the detector's fence count drops 9 → 7 as objective proof. Remaining sites follow the same one-line pattern.

--- a/matterbot_formatting.py
+++ b/matterbot_formatting.py
@@ -3,7 +3,18 @@
 The PR27 structured renderer will need centralized defanging and Markdown-safe
 cell formatting. These helpers are dependency-free and can be adopted by legacy
 modules gradually before the renderer lands.
+
+The ``sanitize_*`` helpers neutralize Markdown-injection vectors in
+attacker-influenced upstream feed content before it is rendered into a
+Mattermost message. They centralize escaping logic that was previously
+re-implemented inline across ``commands/**``.
 """
+
+import re
+
+# Zero-width space: interposed between adjacent backticks so a run cannot close
+# a ``` code fence, while keeping the visible backtick count intact.
+_ZWSP = chr(0x200B)
 
 
 def defang_ioc(value, stixtype=None):
@@ -41,3 +52,58 @@ def format_scalar(value, stixtype=None):
     if not text:
         return "-"
     return f"`{text}`"
+
+
+def sanitize_inline(value):
+    """Return text safe to place inside inline-code (single-backtick) wrapping.
+
+    Strips backticks so upstream content cannot break out of the wrapper, and
+    collapses newlines so the text stays on one line.
+    """
+    if value is None:
+        return ""
+    return str(value).replace("`", "").replace("\r", " ").replace("\n", " ")
+
+
+def sanitize_block(value):
+    """Return text safe to embed inside a fenced (```) code block.
+
+    Interposes a zero-width space between adjacent backticks so no run of
+    backticks in the content can close the surrounding fence. The visible
+    backtick count is preserved.
+    """
+    if value is None:
+        return ""
+    return re.sub(r"`(?=`)", "`" + _ZWSP, str(value))
+
+
+def sanitize_blockquote(value):
+    """Escape a leading ``>`` on each line so upstream text cannot forge a
+    blockquote. Leading indentation is preserved."""
+    if value is None:
+        return ""
+    out = []
+    for line in str(value).split("\n"):
+        stripped = line.lstrip(" ")
+        if stripped.startswith(">"):
+            indent = line[: len(line) - len(stripped)]
+            out.append(indent + "\\" + stripped)
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+def sanitize_heading_echo(value):
+    """Return a single-line value safe to echo into a heading.
+
+    Collapses newlines and escapes a leading ``#`` or ``>`` so an echoed user
+    query cannot forge a heading or blockquote.
+    """
+    if value is None:
+        return ""
+    text = str(value).replace("\r", " ").replace("\n", " ")
+    stripped = text.lstrip(" ")
+    if stripped[:1] in ("#", ">"):
+        indent = text[: len(text) - len(stripped)]
+        return indent + "\\" + stripped
+    return text

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,6 +1,14 @@
 import unittest
 
-from matterbot_formatting import defang_ioc, format_scalar, safe_markdown_cell
+from matterbot_formatting import (
+    defang_ioc,
+    format_scalar,
+    safe_markdown_cell,
+    sanitize_block,
+    sanitize_blockquote,
+    sanitize_heading_echo,
+    sanitize_inline,
+)
 
 
 class DefangIocTests(unittest.TestCase):
@@ -38,6 +46,69 @@ class MarkdownFormattingTests(unittest.TestCase):
 
     def test_format_scalar_defangs_before_formatting(self):
         self.assertEqual("`example[.]com`", format_scalar("example.com", "domain-name"))
+
+
+class SanitizeInlineTests(unittest.TestCase):
+    def test_strips_backticks_so_inline_wrap_cannot_break(self):
+        self.assertEqual("abc", sanitize_inline("a`b`c"))
+
+    def test_collapses_newlines(self):
+        self.assertEqual("a b", sanitize_inline("a\nb"))
+
+    def test_none_becomes_empty_string(self):
+        self.assertEqual("", sanitize_inline(None))
+
+    def test_benign_text_unchanged(self):
+        self.assertEqual("hello world", sanitize_inline("hello world"))
+
+
+class SanitizeBlockTests(unittest.TestCase):
+    def test_neutralizes_fence_breakout(self):
+        out = sanitize_block("```py\nevil\n```")
+        self.assertNotIn("```", out)
+
+    def test_preserves_visible_backtick_count(self):
+        self.assertEqual(3, sanitize_block("```").count("`"))
+
+    def test_single_backtick_unchanged(self):
+        self.assertEqual("a`b", sanitize_block("a`b"))
+
+    def test_none_becomes_empty_string(self):
+        self.assertEqual("", sanitize_block(None))
+
+
+class SanitizeBlockquoteTests(unittest.TestCase):
+    def test_escapes_leading_gt(self):
+        self.assertEqual("\\> forged quote", sanitize_blockquote("> forged quote"))
+
+    def test_escapes_leading_gt_per_line(self):
+        self.assertEqual("a\n\\> b", sanitize_blockquote("a\n> b"))
+
+    def test_preserves_indent_before_escaped_gt(self):
+        self.assertEqual("  \\> x", sanitize_blockquote("  > x"))
+
+    def test_benign_text_unchanged(self):
+        self.assertEqual("not a quote", sanitize_blockquote("not a quote"))
+
+    def test_none_becomes_empty_string(self):
+        self.assertEqual("", sanitize_blockquote(None))
+
+
+class SanitizeHeadingEchoTests(unittest.TestCase):
+    def test_escapes_leading_hash(self):
+        self.assertEqual("\\# forged heading", sanitize_heading_echo("# forged heading"))
+
+    def test_escapes_leading_gt(self):
+        self.assertEqual("\\> forged", sanitize_heading_echo("> forged"))
+
+    def test_collapses_newlines_to_single_line(self):
+        self.assertEqual("a b", sanitize_heading_echo("a\nb"))
+
+    def test_benign_text_unchanged(self):
+        self.assertEqual("query result", sanitize_heading_echo("query result"))
+
+    def test_none_becomes_empty_string(self):
+        self.assertEqual("", sanitize_heading_echo(None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **Part 1 of 5** — hardening `commands/**` against Markdown injection from upstream feed content (tracking: #254):
> 1. **(this PR)** shared `sanitize_*` helpers + rationale doc + tests
> 2. #252 — `render_audit` detector
> 3. #253 — adoption slice 1 (`chatgpt`, `unfurl`)
> 4. #255 — adoption slice 2 (remaining fence sites → fence count 0)
> 5. #256 — CI gate (`render_audit --check --vectors fence`)
>
> Each part stands alone and is independently reviewable; later parts stack on earlier ones.

## What this PR brings

Adds four Markdown-injection sanitizers to `matterbot_formatting.py`, for attacker-influenced upstream feed content that gets rendered into a Mattermost message:

| Helper | Neutralizes |
|--------|-------------|
| `sanitize_inline(value)` | stray backticks that would break out of inline-code (`` `…` ``) wrapping |
| `sanitize_block(value)` | ` ``` ` fence breakout — interposes a zero-width space between adjacent backticks so a run in the content can't close the surrounding fence (visible backtick count preserved) |
| `sanitize_blockquote(value)` | a leading `>` per line forging a blockquote (indentation preserved) |
| `sanitize_heading_echo(value)` | a leading `#`/`>` forging a heading when echoing a user query (also collapses newlines to one line) |

All four follow the module's existing conventions: dependency-free, `None`-safe, str-coercing.

## Why it matters

Command modules pull text from third-party feeds and render it straight into Mattermost markdown. The same escaping bugs — code-fence breakout, forged blockquotes/headings, stray backticks — keep getting fixed one place at a time, inline, in individual `commands/**` modules. That makes the behavior drift-prone and means every new module re-discovers the same vectors. (Part 2's detector finds **9** modules interpolating content straight into a ` ``` ` fence, **571** into inline-backtick wraps, and **58** hand-rolling an incomplete `stripchars` escape — none currently escape the fence/blockquote/heading vectors.)

This centralizes that escaping into the shared `matterbot_formatting.py` (the module whose docstring already anticipates gradual adoption by legacy modules), so a module can call one helper instead of re-implementing the escape.

This PR is intentionally **additive** — it lands the helpers plus tests. It does **not** yet migrate call sites; that is Parts 3–4, done incrementally (same pattern as the `feedutils` rollout in #246).

## Validation

```bash
python3 -m pytest tests/test_formatting.py
```

Adds 18 tests (adversarial payloads, benign round-trip, and `None` handling for each helper); full `tests/test_formatting.py` is green (29 passed). No existing behavior changed.
