### PR TITLE
feat: render_audit detector for unsanitized render sites (2/5)

### DIFF
--- a/render_audit.py
+++ b/render_audit.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Audit command modules for unsanitized Markdown render sites.
+
+Command modules render upstream feed content into Mattermost markdown. When that
+content is interpolated straight into a markdown-significant context — a ``` code
+fence, an inline-code (`) wrap, or a hand-rolled ``stripchars`` filter — attacker
+influenced text can break out (fence breakout, forged blockquote/heading).
+
+This is a heuristic, line-based detector: it produces a worklist of sites that
+should adopt the ``matterbot_formatting.sanitize_*`` helpers, and (with --check)
+can run as a CI lint. It is intentionally conservative and reports rather than
+proves; a site already routed through a ``sanitize_*`` helper is treated as safe.
+
+Usage:
+    python3 render_audit.py [--check] [--root commands]
+"""
+
+import argparse
+import re
+import sys
+from collections import Counter, namedtuple
+from pathlib import Path
+
+Finding = namedtuple("Finding", ["module", "line", "vector", "snippet"])
+
+_FENCE = "```"
+# An interpolation marker on the same line: %-formatting, str.format, f-string
+# placeholder, or a `` % `` expression.
+_INTERP = re.compile(r"%[sdr(]|\.format\(|\{|\s%\s")
+# Inline-code wrap directly around interpolated content: `{...} or `%s.
+_INLINE = re.compile(r"`\{|`%[sdr(]")
+
+
+def audit_source(source, module):
+    """Return a list of Finding for a single module's source text."""
+    findings = []
+    for lineno, line in enumerate(source.splitlines(), 1):
+        if "sanitize_" in line:
+            # Already routed through a sanitizer — treat as safe.
+            continue
+        if _FENCE in line and _INTERP.search(line):
+            findings.append(Finding(module, lineno, "fence", line.strip()))
+        elif _INLINE.search(line):
+            findings.append(Finding(module, lineno, "inline", line.strip()))
+        elif "stripchars" in line:
+            findings.append(Finding(module, lineno, "adhoc-stripchars", line.strip()))
+    return findings
+
+
+def audit_modules(items):
+    """Flatten audit_source over an iterable of (module, source) pairs."""
+    findings = []
+    for module, source in items:
+        findings.extend(audit_source(source, module))
+    return findings
+
+
+def iter_command_sources(root):
+    """Yield (module, source) for each commands/<name>/command.py under root."""
+    root = Path(root)
+    for command_py in sorted(root.glob("*/command.py")):
+        module = command_py.parent.name
+        yield module, command_py.read_text(encoding="utf-8", errors="replace")
+
+
+_FIX = {
+    "fence": "wrap fenced content in matterbot_formatting.sanitize_block()",
+    "inline": "wrap inline-code content in matterbot_formatting.sanitize_inline()",
+    "adhoc-stripchars": "replace the ad-hoc stripchars filter with the sanitize_* helpers",
+}
+
+
+def format_report(findings):
+    """Render findings as a human-readable worklist grouped by module."""
+    if not findings:
+        return "render_audit: no unsanitized render sites found."
+
+    by_vector = Counter(f.vector for f in findings)
+    modules = sorted({f.module for f in findings})
+    lines = [
+        f"render_audit: {len(findings)} finding(s) across {len(modules)} module(s)",
+        "  by vector: " + ", ".join(f"{v}={n}" for v, n in sorted(by_vector.items())),
+        "",
+    ]
+    current = None
+    for f in sorted(findings, key=lambda f: (f.module, f.line)):
+        if f.module != current:
+            current = f.module
+            lines.append(f"{f.module}:")
+        lines.append(f"  L{f.line} [{f.vector}] {f.snippet}")
+        lines.append(f"      -> {_FIX[f.vector]}")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Audit command modules for unsanitized render sites.")
+    parser.add_argument("--root", default="commands", help="commands directory to scan (default: commands)")
+    parser.add_argument("--check", action="store_true", help="exit non-zero if any findings (CI lint mode)")
+    args = parser.parse_args(argv)
+
+    findings = audit_modules(iter_command_sources(args.root))
+    print(format_report(findings))
+    if args.check and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_render_audit.py
+++ b/tests/test_render_audit.py
@@ -1,0 +1,80 @@
+import unittest
+
+from render_audit import audit_modules, audit_source, format_report
+
+
+class AuditSourceTests(unittest.TestCase):
+    def test_flags_fence_breakout_with_interpolation(self):
+        src = "reply = '\\n```%s\\n```' % (answer['content'][1:],)"
+        findings = audit_source(src, "chatgpt")
+        self.assertEqual(1, len(findings))
+        self.assertEqual("fence", findings[0].vector)
+        self.assertEqual("chatgpt", findings[0].module)
+        self.assertEqual(1, findings[0].line)
+
+    def test_flags_inline_backtick_wrap(self):
+        findings = audit_source('text = f"`{value}`"', "foo")
+        self.assertEqual(1, len(findings))
+        self.assertEqual("inline", findings[0].vector)
+
+    def test_flags_inline_percent_wrap(self):
+        findings = audit_source("text = '`%s`' % value", "foo")
+        self.assertEqual(1, len(findings))
+        self.assertEqual("inline", findings[0].vector)
+
+    def test_flags_adhoc_stripchars_idiom(self):
+        findings = audit_source("stripchars = r'\\[\\]\\n\\r'", "bar")
+        self.assertEqual(1, len(findings))
+        self.assertEqual("adhoc-stripchars", findings[0].vector)
+
+    def test_static_fence_without_interpolation_is_not_flagged(self):
+        self.assertEqual([], audit_source("text = '```static text```'", "clean"))
+
+    def test_benign_content_is_not_flagged(self):
+        self.assertEqual([], audit_source("text = 'hello world'", "clean"))
+
+    def test_fence_already_routed_through_sanitizer_is_not_flagged(self):
+        src = "reply = '```%s```' % sanitize_block(answer)"
+        self.assertEqual([], audit_source(src, "safe"))
+
+    def test_inline_already_routed_through_sanitizer_is_not_flagged(self):
+        src = 'text = f"`{sanitize_inline(value)}`"'
+        self.assertEqual([], audit_source(src, "safe"))
+
+    def test_fence_takes_precedence_over_inline_on_same_line(self):
+        # A ``` line that also contains `% must report once, as a fence.
+        findings = audit_source("x = '```%s```' % v", "foo")
+        self.assertEqual(1, len(findings))
+        self.assertEqual("fence", findings[0].vector)
+
+    def test_reports_line_number(self):
+        src = "a = 1\nb = 2\ntext = f'`{v}`'"
+        findings = audit_source(src, "foo")
+        self.assertEqual(3, findings[0].line)
+
+
+class AuditModulesTests(unittest.TestCase):
+    def test_aggregates_across_modules(self):
+        items = [
+            ("chatgpt", "r = '```%s```' % x"),
+            ("clean", "text = 'hi'"),
+            ("foo", "t = f'`{v}`'"),
+        ]
+        findings = audit_modules(items)
+        self.assertEqual(2, len(findings))
+        self.assertEqual({"chatgpt", "foo"}, {f.module for f in findings})
+
+
+class FormatReportTests(unittest.TestCase):
+    def test_empty_findings_report_is_clean(self):
+        self.assertIn("no unsanitized render sites", format_report([]).lower())
+
+    def test_report_groups_and_counts(self):
+        findings = audit_modules([("chatgpt", "r = '```%s```' % x")])
+        report = format_report(findings)
+        self.assertIn("chatgpt", report)
+        self.assertIn("fence", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Part 2 of 5** — hardening `commands/**` against Markdown injection from upstream feed content (tracking: #254):
> 1. #251 — shared sanitization helpers + tests
> 2. **(this PR)** `render_audit` detector that finds unsanitized render sites
> 3. #253 — adoption slice 1 (`chatgpt`, `unfurl`)
> 4. #255 — adoption slice 2 (remaining fence sites → fence count 0)
> 5. #256 — CI gate (`render_audit --check --vectors fence`)
>
> **Stacked on `feat/render-sanitization-helpers` (#251)**, so the diff shows only the detector. GitHub will auto-retarget this to `main` once #251 merges.

## What this PR brings

Adds `render_audit.py` — a heuristic, line-based detector that scans `commands/*/command.py` for upstream content interpolated into a markdown-significant context without a `matterbot_formatting` sanitizer. Three vectors:

| Vector | Meaning | Suggested fix |
|--------|---------|---------------|
| `fence` | content inside a ` ``` ` code fence (breakout risk) | `sanitize_block()` |
| `inline` | content inside inline-code (`` ` ``) wrapping | `sanitize_inline()` |
| `adhoc-stripchars` | module hand-rolls an incomplete `stripchars` filter | adopt the `sanitize_*` helpers |

A site already routed through a `sanitize_*` helper is treated as safe. With `--check` the script exits non-zero, so it can run as a CI lint; Part 5 adds a `--vectors` filter so it can gate the `fence` vector specifically once adoption (Parts 3–4) takes that set to zero.

## What it finds today

Run against the current tree:

```
render_audit: 638 finding(s) across 100 module(s)
  by vector: adhoc-stripchars=58, fence=9, inline=571
```

The **9 `fence` findings are the sharp, high-severity signal** — tool/API/LLM output interpolated straight into a ` ``` ` block with no escaping (e.g. `chatgpt` L49 puts model output directly inside a fence; also `dnstwist`, `ghunt`, `hackertarget`, `holehe`, `qualys`, `unfurl`, `waybacklister`). These are Parts 3–4's targets.

## Honest limits (it reports, it does not prove)

- **The `inline` set (571) is deliberately broad.** It flags any inline-code wrap around interpolation, including sites that already have *module-local* escaping (e.g. `apivoid`'s `_cell()`). It's a worklist, not a vulnerability count.
- Line-based, so a fence whose opening and interpolation span different lines can be missed. Good enough for a worklist + a fence-focused CI gate; not a substitute for the helpers themselves.

## Validation

```bash
python3 -m pytest tests/test_render_audit.py   # 13 tests, synthetic fixtures
python3 render_audit.py                         # prints the worklist
python3 render_audit.py --check                 # CI lint mode (exit 1 if findings)
```

Full `tests/` suite green (63 passed). Detector is pure-stdlib and read-only — it changes no runtime code.
