### PR TITLE
Fix all feed modules failing on Python 3.14 (multiprocessing forkserver default)

### DIFF
--- a/matterfeed.py
+++ b/matterfeed.py
@@ -8,6 +8,7 @@ import fnmatch
 import importlib.util
 import json
 import logging
+import multiprocessing
 import pebble
 import os
 import shelve
@@ -265,7 +266,15 @@ class MattermostManager(object):
                 self.feedmap = self.load_feedmap()
                 self.modules = self.findModules()
                 self.channels = self.update_channels()
-                with pebble.ProcessPool(max_workers=options.Modules['threads']) as pool:
+                # Python 3.14 changed the default multiprocessing start method
+                # on Linux from 'fork' to 'forkserver'. Under forkserver the
+                # worker is a fresh interpreter that re-imports matterfeed.py as
+                # a plain module (not __main__), so it cannot unpickle the bound
+                # method self.runModule nor see the __main__-scoped `options`
+                # global — every module fails instantly. Pin 'fork' to restore
+                # the pre-3.14 behavior this pool relies on.
+                mp_context = multiprocessing.get_context('fork')
+                with pebble.ProcessPool(max_workers=options.Modules['threads'], context=mp_context) as pool:
                     futures = []
                     for module_name in self.modules:
                         self.log.info(f"Starting : {module_name} module ...")


### PR DESCRIPTION
## Problem

Under **Python 3.14**, every feed module errors instantly and nothing runs:

```
INFO - MatterFeed - Error    : sophos module ...
INFO - MatterFeed - Error    : sans module ...
INFO - MatterFeed - Error    : darkowl module ...
...
INFO - MatterFeed - Finished : 0/210 modules ran successfully, sleeping 1800 seconds ...
```

All 210 fail in under a second via the generic `except Exception` handler in `runModules()` — not timeouts, not cancellations.

## Root cause

Python 3.14 changed the **default `multiprocessing` start method on Linux from `fork` to `forkserver`** (per the 3.14 changelog: *"On Unix platforms other than macOS, 'forkserver' is now the default start method (replacing 'fork')"*).

`runModules()` uses a `pebble.ProcessPool` and schedules `self.runModule` — a **bound method** — while `runModule` depends on the module-level `options` global. This worked under `fork` because workers inherited the parent's memory (imported classes + globals).

Under `forkserver`, each worker is a fresh interpreter that re-imports `matterfeed.py` as a **plain module, not `__main__`**. Consequently:

- it cannot unpickle `self.runModule` (the class/method context lived in `__main__`), and
- the `options` global (assigned only inside `if __name__ == '__main__'`) is undefined in the worker.

Either way every scheduled task raises immediately → caught as `"Error"` → `0/210`.

This is not a code regression on our side; the same design worked on ≤3.13 and only broke on the interpreter upgrade.

## Fix

Pass an explicit `fork` context to the pool, restoring pre-3.14 behavior:

```python
mp_context = multiprocessing.get_context('fork')
with pebble.ProcessPool(max_workers=options.Modules['threads'], context=mp_context) as pool:
```

`pebble.ProcessPool` accepts a `context=` argument (verified against pebble 5.2.0). This is the minimal, scoped restoration — it does not change any other multiprocessing usage.

## Verification

- `python -m py_compile matterfeed.py` passes.
- Runtime confirmation requires the 3.14 host (this dev checkout can't reproduce the 3.14 start-method behavior). To confirm the diagnosis on the host: `python3.14 -c "import multiprocessing; print(multiprocessing.get_start_method())"` → expect `forkserver`.

## Longer-term note

`fork` in a multi-threaded parent is exactly what CPython is steering away from, and the policy/start-method surface is slated for further change in 3.16. A more durable fix would make `runModule` self-contained (pass `options` explicitly, avoid shipping a `Driver`-carrying `self` into workers) so it runs cleanly under `forkserver`/`spawn`. Out of scope for this hotfix.

---

Companion to #258 (the other Python 3.14 breakage — websocket event loop).