### PR TITLE
feat: adopt render sanitizers in chatgpt & unfurl (3/5)

### DIFF
--- a/commands/chatgpt/command.py
+++ b/commands/chatgpt/command.py
@@ -2,6 +2,8 @@
 
 import requests
 
+from matterbot_formatting import sanitize_block, sanitize_inline
+
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module
 from types import SimpleNamespace
@@ -27,6 +29,18 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
 
+def _format_answer(content):
+    """Render a model answer inside a fenced code block, neutralizing any
+    ``` in the (untrusted) model output so it cannot break out of the fence."""
+    return '\n```%s\n```' % (sanitize_block(content),)
+
+
+def _format_error(message):
+    """Render an API error message inside inline code, stripping backticks so
+    the (upstream) message cannot break out of the inline-code wrapper."""
+    return 'An error occurred querying OpenAI: `%s`' % (sanitize_inline(message),)
+
+
 def process(command, channel, username, params, files, conn):
     if len(params)>0:
         params = ' '.join(params)
@@ -44,9 +58,9 @@ def process(command, channel, username, params, files, conn):
             answer = response.json()
             reply = None
             if 'error' in answer:
-                reply = "An error occurred querying OpenAI: `"+answer['error']['message']+'`'
+                reply = _format_error(answer['error']['message'])
             if 'choices' in answer:
-                reply = '\n```%s\n```' % (answer['choices'][0]['message']['content'][1:],)
+                reply = _format_answer(answer['choices'][0]['message']['content'][1:])
             if reply:
                 return {'messages': [
                     {'text': reply},

--- a/commands/unfurl/command.py
+++ b/commands/unfurl/command.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from matterbot_formatting import sanitize_block, sanitize_inline
+
 log = logging.getLogger("MatterBot")
 
 ### Dynamic configuration loader (do not change/edit)
@@ -33,6 +35,13 @@ _settings_dict = {
 }
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
+
+
+def _format_tree(url, tree):
+    """Render the unfurl output: the (untrusted) tool tree goes inside a fenced
+    code block via sanitize_block so it cannot break out, and the user-supplied
+    URL is wrapped in inline code via sanitize_inline."""
+    return f"**Unfurl tree for `{sanitize_inline(url)}`:**\n```\n{sanitize_block(tree)}\n```"
 
 
 def process(command, channel, username, params, files, conn):
@@ -67,7 +76,7 @@ def process(command, channel, username, params, files, conn):
 
         if not tree:
             messages.append(
-                {"text": f"Unfurl produced no output for `{url}`."}
+                {"text": f"Unfurl produced no output for `{sanitize_inline(url)}`."}
             )
             return {"messages": messages}
 
@@ -76,7 +85,7 @@ def process(command, channel, username, params, files, conn):
             tree = tree[: settings.MAX_OUTPUT_CHARS]
             truncated = True
 
-        body = f"**Unfurl tree for `{url}`:**\n```\n{tree}\n```"
+        body = _format_tree(url, tree)
         if truncated:
             body += (
                 f"\n_Output truncated at {settings.MAX_OUTPUT_CHARS} characters; "

--- a/tests/test_render_adoption.py
+++ b/tests/test_render_adoption.py
@@ -1,0 +1,43 @@
+"""Render-safety tests for command modules that adopted the sanitize_* helpers.
+
+These assert the specific Markdown-injection vectors render_audit flagged for
+each module can no longer break out, while benign content is preserved.
+"""
+
+import unittest
+
+from commands.chatgpt.command import _format_answer, _format_error
+from commands.unfurl.command import _format_tree
+
+
+class ChatgptRenderTests(unittest.TestCase):
+    def test_model_output_cannot_break_out_of_fence(self):
+        out = _format_answer("```\n@channel escaped the code block")
+        # Only the wrapper's own opening + closing fence should remain.
+        self.assertEqual(2, out.count("```"))
+
+    def test_error_message_cannot_break_inline_code(self):
+        out = _format_error("boom `injected` payload")
+        self.assertIn("`boom injected payload`", out)
+
+    def test_benign_answer_is_preserved(self):
+        self.assertIn("hello world", _format_answer("hello world"))
+
+
+class UnfurlRenderTests(unittest.TestCase):
+    def test_tool_output_cannot_break_out_of_fence(self):
+        out = _format_tree("http://example.com", "```\nmalicious payload")
+        self.assertEqual(2, out.count("```"))
+
+    def test_url_cannot_break_inline_code(self):
+        out = _format_tree("a`b`c", "tree")
+        self.assertIn("`abc`", out)
+
+    def test_benign_tree_is_preserved(self):
+        out = _format_tree("http://example.com", "scheme: http")
+        self.assertIn("scheme: http", out)
+        self.assertIn("example.com", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Part 3 of 5** — hardening `commands/**` against Markdown injection from upstream feed content (tracking: #254):
> 1. #251 — shared sanitization helpers + tests
> 2. #252 — `render_audit` detector
> 3. **(this PR)** adoption slice 1 — route the two clearest fence sites through the helpers
> 4. #255 — adoption slice 2 (remaining fence sites → fence count 0)
> 5. #256 — CI gate (`render_audit --check --vectors fence`)
>
> **Stacked on `feat/render-audit-detector` (#252)** → #251. GitHub auto-retargets down the stack as each merges. Review/merge in stack order.

## What this PR brings

Adopts the Part 1 helpers in the **two clearest fence-breakout sites** the Part 2 detector flagged:

| Module | Untrusted input | Was | Now |
|--------|-----------------|-----|-----|
| `chatgpt` | model response rendered in a ` ``` ` fence | `'\n```%s\n```' % content` | `sanitize_block(content)` |
| `chatgpt` | API error message in inline code | `` "…: `"+msg+"`" `` | `sanitize_inline(msg)` |
| `unfurl` | tool tree in a ` ``` ` fence | `f"…\n```\n{tree}\n```"` | `sanitize_block(tree)` |
| `unfurl` | user-supplied URL in inline code | `` f"`{url}`" `` | `sanitize_inline(url)` |

Render logic is extracted into small pure helpers (`_format_answer` / `_format_error`, `_format_tree`) so the injection vectors are **unit-tested directly** without touching the network path. Behavior is unchanged for benign content.

## Why start here

These two put **the most obviously untrusted content** — third-party model output and external-tool output — straight inside a code fence with zero escaping. A response containing ` ``` ` closes the fence and lets everything after it render as live Markdown (forged headings, `@channel` mentions, links). `sanitize_block` interposes a zero-width space so a run can't close the fence.

## Verification

```bash
python3 -m pytest tests/test_render_adoption.py   # 6 tests
python3 render_audit.py | grep '\[fence\]'         # chatgpt & unfurl no longer listed
```

Full `tests/` suite green (69 passed). The detector's fence count drops **9 → 7** — an objective before/after on the exact thing Part 2 measures.

## Remaining (Part 4, same pattern)

`dnstwist`, `ghunt`, `hackertarget`, `holehe`, `qualys`, `waybacklister` still interpolate tool/API output into a fence. Each is a one-helper change like these two; batching them here would have made the diff harder to review. Part 4 (#255) converts them and takes the fence count to 0.
