### PR TITLE
Fix certes silent failure on bot-blocked feeds; surface module errors

### DIFF
--- a/matterfeed.py
+++ b/matterfeed.py
@@ -302,7 +302,7 @@ class MattermostManager(object):
                             if options.debug:
                                 self.log.error(f"Error   : {module_name} module ...\nTraceback: {str(e)}\n{traceback.format_exc()}")
                             else:
-                                self.log.info(f"Error    : {module_name} module ...")
+                                self.log.info(f"Error    : {module_name} module failed: {type(e).__name__}: {e}")
                             failed += 1
                         finally:
                             if not future.done():

--- a/modules/certes/defaults.py
+++ b/modules/certes/defaults.py
@@ -8,8 +8,9 @@ URLS = (
     "https://www.incibe.es/incibe-cert/alerta-temprana/avisos/feed",                   # CERT Advisories
     "https://www.incibe.es/incibe-cert/alerta-temprana/vulnerabilidades/feed",         # CERT Vulnerabilities
     "https://www.incibe.es/en/incibe-cert/publications/cybersecurity-highlights/feed", # CERT Cybersecurity Highlights (Based off external research)
-    "https://www.ccn-cert.cni.es/es/seguridad-al-dia/alertas-ccn-cert.feed?type=rss",  # CCNI Alerts
-    "https://www.ccn-cert.cni.es/es/seguridad-al-dia/avisos-ccn-cert.html?type=rss"    # CCNI Advisories
+    # CCN-CERT (ccn-cert.cni.es) feeds removed: the site serves an HTTP 403
+    # "Voight-Kampff" anti-bot challenge to automated fetchers, so these never
+    # yield data and their block page can crash the feed parse (see feed.py).
 )
 CHANNELS = (
     "newsfeed",

--- a/modules/certes/feed.py
+++ b/modules/certes/feed.py
@@ -38,7 +38,12 @@ def query(settings=None):
         regex = re.compile('[%s]' % stripchars)
         while count < settings.ENTRIES:
             try:
-                title = feed.entries[count].title
+                entry = feed.entries[count]
+            except IndexError:
+                break  # No more entries in this feed; continue with the next URL
+            count += 1
+            try:
+                title = entry.title
                 if settings.TRANSLATION:
                     from_lan = "es"
                     to_lan = "en"
@@ -51,13 +56,14 @@ def query(settings=None):
                     if packageSelection not in installed_packages:
                         package.install_from_path(packageSelection.download())
                     title = translate.translate(title, from_lan, to_lan)
-                link = feed.entries[count].link
+                link = entry.link
                 content = settings.NAME + ': [' + title + '](' + link + ')'
                 for channel in settings.CHANNELS:
                     items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
+            except Exception:
+                # A malformed or blocked entry (e.g. an anti-bot 403 page parsed
+                # as junk) must not discard the items already collected.
+                continue
     return items
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

A single feed module (`certes`) was failing on every run — `208/209 modules ran successfully` — but the log gave no indication of *which* module or *why*.

## Root cause

1. **`ccn-cert.cni.es` bot-blocks the feed.** Two of `certes`'s seven URLs (the CCN-CERT alert/advisory feeds) return **HTTP 403 with a "Voight-Kampff Browser Test"** anti-bot challenge to any automated fetcher. They never yield data.

2. **One bad feed crashed the whole module.** `modules/certes/feed.py` caught only `IndexError` in its entry loop. When the 403 block page parsed into a junk entry (e.g. missing `.link`) any other exception propagated out of `query()`, discarding **every item already collected from the working INCIBE feeds**. Separately, the `except IndexError: return items` handler returned from the *entire function* on the first short/empty feed, so remaining URLs were silently skipped.

3. **The failure was silent.** In `matterfeed.py`, the non-debug module-error branch logged only `Error : <module> module ...` and threw the exception away — no type, no message. Diagnosing required flipping on `debug` globally.

## Changes

- **`matterfeed.py`** — non-debug error log now includes `{type(e).__name__}: {e}`, so any failing module is diagnosable in normal operation (applies to all modules, not just `certes`).
- **`modules/certes/defaults.py`** — removed the two bot-blocked `ccn-cert.cni.es` URLs (a 403 challenge page can't be reliably fetched by a bot; they only ever produced failures).
- **`modules/certes/feed.py`** — wrapped per-entry processing in `try/except` so a malformed/blocked entry is skipped rather than fatal, and changed the end-of-feed `IndexError` handler from `return items` to `break` so a short feed no longer aborts the remaining URLs.

## Testing

- Reproduced the 403 anti-bot response from `ccn-cert.cni.es` directly (both feeds).
- Ran `certes.query()` end-to-end before/after: previously truncated at 30 items (aborted at the first short feed); now returns 40 items from all working INCIBE feeds.
- All edited files byte-compile.

## Note

The argostranslate INFO log-flood fix that was briefly listed here landed after this PR was merged; it is tracked separately in #261.