### PR TITLE
Hotfix: make feedutils importable in callModule (all feed modules failing after #264)

### DIFF
--- a/matterfeed.py
+++ b/matterfeed.py
@@ -386,6 +386,16 @@ class MattermostManager(object):
         try:
             # Load the module
             importlib.invalidate_caches()
+            # findModules() removes module_path from sys.path once discovery is
+            # done, but a feed module -- and the FeedResult normalisation below --
+            # may `import feedutils` from the modules dir. Re-add it (append, so
+            # it can never shadow a stdlib/site-packages name; feedutils lives
+            # only here). This is safe w.r.t. the modules/socket feed shadowing
+            # stdlib socket: socket is already cached in sys.modules from
+            # matterfeed's own startup imports, so a later `import socket`
+            # resolves from the cache and never re-scans sys.path.
+            if module_path not in sys.path:
+                sys.path.append(module_path)
             module_file = os.path.join(module_path, module_name, "feed.py")
             if not os.path.exists(module_file):
                 raise ImportError(f"No feed.py found for {module_name} ...")


### PR DESCRIPTION
## Severity: production down — every feed module failing

After #264 merged, all modules fail on each run:

```
ERROR - MatterFeed - Error : checkmarx module call failed: No module named 'feedutils'
ERROR - MatterFeed - Error : deepinstinct module call failed: No module named 'feedutils'
ERROR - MatterFeed - Error : sploitus module call failed: No module named 'feedutils'
... (all modules)
```

## Root cause

#264 added `import feedutils` to `callModule` to normalise module returns. But `findModules()` **removes** `module_path` from `sys.path` once discovery is done (`matterfeed.py:250`), so by the time `callModule` runs, the modules dir is no longer on the path and `import feedutils` raises `ModuleNotFoundError`. `callModule` catches it and returns `None`, so every module — migrated or not — produces nothing.

(This also affected the two modules already on `main` that `import feedutils` — `abb`/`akamai` — which is why they carry a `try: import feedutils / except ImportError: sys.path.insert(...)` fallback. `callModule` used a bare import with no such fallback.)

## Fix

Re-add `module_path` to `sys.path` (via `append`, so it can never shadow a stdlib or site-packages name — `feedutils` lives only in the modules dir) before loading and normalising a module. This mirrors the fallback the feed modules already use, and also covers modules that `import feedutils` at their own top level.

**Safe re: `modules/socket/` shadowing stdlib `socket`:** `socket` is already cached in `sys.modules` from matterfeed's startup `import multiprocessing`, so a later `import socket` resolves from the cache and never re-scans `sys.path`. (The `socket` *feed* is also loaded under a unique `feed_<uuid>` name, never as `socket`.)

## Testing

Reproduced the production flow end-to-end (matterfeed imported so `socket` is cached; `module_path` off `sys.path` as after `findModules`):
- A `FeedResult`-returning module: partial errors logged centrally, items returned. ✓
- A legacy plain-list module: unchanged, no logs. ✓
- A module that `import socket`: binds **stdlib** `socket` (not shadowed). ✓

Please merge and redeploy — this restores all feeds.