### PR TITLE
Silence argostranslate INFO log flood

### DIFF
--- a/matterfeed.py
+++ b/matterfeed.py
@@ -451,6 +451,15 @@ if __name__ == '__main__' :
         log.info('>>> WARNING: debug logging enabled ...')
     else:
         log.info('>>> Debug logging disabled ...')
+    # argostranslate logs every translated line at INFO ("('paragraphs:', ...)",
+    # "('apply_packaged_translation', ...)"), which floods the feed log. Import it
+    # here in the parent (before the fork pool starts) so its logger exists, then
+    # pin it to WARNING; forked workers inherit this and never reset it to INFO.
+    try:
+        import argostranslate.utils  # noqa: F401 -- import runs its own logger.setLevel(logging.INFO)
+        logging.getLogger('argostranslate.utils').setLevel(logging.WARNING)
+    except ImportError:
+        pass  # translation modules not installed / not in use
     try:
         current_dir = os.path.dirname(__file__)
         module_path = os.path.abspath(os.path.expanduser(options.Modules['moduledir']))


### PR DESCRIPTION
## Problem

Every translation module (the `cert*` feeds, `synacktiv`, `securitylab`, etc.) floods the feed log at INFO level. argostranslate logs every translated line through its own `argostranslate.utils` logger:

```
INFO - argostranslate.utils - ... - ('paragraphs:', ['Make it Blink: Over-the-Air Exploitation of the Philips Hue Bridge'])
INFO - argostranslate.utils - ... - ('apply_packaged_translation', 'Make it Blink: Over-the-Air Exploitation of the Philips Hue Bridge')
```

These records propagate to MatterFeed's root handler and land in the logfile on every run.

## Fix

`argostranslate.utils` sets **its own** logger level to `INFO` at import time, so setting a parent logger's level doesn't override it. Instead, import argostranslate in the parent process (before the `fork` pool starts) so the logger object exists, then pin `argostranslate.utils` to `WARNING`. Forked workers inherit `sys.modules` and never re-run the INFO `setLevel`, so the suppression holds in every worker. Wrapped in `try/except ImportError` so argostranslate stays an optional dependency for setups that don't use translation modules.

## Testing

With root logging configured at INFO (as in production), an `argostranslate.utils` INFO record prints before the fix and is fully suppressed after, while WARNING/ERROR records still pass through.

## Note

Follow-up to #260 — this commit was ready alongside that PR's changes but landed after #260 was merged, so it's split out here.