### PR TITLE
ci: fence-vector gate via render_audit (5/5)

### DIFF
--- a/.github/workflows/render-audit.yml
+++ b/.github/workflows/render-audit.yml
@@ -1,0 +1,48 @@
+name: Render audit (fence gate)
+
+# Why this exists:
+#   commands/*/command.py render untrusted feed / API / CLI-tool output into
+#   Mattermost Markdown. Content interpolated into a ``` code fence can close
+#   the fence early and render the rest as live Markdown — forged headings,
+#   @channel pings, phishing links (see docs/render-sanitization-rationale.md).
+#
+#   Every existing fence site was routed through
+#   matterbot_formatting.sanitize_block (PRs #253, #255), so the fence vector is
+#   at zero. This gate keeps it there: it fails if any command module
+#   interpolates content into a ``` fence without a sanitizer.
+#
+# Scope:
+#   The fence vector ONLY. render_audit's broader `inline` and
+#   `adhoc-stripchars` sets are still open (tracked in #254) and are
+#   deliberately NOT gated here, so this stays a hard, low-noise invariant.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'commands/**.py'
+      - 'render_audit.py'
+      - '.github/workflows/render-audit.yml'
+  # Allow manual re-runs from the Actions tab.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fence-gate:
+    name: render_audit --vectors fence
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # render_audit.py is stdlib-only, so no dependency install is needed.
+      - name: Fail if any command module interpolates into a code fence unsanitized
+        run: python render_audit.py --check --vectors fence

--- a/render_audit.py
+++ b/render_audit.py
@@ -23,6 +23,8 @@ from pathlib import Path
 
 Finding = namedtuple("Finding", ["module", "line", "vector", "snippet"])
 
+VECTORS = ("fence", "inline", "adhoc-stripchars")
+
 _FENCE = "```"
 # An interpolation marker on the same line: %-formatting, str.format, f-string
 # placeholder, or a `` % `` expression.
@@ -53,6 +55,12 @@ def audit_modules(items):
     for module, source in items:
         findings.extend(audit_source(source, module))
     return findings
+
+
+def select_vectors(findings, vectors):
+    """Keep only findings whose vector is in `vectors`."""
+    wanted = set(vectors)
+    return [f for f in findings if f.vector in wanted]
 
 
 def iter_command_sources(root):
@@ -96,9 +104,19 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description="Audit command modules for unsanitized render sites.")
     parser.add_argument("--root", default="commands", help="commands directory to scan (default: commands)")
     parser.add_argument("--check", action="store_true", help="exit non-zero if any findings (CI lint mode)")
+    parser.add_argument(
+        "--vectors",
+        default=",".join(VECTORS),
+        help=f"comma-separated vectors to report/gate on (default: all). Choices: {', '.join(VECTORS)}",
+    )
     args = parser.parse_args(argv)
 
-    findings = audit_modules(iter_command_sources(args.root))
+    vectors = [v.strip() for v in args.vectors.split(",") if v.strip()]
+    unknown = [v for v in vectors if v not in VECTORS]
+    if unknown:
+        parser.error(f"unknown vector(s): {', '.join(unknown)}. Choices: {', '.join(VECTORS)}")
+
+    findings = select_vectors(audit_modules(iter_command_sources(args.root)), vectors)
     print(format_report(findings))
     if args.check and findings:
         return 1

--- a/tests/test_render_audit.py
+++ b/tests/test_render_audit.py
@@ -1,6 +1,8 @@
+import os
+import tempfile
 import unittest
 
-from render_audit import audit_modules, audit_source, format_report
+from render_audit import Finding, audit_modules, audit_source, format_report, main, select_vectors
 
 
 class AuditSourceTests(unittest.TestCase):
@@ -74,6 +76,42 @@ class FormatReportTests(unittest.TestCase):
         report = format_report(findings)
         self.assertIn("chatgpt", report)
         self.assertIn("fence", report)
+
+
+class SelectVectorsTests(unittest.TestCase):
+    def test_filters_to_requested_vector(self):
+        findings = [
+            Finding("a", 1, "fence", "x"),
+            Finding("b", 2, "inline", "y"),
+            Finding("c", 3, "adhoc-stripchars", "z"),
+        ]
+        self.assertEqual(["fence"], [f.vector for f in select_vectors(findings, ["fence"])])
+
+    def test_keeps_multiple_requested_vectors(self):
+        findings = [Finding("a", 1, "fence", "x"), Finding("b", 2, "inline", "y")]
+        self.assertEqual(2, len(select_vectors(findings, ["fence", "inline"])))
+
+
+class MainVectorGateTests(unittest.TestCase):
+    def _write_fixture(self, root, source):
+        moddir = os.path.join(root, "evilmod")
+        os.makedirs(moddir)
+        with open(os.path.join(moddir, "command.py"), "w", encoding="utf-8") as fh:
+            fh.write(source)
+
+    def test_fence_gate_fails_on_a_fence_site(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_fixture(tmp, "r = '```%s```' % x\n")
+            self.assertEqual(1, main(["--root", tmp, "--check", "--vectors", "fence"]))
+
+    def test_fence_gate_ignores_inline_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_fixture(tmp, "t = f'`{v}`'\n")
+            self.assertEqual(0, main(["--root", tmp, "--check", "--vectors", "fence"]))
+
+    def test_unknown_vector_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            main(["--root", ".", "--check", "--vectors", "bogus"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **Part 5 — locks in the fence vector** for the Markdown-injection series (#254):
> 1. #251 helpers · 2. #252 detector · 3. #253 adoption 1 · 4. #255 adoption 2 (fence → 0) · **5. (this PR) CI gate so it stays 0**
>
> **Stacked on `feat/render-sanitization-fence-rest` (#255)**. Review/merge in stack order.

## What this PR brings

Two pieces that turn "fence count is 0" into an enforced invariant:

1. **`render_audit.py --vectors`** — a filter so `--check` can gate a single vector: `render_audit.py --check --vectors fence` exits non-zero only on fence findings. (Unknown vectors are rejected; default remains all three.)
2. **`.github/workflows/render-audit.yml`** — runs that fence gate on PRs to `main` (paths-scoped to `commands/**.py` + `render_audit.py`). Stdlib-only, Python 3.12, `contents: read`, no untrusted input in the `run:` step.

**Fence-only by design.** The broader `inline` (571) and `adhoc-stripchars` (29) sets are still open (#254), so gating just `fence` keeps this a hard, low-noise invariant — it fails only when a *new* module reintroduces the highest-severity vector.

## Verification

```bash
python3 -m pytest tests/test_render_audit.py        # 18 tests (5 new: filter + gate)
python3 render_audit.py --check --vectors fence     # exit 0 — fence set is empty
python3 render_audit.py --check                      # exit 1 — inline/stripchars still open
```

Full `tests/` suite green (84 passed).

---

### ⚠️ Note on the workflow file

The `.github/workflows/render-audit.yml` commit is **not yet on this branch** — my push credentials lack the `workflow` scope (and the API path is read-only on this repo), so the automated push was rejected. The file is ready in a local commit; it needs one push from a credential with `workflow` scope:

```bash
git push origin feat/render-audit-ci-gate
```

Until then this PR shows only the `--vectors` filter (the code half). Once the workflow commit lands, the gate is live for future PRs to `main`.
