### PR TITLE
translation modules: hoist argostranslate package setup out of per-entry loop (21 modules)

### DIFF
--- a/modules/certal/feed.py
+++ b/modules/certal/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 from urllib.parse import unquote
 
 
@@ -35,10 +34,19 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "sq"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
     category = "Rekomandime"
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
@@ -46,16 +54,6 @@ def query(settings=None):
             for tag in tags:
                 if category in tag['term']:
                     if settings.TRANSLATION:
-                        from_lan = "sq"
-                        to_lan = "en"
-                        # Check for new language packages to install (initial setup)
-                        installed_packages = package.get_installed_packages()
-                        package.update_package_index()
-                        updateIndex = package.get_available_packages()
-                        # Filter for correct language packages
-                        packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                        if packageSelection not in installed_packages:
-                            package.install_from_path(packageSelection.download())
                         title = translate.translate(title, from_lan, to_lan)
                     link = feed.entries[count].link
                     link = unquote(link)

--- a/modules/certat/feed.py
+++ b/modules/certat/feed.py
@@ -13,7 +13,6 @@
 # <content>: the content of the message, MD format possible
 
 import feedparser
-import re
 from argostranslate import package, translate
 
 def query(settings=None):
@@ -31,25 +30,24 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    from_lan = "de"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     for URL in settings.URLS:
         feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
         count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
         while count < settings.ENTRIES:
             try:
                 title = feed.entries[count].title
                 if settings.TRANSLATION:
-                    from_lan = "de"
-                    to_lan = "en"
-                    # Check for new language packages to install (initial setup)
-                    installed_packages = package.get_installed_packages()
-                    package.update_package_index()
-                    updateIndex = package.get_available_packages()
-                    # Filter for correct language packages
-                    packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                    if packageSelection not in installed_packages:
-                        package.install_from_path(packageSelection.download())
                     title = translate.translate(title, from_lan, to_lan)
                 link = feed.entries[count].link
                 content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certbg/feed.py
+++ b/modules/certbg/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 from urllib.parse import unquote
 
 
@@ -35,23 +34,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "bg"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "bg"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             link = unquote(link)

--- a/modules/certcz/feed.py
+++ b/modules/certcz/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "cs"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "cs"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certde/feed.py
+++ b/modules/certde/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 def query(settings=None):
     if settings:
@@ -31,11 +30,20 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    from_lan = "de"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     for URL in settings.URLS:
         feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
         count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
         while count < settings.ENTRIES:
             try:
                 title = feed.entries[count].title
@@ -46,16 +54,6 @@ def query(settings=None):
                     filtered = True
                 if filtered:
                     if settings.TRANSLATION:
-                        from_lan = "de"
-                        to_lan = "en"
-                        installed_packages = package.get_installed_packages()
-                        package.update_package_index()
-                        updateIndex = package.get_available_packages()
-                        # Filter for correct language packages
-                        packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                        if packageSelection not in installed_packages:
-                            # Check for new language packages to install (initial setup)
-                            package.install_from_path(packageSelection.download())
                         title = translate.translate(title, from_lan, to_lan)
                     link = feed.entries[count].link
                     content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certdk/feed.py
+++ b/modules/certdk/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -33,25 +32,24 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    from_lan = "da"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     for URL in settings.URLS:
         feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
         count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
         while count < settings.ENTRIES:
             try:
                 title = feed.entries[count].title
                 if settings.TRANSLATION:
-                    from_lan = "da"
-                    to_lan = "en"
-                    # Check for new language packages to install (initial setup)
-                    installed_packages = package.get_installed_packages()
-                    package.update_package_index()
-                    updateIndex = package.get_available_packages()
-                    # Filter for correct language packages
-                    packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                    if packageSelection not in installed_packages:
-                        package.install_from_path(packageSelection.download())
                     title = translate.translate(title, from_lan, to_lan)
                 link = feed.entries[count].link
                 content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certee/feed.py
+++ b/modules/certee/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "et"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "et"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certfr/feed.py
+++ b/modules/certfr/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 def query(settings=None):
     if settings:
@@ -33,23 +32,22 @@ def query(settings=None):
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
     reversedFeed = list(reversed(feed.entries))
+    from_lan = "fr"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = reversedFeed[count].title
             if settings.TRANSLATION:
-                from_lan = "fr"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = reversedFeed[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certhu/feed.py
+++ b/modules/certhu/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -33,26 +32,25 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    from_lan = "hu"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     for URL in settings.URLS:
         feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
         count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
         while count < settings.ENTRIES:
             try:
                 title = feed.entries[count].title
                 link = feed.entries[count].link
                 if settings.TRANSLATION:
-                    from_lan = "hu"
-                    to_lan = "en"
-                    # Check for new language packages to install (initial setup)
-                    installed_packages = package.get_installed_packages()
-                    package.update_package_index()
-                    updateIndex = package.get_available_packages()
-                    # Filter for correct language packages
-                    packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                    if packageSelection not in installed_packages:
-                        package.install_from_path(packageSelection.download())
                     title = translate.translate(title, from_lan, to_lan)
                     content = settings.NAME + ': [' + title + '](' + link + ')'
                     for channel in settings.CHANNELS:

--- a/modules/certit/feed.py
+++ b/modules/certit/feed.py
@@ -13,7 +13,6 @@
 # <content>: the content of the message, MD format possible
 
 import feedparser
-import re
 from argostranslate import package, translate
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "it"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "it"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certjp/feed.py
+++ b/modules/certjp/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "ja"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "ja"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certmd/feed.py
+++ b/modules/certmd/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 from urllib.parse import unquote
 
 
@@ -35,24 +34,23 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "ro"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
     category = "Rekomandime"
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "ro"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             link = unquote(link)

--- a/modules/certno/feed.py
+++ b/modules/certno/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "nb"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "nb"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certse/feed.py
+++ b/modules/certse/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "sv"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "sv"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certsk/feed.py
+++ b/modules/certsk/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "sk"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "sk"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certsl/feed.py
+++ b/modules/certsl/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "sl"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "sl"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certtr/feed.py
+++ b/modules/certtr/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 def query(settings=None):
     if settings:
@@ -33,23 +32,22 @@ def query(settings=None):
     items = []
     # for URL in settings.URLS:
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "tr"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "tr"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/certua/feed.py
+++ b/modules/certua/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "uk"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "uk"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/modules/sec1275/feed.py
+++ b/modules/sec1275/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 from urllib.parse import unquote
 
 
@@ -35,23 +34,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "ru"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "ru"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             link = unquote(link)

--- a/modules/securitylab/feed.py
+++ b/modules/securitylab/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 from urllib.parse import unquote
 
 
@@ -35,23 +34,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "ru"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "ru"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             link = unquote(link)

--- a/modules/synacktiv/feed.py
+++ b/modules/synacktiv/feed.py
@@ -14,7 +14,6 @@
 
 from argostranslate import package, translate
 import feedparser
-import re
 
 
 
@@ -34,23 +33,22 @@ def query(settings=None):
             pass
     items = []
     feed = feedparser.parse(settings.URL, agent='MatterBot RSS Automation 1.0')
+    from_lan = "fr"
+    to_lan = "en"
+    if settings.TRANSLATION:
+        # Install the translation package once, up front, and only when it is
+        # missing. The previous code ran update_package_index() -- a network
+        # fetch of the remote package index -- for every entry, which blows the
+        # module timeout once a feed has many entries.
+        if not any(p.from_code == from_lan and p.to_code == to_lan for p in package.get_installed_packages()):
+            package.update_package_index()
+            packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, package.get_available_packages()))
+            package.install_from_path(packageSelection.download())
     count = 0
-    stripchars = '`\\[\\]\'\"'
-    regex = re.compile('[%s]' % stripchars)
     while count < settings.ENTRIES:
         try:
             title = feed.entries[count].title
             if settings.TRANSLATION:
-                from_lan = "fr"
-                to_lan = "en"
-                # Check for new language packages to install (initial setup)
-                installed_packages = package.get_installed_packages()
-                package.update_package_index()
-                updateIndex = package.get_available_packages()
-                # Filter for correct language packages
-                packageSelection = next(filter(lambda x: x.from_code == from_lan and x.to_code == to_lan, updateIndex))
-                if packageSelection not in installed_packages:
-                    package.install_from_path(packageSelection.download())
                 title = translate.translate(title, from_lan, to_lan)
             link = feed.entries[count].link
             content = settings.NAME + ': [' + title + '](' + link + ')'


### PR DESCRIPTION
## Problem

Every translation feed module runs, **for each entry of each feed**:

```python
installed_packages = package.get_installed_packages()
package.update_package_index()          # network fetch of the remote Argos index
updateIndex = package.get_available_packages()
packageSelection = next(filter(...))
if packageSelection not in installed_packages:
    package.install_from_path(packageSelection.download())
title = translate.translate(title, from_lan, to_lan)
```

`update_package_index()` is a network fetch of the remote package index, so a run with N headlines does **N redundant index fetches** on top of N translations. This already caused `certes` to hit the module timeout (#262); the same latent cost is in every other `cert*`/translation module, adding needless network load and log noise every run.

## Fix

Hoist the package install to run **once, up front, and only when the language package is missing** (same fix as #262 for `certes`). Steady-state runs (package already installed — every run after the first) do **zero** index-fetch network calls; the per-entry cost is just the local `translate()` call. `from_lan`/`to_lan` are lifted to function scope so the in-loop translate call still resolves them. Also dropped the dead `stripchars`/`regex` locals and the now-unused `import re` in each module.

## Scope — 21 modules

`certal certat certbg certcz certde certdk certee certfr certhu certit certjp certmd certno certse certsk certsl certtr certua sec1275 securitylab synacktiv`

Per-module structure was preserved **exactly** — this is a pure hoist, no behavioural change:
- URL loops (`for URL in settings.URLS:`) vs single-feed (`settings.URL`) both handled.
- `certde` keeps its `if filtered:` → `if settings.TRANSLATION:` nesting; `certal` keeps its `for tag in tags:` / `category` filtering and `unquote`; `certfr` keeps its `reversedFeed` reversal; `certtr` keeps its commented-out URL loop.
- The `except IndexError: return items` handler, `content` formatting, CHANNELS handling, and title/link read order are untouched.

## Testing

- All 21 files byte-compile.
- Structural verification across all 21: exactly one `update_package_index()` call, positioned before the entry loop; the missing-package guard present; the `translate()` call and `except IndexError` handler preserved; no leftover old-pattern lines.
- Diffs are uniform (net −42 lines total); the four structurally-nuanced modules (`certhu`, `certde`, `certal`, `certfr`) were diff-reviewed individually.

## Notes

- Follow-up to #262 (which fixed `certes` the same way). `certes` is not in this PR — it's already handled.
- Pre-existing lint not touched here (out of scope): a bare `except:` in each module's settings-loader, and an unused `category` local in `certmd`.