### PR TITLE
Fix websocket crash on Python 3.14 (asyncio.get_event_loop RuntimeError)

### DIFF
--- a/matterbot.py
+++ b/matterbot.py
@@ -181,7 +181,18 @@ class MattermostManager(object):
                 except Exception:
                     log.exception("welcome.reconcile failed (continuing)")
                 log.info("Connecting Mattermost websocket")
-                self.mmDriver.init_websocket(self.handle_raw_message)
+                # Python 3.14 removed the implicit loop creation in
+                # asyncio.get_event_loop(); mattermostdriver.init_websocket
+                # still relies on it (driver.py:150). Give this thread a fresh
+                # event loop per attempt and close it afterwards — the driver
+                # never closes it, so reusing/leaking loops across reconnects
+                # would leak the loop's self-pipe file descriptors.
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                try:
+                    self.mmDriver.init_websocket(self.handle_raw_message)
+                finally:
+                    loop.close()
                 log.warning("Websocket loop returned (server closed connection?)")
             except KeyboardInterrupt:
                 log.info("Interrupted — exiting")


### PR DESCRIPTION
## Problem

Under **Python 3.14** the websocket loop crashes on every connection attempt:

```
ERROR - MatterBot - Websocket loop crashed
Traceback (most recent call last):
  File "matterbot.py", line 184, in run_forever
    self.mmDriver.init_websocket(self.handle_raw_message)
  File ".../mattermostdriver/driver.py", line 150, in init_websocket
    loop = asyncio.get_event_loop()
  File "/usr/lib/python3.14/asyncio/events.py", line 718, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.' ...)
RuntimeError: There is no current event loop in thread 'MainThread'.
```

## Root cause

Python 3.14 removed the implicit event-loop creation in `asyncio.get_event_loop()` — it now **raises `RuntimeError`** when no current loop exists in the thread, instead of lazily creating one. (Deprecation timeline: warning in 3.10, refined in 3.12, hard error in 3.14; the whole policy system is slated for removal in 3.16.)

`mattermostdriver.init_websocket` still uses the old pattern (`driver.py:150`), so on 3.14 there is never a current loop in `MainThread` and every attempt dies — the exponential-backoff reconnect loop just retries the same crash forever.

This is not a code regression on our side: the same call worked on ≤3.13 and only broke on the interpreter upgrade.

## Fix

Give `run_forever` a fresh event loop per connection attempt and close it afterwards:

```python
loop = asyncio.new_event_loop()
asyncio.set_event_loop(loop)
try:
    self.mmDriver.init_websocket(self.handle_raw_message)
finally:
    loop.close()
```

- **Fresh loop each attempt** — the driver never closes the loop, and a loop that has already run can't be reused, so a new one is required on every reconnect.
- **`loop.close()` in `finally`** — prevents leaking the loop's self-pipe file descriptors across the reconnect/backoff loop.

## Verification

- `python -m py_compile matterbot.py` passes.
- Runtime confirmation requires the 3.14 deploy host (mattermostdriver isn't installed in the dev checkout); `init_websocket` behavior was diagnosed from the traceback + the library's known shape.