### PR TITLE
feedutils: FeedResult contract for central partial-error reporting (Phase 1)

### DIFF
--- a/matterfeed.py
+++ b/matterfeed.py
@@ -403,8 +403,16 @@ class MattermostManager(object):
             if not callable(func):
                 raise AttributeError(f"The 'query' function is not callable in {module_name} ...")
 
-            # Return a handle to the module query function entry point
-            return func(*args, **kwargs)
+            # Run the module and normalise its return. A module may return the
+            # legacy plain list of posts, or a feedutils.FeedResult carrying
+            # both posts and per-source errors. Log any partial errors here,
+            # centrally, so a module never has to swallow them silently, and
+            # hand the posts back to the caller unchanged either way.
+            import feedutils
+            items, errors = feedutils.split_result(func(*args, **kwargs))
+            for source, message in errors:
+                self.log.info(f"Partial  : {module_name} module: {source}: {message}")
+            return items
         except Exception as e:
             if options.debug:
                 self.log.error(f"Error   :{str(e)}\nTraceback: {traceback.format_exc()}")

--- a/modules/feedutils.py
+++ b/modules/feedutils.py
@@ -2,12 +2,43 @@
 
 import importlib
 import re
+from collections import namedtuple
 from types import SimpleNamespace
-
-import bs4
 
 _STRIPCHARS = '`\\[\\]\'\"'
 _DESCRIPTION_RX = re.compile('[%s]' % _STRIPCHARS)
+
+
+# A feed module's query() may return either the original plain list of posts,
+# or a FeedResult carrying BOTH the posts it collected AND the per-source
+# errors it hit. The second form lets a module report partial failures (e.g.
+# "one of my five feeds returned a 403") to the main loop, which logs them
+# centrally, instead of the module having to choose between swallowing the
+# error silently or raising and discarding every post it already collected.
+#
+# `errors` is a list of (source, message) pairs -- source is whatever
+# identifies the failing input (a feed URL, a section name), message a short
+# human-readable string.
+FeedResult = namedtuple('FeedResult', ['items', 'errors'])
+
+
+def result(items=None, errors=None):
+    """Build a FeedResult from collected posts and (source, message) errors."""
+    return FeedResult(list(items) if items else [], list(errors) if errors else [])
+
+
+def split_result(value):
+    """Normalise a query() return value into a (items, errors) pair.
+
+    Accepts the legacy contract (a plain list, or None) -- for which errors is
+    always empty -- as well as a FeedResult. This is what the main loop calls
+    so that both old and migrated modules go through one code path.
+    """
+    if isinstance(value, FeedResult):
+        return list(value.items) if value.items else [], list(value.errors) if value.errors else []
+    if value is None:
+        return [], []
+    return list(value), []
 
 
 def load_settings(settings=None, defaults_module='defaults', overrides_module='settings'):
@@ -25,6 +56,7 @@ def load_settings(settings=None, defaults_module='defaults', overrides_module='s
 
 
 def clean_description(description, max_length=400):
+    import bs4  # imported lazily so feedutils stays importable without bs4 (e.g. under the stdlib-only test runner)
     text = _DESCRIPTION_RX.sub('', bs4.BeautifulSoup(description, 'lxml').get_text("\n"))
     text = text.strip().replace('\n', '. ')
     if len(text) > max_length:

--- a/tests/test_feed_result.py
+++ b/tests/test_feed_result.py
@@ -1,0 +1,88 @@
+"""Tests for the feed-module return contract (feedutils.FeedResult).
+
+A `query()` may return either the legacy plain list of posts, or a
+`feedutils.FeedResult(items, errors)` that also carries the per-source errors
+the module hit. `matterfeed.callModule` funnels both through
+`feedutils.split_result`, logs any errors centrally, and hands the posts back
+unchanged -- so a module can report a partial failure (one feed of several
+returned a 403) without either swallowing it silently or raising and throwing
+away the posts it already collected.
+
+These tests cover that normalisation logic. They import only `feedutils`,
+which is kept stdlib-only (bs4 is imported lazily) so it runs under the
+dependency-free `python -m unittest` CI runner.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+# feedutils lives in modules/, which is not on the path under the test runner.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "modules"))
+
+import feedutils
+
+
+class SplitResultTests(unittest.TestCase):
+    def test_plain_list_return_has_no_errors(self):
+        items, errors = feedutils.split_result([["news", "a"], ["news", "b"]])
+        self.assertEqual([["news", "a"], ["news", "b"]], items)
+        self.assertEqual([], errors)
+
+    def test_none_return_is_empty(self):
+        self.assertEqual(([], []), feedutils.split_result(None))
+
+    def test_feedresult_exposes_items_and_errors(self):
+        r = feedutils.result(items=[["news", "a"]], errors=[("http://x/feed", "403 blocked")])
+        items, errors = feedutils.split_result(r)
+        self.assertEqual([["news", "a"]], items)
+        self.assertEqual([("http://x/feed", "403 blocked")], errors)
+
+    def test_partial_result_keeps_items_alongside_errors(self):
+        # The entire point of the contract: report a failed source AND still
+        # return everything that was collected.
+        r = feedutils.result(items=[["news", "kept"]], errors=[("feed-2", "timeout")])
+        items, errors = feedutils.split_result(r)
+        self.assertEqual([["news", "kept"]], items)
+        self.assertEqual(1, len(errors))
+
+    def test_split_result_of_plain_list_returns_a_copy(self):
+        # callModule/runModule mutate the returned list; that must not mutate
+        # the caller's input.
+        src = [["news", "a"]]
+        items, _ = feedutils.split_result(src)
+        items.append(["news", "b"])
+        self.assertEqual([["news", "a"]], src)
+
+
+class ResultFactoryTests(unittest.TestCase):
+    def test_empty_result_is_two_empty_lists(self):
+        r = feedutils.result()
+        self.assertEqual([], r.items)
+        self.assertEqual([], r.errors)
+        self.assertEqual(([], []), feedutils.split_result(r))
+
+    def test_result_copies_its_inputs(self):
+        # A module often passes its own working list; result() must not alias
+        # it, or later mutation would corrupt the returned FeedResult.
+        src_items = [["news", "a"]]
+        src_errors = [("feed", "err")]
+        r = feedutils.result(items=src_items, errors=src_errors)
+        src_items.append(["news", "b"])
+        src_errors.append(("feed2", "err2"))
+        self.assertEqual([["news", "a"]], r.items)
+        self.assertEqual([("feed", "err")], r.errors)
+
+    def test_is_a_named_2_tuple(self):
+        r = feedutils.result(items=[1], errors=[2])
+        self.assertEqual((([1]), ([2])), (r.items, r.errors))
+        # namedtuple: unpackable and indexable, so existing list-style handling
+        # of a FeedResult (were one passed straight through) still degrades
+        # predictably rather than raising oddly.
+        items, errors = r
+        self.assertEqual([1], items)
+        self.assertEqual([2], errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Feed modules should pass their error state to the main loop and let it log centrally, rather than each module handling errors ad hoc. Today `query()` has only two outcomes — **return a list** or **raise** — but real modules have a **third state with nowhere to go**: *partial success* (e.g. "four of my five feeds worked, one returned a 403"). Faced with that, authors either:
- **swallow** the error → silent failure (the original `certes` bug), or
- **let it raise** → the main loop logs it, but every post already collected is discarded.

This is Phase 1 of giving that third state a channel. It adds the mechanism only — **no module behaviour changes**; the migration of modules that benefit is Phase 2.

## What this adds

**`modules/feedutils.py`**
- `FeedResult(items, errors)` — a namedtuple a module may return *instead of* a bare list, carrying both the posts it collected **and** a list of `(source, message)` errors it hit.
- `result(items, errors)` — a factory that copies its inputs.
- `split_result(value)` — normalises any `query()` return (legacy `list`, `None`, or `FeedResult`) into an `(items, errors)` pair. One code path for old and new modules.
- Made the `bs4` import lazy (only `clean_description` uses it) so `feedutils` imports on the stdlib alone.

**`matterfeed.py`** — `callModule` now funnels every module's return through `split_result`, logs each partial error centrally (`Partial : <module> module: <source>: <message>`), and hands the posts back unchanged.

## Backward compatibility

Fully preserved. A module returning a plain list yields no errors and behaves exactly as before — **none of the ~210 existing modules need changing**. The legacy `list`/`None` returns and the existing raise→`Error :`→`None` path are untouched.

## Testing

- `tests/test_feed_result.py` (new, 8 tests): `split_result`/`result` across the legacy, `None`, and `FeedResult` shapes — including that a partial result keeps its items alongside errors, and that inputs are copied (no aliasing). Runs under the dependency-free `unittest` CI runner (that's why the lazy `bs4` change was needed).
- Full suite: 66 tests pass.
- The `callModule` wiring (FeedResult → central logging; legacy list passthrough; raise → `None`) was smoke-tested locally — it can't run under the dep-free CI runner because `matterfeed` imports `pebble`/`mattermostdriver`.

## Next (Phase 2, separate PR)

Migrate the ~25–30 modules with real partial-failure surface (the 20 multi-source `for URL in settings.URLS` modules + the 13 that currently broadly swallow) to collect per-source errors and return `FeedResult`. Mechanical, incremental, and built on this contract.