### PR TITLE
certes: fix module timeout from per-entry translation-package setup

### DIFF
--- a/modules/certes/feed.py
+++ b/modules/certes/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 def query(settings=None):
     if settings:
@@ -31,11 +30,20 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    from_lan = "es"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every single entry, which
+        # blows the module timeout once the working feeds have many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     for URL in settings.URLS:
         feed = feedparser.parse(URL, agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36")
         count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
         while count < settings.ENTRIES:
             try:
                 entry = feed.entries[count]
@@ -45,16 +53,6 @@ def query(settings=None):
             try:
                 title = entry.title
                 if settings.TRANSLATION:
-                    from_lan = "es"
-                    to_lan = "en"
-                    # Check for new language packages to install (initial setup)
-                    installed_packages = package.get_installed_packages()
-                    package.update_package_index()
-                    updateIndex = package.get_available_packages()
-                    # Filter for correct language packages
-                    packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                    if packageSelection not in installed_packages:
-                        package.install_from_path(packageSelection.download())
                     title = translate.translate(title, from_lan, to_lan)
                 link = entry.link
                 content = settings.NAME + ': [' + title + '](' + link + ')'


### PR DESCRIPTION
## Problem

After #260 stopped `certes` from crashing early on the bot-blocked CCN-CERT feeds, it now runs the full translation path over all working feeds and hits the module timeout:

```
INFO - MatterFeed - ... - Timeout  : certes module
```

## Root cause

The translation block ran, **for every entry of every feed**:

```python
installed_packages = package.get_installed_packages()
package.update_package_index()          # <-- network fetch of the remote index
updateIndex = package.get_available_packages()
packageSelection = next(filter(...))
if packageSelection not in installed_packages:
    package.install_from_path(packageSelection.download())
title = translate.translate(title, from_lan, to_lan)
```

`update_package_index()` is a network fetch of the remote Argos package index. A run with N headlines did **N index fetches** on top of N translations. Measured locally at ~0.25–0.6s per index fetch — with 5 working feeds × up to 10 entries that's 15–30s+ of pure redundant network before translation, and far worse on a slow or rate-limited link. That's the timeout.

## Fix

Hoist the package install out of the per-entry loop: run it **once, up front, and only when the es→en package is actually missing**. Steady-state runs (package already installed, i.e. every run after the first) do **zero** index-fetch network calls; the only per-entry cost is the local `translate()` call. Also dropped the now-unused `stripchars`/`regex` locals and the `import re` they needed.

## Testing

- `certes.query()` end-to-end went from timing out to **~9s for 40 items** locally (es→en already installed — the common case).
- First-run behaviour preserved: when the package is missing, it still updates the index and installs it once.
- File byte-compiles.

## Note

Follow-up to #260 (which introduced the fuller code path) and independent of #261 (argostranslate log flood). Same pattern exists in the other `cert*` translation modules; this PR fixes `certes` only, matching the reported symptom.