### PR TITLE
feat: adopt render sanitizers in remaining fence sites (4/5)

### DIFF
--- a/commands/dnstwist/command.py
+++ b/commands/dnstwist/command.py
@@ -5,6 +5,8 @@ import io
 import logging
 import re
 
+from matterbot_formatting import sanitize_block, sanitize_inline
+
 log = logging.getLogger("MatterBot")
 
 ### Dynamic configuration loader (do not change/edit)
@@ -36,6 +38,13 @@ _settings_dict = {
 }
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
+
+
+def _wrap_output(mode, domain, body, truncation_note):
+    """Wrap DNSTwist output: the tool body goes inside a code fence via
+    sanitize_block and the domain in inline code via sanitize_inline, so
+    neither can break out of its Markdown context."""
+    return f"**DNSTwist {mode} for `{sanitize_inline(domain)}`:**\n```\n{sanitize_block(body)}\n```{truncation_note}"
 
 # Strict RFC-1123 hostname check — rejects URLs with paths, IPs, and shell
 # metacharacters so the operator-supplied string is safe to pass to dnstwist.
@@ -151,9 +160,7 @@ def process(command, channel, username, params, files, conn):
             if registered_only
             else "permutations (no DNS resolution)"
         )
-        wrapped = (
-            f"**DNSTwist {mode} for `{domain}`:**\n```\n{body}\n```{truncation_note}"
-        )
+        wrapped = _wrap_output(mode, domain, body, truncation_note)
         if truncated:
             wrapped += (
                 f"\n_Output truncated at {settings.MAX_OUTPUT_CHARS} characters._"

--- a/commands/ghunt/command.py
+++ b/commands/ghunt/command.py
@@ -8,6 +8,8 @@ import shutil
 import subprocess
 import tempfile
 
+from matterbot_formatting import sanitize_block, sanitize_inline
+
 log = logging.getLogger("MatterBot")
 
 ### Dynamic configuration loader (do not change/edit)
@@ -39,6 +41,12 @@ _settings_dict = {
 }
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
+
+
+def _wrap_output(email, body):
+    """Wrap Ghunt output: the profile summary goes inside a code fence via
+    sanitize_block and the email in inline code via sanitize_inline."""
+    return f"**Ghunt profile for `{sanitize_inline(email)}`:**\n```\n{sanitize_block(body)}\n```"
 
 # Strict RFC-5321-ish local + RFC-1123 domain. Rejects whitespace, quotes and
 # shell metacharacters so the operator-supplied string is safe to pass as a
@@ -235,7 +243,7 @@ def process(command, channel, username, params, files, conn):
         body = body[: settings.MAX_OUTPUT_CHARS]
         truncated = True
 
-    wrapped = f"**Ghunt profile for `{email}`:**\n```\n{body}\n```"
+    wrapped = _wrap_output(email, body)
     if truncated:
         wrapped += (
             f"\n_Output truncated at {settings.MAX_OUTPUT_CHARS} characters._"

--- a/commands/hackertarget/command.py
+++ b/commands/hackertarget/command.py
@@ -4,6 +4,8 @@ import ipaddress
 import re
 import requests
 
+from matterbot_formatting import sanitize_block, sanitize_inline
+
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module
 from types import SimpleNamespace
@@ -31,6 +33,13 @@ _settings_dict = {
 }
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
+
+
+def _wrap_output(header, body):
+    """Wrap hackertarget output: the tool body goes inside a code fence via
+    sanitize_block. The caller builds the header and sanitizes its interpolated
+    subject with sanitize_inline before passing it in."""
+    return f"{header}\n```\n{sanitize_block(body)}\n```"
 
 HOSTNAME_RE = re.compile(
     r'^(?=.{1,253}$)'
@@ -179,13 +188,13 @@ def process(command, channel, username, params, files, conn):
     if truncated_lines:
         rendered_body += f"\n…({total - max_lines} more line(s) omitted)"
 
-    header = f"**hackertarget {sub}** ({cfg['label']}) for `{normalized}`:"
-    text = f"{header}\n```\n{rendered_body}\n```"
+    header = f"**hackertarget {sub}** ({cfg['label']}) for `{sanitize_inline(normalized)}`:"
+    text = _wrap_output(header, rendered_body)
     if len(text) > max_chars:
         # Pull back inside the code fence so the closing ``` survives.
         head_room = max_chars - len(header) - len('\n```\n\n```\n_…output truncated._')
         if head_room > 0:
-            text = f"{header}\n```\n{rendered_body[:head_room]}\n```\n_…output truncated._"
+            text = _wrap_output(header, rendered_body[:head_room]) + "\n_…output truncated._"
 
     messages.append({'text': text})
     return {'messages': messages}

--- a/commands/holehe/command.py
+++ b/commands/holehe/command.py
@@ -5,6 +5,8 @@ import re
 import shutil
 import subprocess
 
+from matterbot_formatting import sanitize_block, sanitize_inline
+
 log = logging.getLogger("MatterBot")
 
 ### Dynamic configuration loader (do not change/edit)
@@ -36,6 +38,12 @@ _settings_dict = {
 }
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
+
+
+def _wrap_output(email, body):
+    """Wrap Holehe output: the results go inside a code fence via sanitize_block
+    and the email in inline code via sanitize_inline."""
+    return f"**Holehe results for `{sanitize_inline(email)}`:**\n```\n{sanitize_block(body)}\n```"
 
 # Strict RFC-5321-ish local + RFC-1123 domain. Rejects whitespace, quotes, and
 # shell metacharacters so the operator-supplied string is safe to pass as a
@@ -152,7 +160,7 @@ def process(command, channel, username, params, files, conn):
         body = body[: settings.MAX_OUTPUT_CHARS]
         truncated = True
 
-    wrapped = f"**Holehe results for `{email}`:**\n```\n{body}\n```"
+    wrapped = _wrap_output(email, body)
     if truncated:
         wrapped += (
             f"\n_Output truncated at {settings.MAX_OUTPUT_CHARS} characters._"

--- a/commands/qualys/command.py
+++ b/commands/qualys/command.py
@@ -8,6 +8,8 @@ import requests
 import sys
 import urllib.parse
 
+from matterbot_formatting import sanitize_block, sanitize_inline
+
 ### Dynamic configuration loader (do not change/edit)
 from importlib import import_module
 from types import SimpleNamespace
@@ -35,6 +37,13 @@ _settings_dict = {
 }
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
+
+
+def _format_api_error(err, content):
+    """Render a Qualys API error: the exception message in inline code via
+    sanitize_inline and the raw response content inside a code fence via
+    sanitize_block, so neither can break out of its Markdown context."""
+    return 'The Qualys Cyber Security Asset Management API call returned an unexpected result/error: `%s`\n```%s```' % (sanitize_inline(err), sanitize_block(content))
 
 def getToken():
     try:
@@ -308,7 +317,7 @@ def process(command, channel, username, params, files, conn):
                                 messages.append({'text': f'No Qualys assets were found matching for `{querytype}`: `{query}`.'})
                         except Exception as e:
                             log.exception("qualys module error")
-                            messages.append({'text': 'The Qualys Cyber Security Asset Management API call returned an unexpected result/error: `%s`\n```%s```' % (str(e), response.content)})
+                            messages.append({'text': _format_api_error(str(e), response.content)})
                 else:
                     messages.append({'text': 'The Qualys module could not obtain a valid JWT token. Check your credentials and/or subscription permissions.'})
     except Exception as e:

--- a/commands/waybacklister/command.py
+++ b/commands/waybacklister/command.py
@@ -6,6 +6,8 @@ from urllib.parse import urlsplit
 
 import requests
 
+from matterbot_formatting import sanitize_block, sanitize_inline
+
 log = logging.getLogger("MatterBot")
 
 ### Dynamic configuration loader (do not change/edit)
@@ -37,6 +39,12 @@ _settings_dict = {
 }
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
+
+
+def _wrap_output(domain, body, truncation_note):
+    """Wrap Wayback output: the enumerated paths go inside a code fence via
+    sanitize_block and the domain in inline code via sanitize_inline."""
+    return f"**Wayback directory enumeration for `{sanitize_inline(domain)}`:**\n```\n{sanitize_block(body)}\n```{truncation_note}"
 
 # Strict RFC-1123 hostname check — rejects URLs with paths, IPs, and shell
 # metacharacters so the operator-supplied string is safe to interpolate into
@@ -193,7 +201,7 @@ def process(command, channel, username, params, files, conn):
         body = body[: settings.MAX_OUTPUT_CHARS]
         truncated = True
 
-    wrapped = f"**Wayback directory enumeration for `{domain}`:**\n```\n{body}\n```{truncation_note}"
+    wrapped = _wrap_output(domain, body, truncation_note)
     if truncated:
         wrapped += (
             f"\n_Output truncated at {settings.MAX_OUTPUT_CHARS} characters._"

--- a/tests/test_render_adoption_fence.py
+++ b/tests/test_render_adoption_fence.py
@@ -1,0 +1,58 @@
+"""Render-safety tests for the remaining fence-breakout modules (Part 4).
+
+Each module interpolates tool/API output into a ``` fence; these assert the
+output can no longer close the fence, and (where the module wraps a subject in
+inline code) that the subject cannot break the inline wrap. Benign content is
+preserved.
+"""
+
+import unittest
+
+from commands.dnstwist.command import _wrap_output as dnstwist_wrap
+from commands.ghunt.command import _wrap_output as ghunt_wrap
+from commands.hackertarget.command import _wrap_output as hackertarget_wrap
+from commands.holehe.command import _wrap_output as holehe_wrap
+from commands.qualys.command import _format_api_error as qualys_error
+from commands.waybacklister.command import _wrap_output as wayback_wrap
+
+FENCE_BREAKOUT = "```\n# forged heading\n@channel click http://evil.example"
+
+
+class FenceAdoptionTests(unittest.TestCase):
+    def test_dnstwist_body_cannot_break_fence(self):
+        out = dnstwist_wrap("registered permutations", "evil.com", FENCE_BREAKOUT, "")
+        self.assertEqual(2, out.count("```"))
+
+    def test_dnstwist_domain_cannot_break_inline(self):
+        self.assertIn("`abc`", dnstwist_wrap("m", "a`b`c", "body", ""))
+
+    def test_ghunt_body_cannot_break_fence(self):
+        self.assertEqual(2, ghunt_wrap("x@y.com", FENCE_BREAKOUT).count("```"))
+
+    def test_ghunt_email_cannot_break_inline(self):
+        self.assertIn("`ab`", ghunt_wrap("a`b", "body"))
+
+    def test_holehe_body_cannot_break_fence(self):
+        self.assertEqual(2, holehe_wrap("x@y.com", FENCE_BREAKOUT).count("```"))
+
+    def test_waybacklister_body_cannot_break_fence(self):
+        self.assertEqual(2, wayback_wrap("evil.com", FENCE_BREAKOUT, "").count("```"))
+
+    def test_hackertarget_body_cannot_break_fence(self):
+        header = "**hackertarget dns** (label) for `evil.com`:"
+        self.assertEqual(2, hackertarget_wrap(header, FENCE_BREAKOUT).count("```"))
+
+    def test_qualys_fenced_content_cannot_break_fence(self):
+        self.assertEqual(2, qualys_error("boom", FENCE_BREAKOUT).count("```"))
+
+    def test_qualys_error_message_cannot_break_inline(self):
+        self.assertIn("`ab`", qualys_error("a`b", "content"))
+
+    def test_benign_content_preserved(self):
+        out = ghunt_wrap("a@b.com", "clean body text")
+        self.assertIn("clean body text", out)
+        self.assertIn("b.com", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Part 4 of 5** — completes the fence vector in the Markdown-injection series (tracking: #254):
> 1. #251 — sanitization helpers
> 2. #252 — `render_audit` detector
> 3. #253 — adoption slice 1 (`chatgpt`, `unfurl`)
> 4. **(this PR)** the remaining fence sites → detector fence count reaches **0**
> 5. #256 — CI gate that keeps it at 0 (`render_audit --check --vectors fence`)
>
> **Stacked on `feat/render-sanitization-adoption` (#253)** → #252 → #251. GitHub auto-retargets down the stack as each merges; review/merge in order.

## What this PR brings

Routes the last **6** fence-breakout sites through the helpers. (Part 3's PR body said "5 remaining" — the detector actually lists 6 modules once `hackertarget`'s two sites are counted; this PR does all of them.)

| Module | Untrusted content → fix |
|--------|--------------------------|
| `dnstwist` | permutation output → `sanitize_block`; queried domain (inline) → `sanitize_inline` |
| `ghunt` | profile summary → `sanitize_block`; email (inline) → `sanitize_inline` |
| `holehe` | results → `sanitize_block`; email (inline) → `sanitize_inline` |
| `waybacklister` | enumerated paths → `sanitize_block`; domain (inline) → `sanitize_inline` |
| `hackertarget` | tool body → `sanitize_block`; normalized target (header inline) → `sanitize_inline`; fence-length truncation logic preserved |
| `qualys` | raw API response content → `sanitize_block`; exception message (inline) → `sanitize_inline` |

Each fenced render is extracted into a small pure helper (`_wrap_output` / `_format_api_error`) and unit-tested against a fence-breakout payload. Behavior is unchanged for benign content.

## The payoff — an objective completion signal

```
python3 render_audit.py | grep -c '[fence]'
# before this series: 9   after #253: 7   after this PR: 0
```

**Every fence site now routes through `sanitize_block`.** Because the detector's fence set is empty, Part 5 (#256) gates it in CI so no new module can reintroduce it.

## Validation

```bash
python3 -m pytest tests/test_render_adoption_fence.py   # 10 tests
python3 render_audit.py | grep -c '[fence]'             # 0
```

Full `tests/` suite green (79 passed).

## Still open (future slices, lower severity)

`inline` (571, many with existing module-local escaping) and `adhoc-stripchars` (29) remain — lower impact than fence breakout, and best converted incrementally per the same pattern.
