### PR TITLE
Adopt FeedResult per-source error contract in 16 multi-source modules (Phase 2)

### DIFF
--- a/modules/aquasec/feed.py
+++ b/modules/aquasec/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/bluesky/feed.py
+++ b/modules/bluesky/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import ipaddress
 import re
 import requests
@@ -74,46 +75,51 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     user_agent = 'MatterBot RSS Automation 1.0'
     headers = {
         'Content-Type': 'text/json',
         'User-Agent': f"{user_agent}",
     }
     for url in settings.URLS:
-        title = url
-        feed = feedparser.parse(settings.URLS[url], agent=user_agent)
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                upload = None
-                if 'media_content' in feed.entries[count]:
-                    uploads = []
-                    for media in feed.entries[count]['media_content']:
-                        if 'url' in media:
-                            url = media['url']
-                            body = _safe_fetch(url, headers)
-                            if body is not None:
-                                filename = url.split('/')[-1]
-                                upload = {'filename': filename, 'bytes': body}
-                                uploads.append(upload)
-                for channel in settings.CHANNELS:
-                    if upload:
-                        items.append([channel, content, {'uploads': uploads}])
-                    else:
-                        items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            title = url
+            feed = feedparser.parse(settings.URLS[url], agent=user_agent)
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    upload = None
+                    if 'media_content' in feed.entries[count]:
+                        uploads = []
+                        for media in feed.entries[count]['media_content']:
+                            if 'url' in media:
+                                url = media['url']
+                                body = _safe_fetch(url, headers)
+                                if body is not None:
+                                    filename = url.split('/')[-1]
+                                    upload = {'filename': filename, 'bytes': body}
+                                    uploads.append(upload)
+                    for channel in settings.CHANNELS:
+                        if upload:
+                            items.append([channel, content, {'uploads': uploads}])
+                        else:
+                            items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((title, str(e)))  # title holds the source key; url is reassigned during media handling
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/broadcom/feed.py
+++ b/modules/broadcom/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 def query(settings=None):
@@ -31,27 +32,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/certau/feed.py
+++ b/modules/certau/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/certca/feed.py
+++ b/modules/certca/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/certeu/feed.py
+++ b/modules/certeu/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/certfi/feed.py
+++ b/modules/certfi/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/checkpoint/feed.py
+++ b/modules/checkpoint/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description) > 400:
-                        description = description[:396] + ' ...'
-                    content += '\n>'+ description +'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count += 1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description) > 400:
+                            description = description[:396] + ' ...'
+                        content += '\n>'+ description +'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count += 1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/fortinet/feed.py
+++ b/modules/fortinet/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import os
 import re
 import requests
@@ -68,50 +69,55 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(str(URL), agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                if settings.FILTER:
-                    THRESHOLD = importScore()
-                    matches = checkPage(link)
-                    filtered = False
-                    if not matches:
-                        cvss = False
-                        filtered = True
-                    else:
-                        if isinstance(matches, tuple): # Filter for return values from checkPage()
-                            cvss = matches[1]
-                            if float(cvss) >= THRESHOLD:
-                                filtered = True
+        try:
+            feed = feedparser.parse(str(URL), agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    if settings.FILTER:
+                        THRESHOLD = importScore()
+                        matches = checkPage(link)
+                        filtered = False
+                        if not matches:
+                            cvss = False
+                            filtered = True
                         else:
-                            for score in matches:
-                                if float(score.text.strip()) >= THRESHOLD: # Check if CVSS score meets threshold
-                                    cvss = float(score.text.strip())
+                            if isinstance(matches, tuple): # Filter for return values from checkPage()
+                                cvss = matches[1]
+                                if float(cvss) >= THRESHOLD:
                                     filtered = True
-                    if filtered:
-                        content = settings.NAME + ': [' + title
-                        if cvss:
-                            content += f' - CVSS: `{cvss}`'
-                        content += '](' + link + ')'
-                else:
-                    content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+                            else:
+                                for score in matches:
+                                    if float(score.text.strip()) >= THRESHOLD: # Check if CVSS score meets threshold
+                                        cvss = float(score.text.strip())
+                                        filtered = True
+                        if filtered:
+                            content = settings.NAME + ': [' + title
+                            if cvss:
+                                content += f' - CVSS: `{cvss}`'
+                            content += '](' + link + ')'
+                    else:
+                        content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/googlecloud/feed.py
+++ b/modules/googlecloud/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/mastodon/feed.py
+++ b/modules/mastodon/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import html
 import ipaddress
 import re
@@ -75,6 +76,7 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     user_agent = 'MatterBot RSS Automation 1.0'
     headers = {
         'Content-Type': 'text/json',
@@ -82,40 +84,44 @@ def query(settings=None):
     }
     MAXENTRIES = settings.ENTRIES * len(settings.URLS)
     for url in settings.URLS:
-        title = url
-        feed = feedparser.parse(settings.URLS[url], agent=user_agent)
-        count = 0
-        stripchars = '\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                link = feed.entries[count].link
-                content = bs4.BeautifulSoup(html.unescape(settings.NAME), 'html.parser').get_text() + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(html.unescape(feed.entries[count].description),'html.parser').get_text()).replace('```json','\n```json\n')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                upload = None
-                if 'media_content' in feed.entries[count]:
-                    uploads = []
-                    for media in feed.entries[count]['media_content']:
-                        if 'url' in media:
-                            url = media['url']
-                            body = _safe_fetch(url, headers)
-                            if body is not None:
-                                filename = url.split('/')[-1]
-                                upload = {'filename': filename, 'bytes': body}
-                                uploads.append(upload)
-                for channel in settings.CHANNELS:
-                    if upload:
-                        items.append([channel, content, {'uploads': uploads}])
-                    else:
-                        items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            title = url
+            feed = feedparser.parse(settings.URLS[url], agent=user_agent)
+            count = 0
+            stripchars = '\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    link = feed.entries[count].link
+                    content = bs4.BeautifulSoup(html.unescape(settings.NAME), 'html.parser').get_text() + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(html.unescape(feed.entries[count].description),'html.parser').get_text()).replace('```json','\n```json\n')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    upload = None
+                    if 'media_content' in feed.entries[count]:
+                        uploads = []
+                        for media in feed.entries[count]['media_content']:
+                            if 'url' in media:
+                                url = media['url']
+                                body = _safe_fetch(url, headers)
+                                if body is not None:
+                                    filename = url.split('/')[-1]
+                                    upload = {'filename': filename, 'bytes': body}
+                                    uploads.append(upload)
+                    for channel in settings.CHANNELS:
+                        if upload:
+                            items.append([channel, content, {'uploads': uploads}])
+                        else:
+                            items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((title, str(e)))  # title holds the source key; url is reassigned during media handling
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/microsoft/feed.py
+++ b/modules/microsoft/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/paloalto/feed.py
+++ b/modules/paloalto/feed.py
@@ -13,6 +13,7 @@
 # <content>: the content of the message, MD format possible
 
 import feedparser
+import feedutils
 import re
 
 
@@ -32,28 +33,33 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                filtered = False
-                if "security" in URL and "Severity: CRITICAL" in title: # Check for critical advisories
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    filtered = False
+                    if "security" in URL and "Severity: CRITICAL" in title: # Check for critical advisories
+                            filtered = True
+                    elif "unit42" in URL:
                         filtered = True
-                elif "unit42" in URL:
-                    filtered = True
-                if filtered:
-                    link = feed.entries[count].link
-                    content = settings.NAME + ': [' + title + '](' + link + ')'
-                    for channel in settings.CHANNELS:
-                        items.append([channel, content])
-                count += 1
-            except IndexError:
-                return items # No more items
-    return items
+                    if filtered:
+                        link = feed.entries[count].link
+                        content = settings.NAME + ': [' + title + '](' + link + ')'
+                        for channel in settings.CHANNELS:
+                            items.append([channel, content])
+                    count += 1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/silobreaker/feed.py
+++ b/modules/silobreaker/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/specterops/feed.py
+++ b/modules/specterops/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 
@@ -33,27 +34,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description)>400:
+                            description = description[:396]+' ...'
+                        content += '\n>'+description+'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count+=1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())

--- a/modules/watchtowr/feed.py
+++ b/modules/watchtowr/feed.py
@@ -14,6 +14,7 @@
 
 import bs4
 import feedparser
+import feedutils
 import re
 
 def query(settings=None):
@@ -31,27 +32,32 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = settings.NAME + ': [' + title + '](' + link + ')'
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description) > 400:
-                        description = description[:396] + ' ...'
-                    content += '\n>'+ description +'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count += 1
-            except IndexError:
-                return items # No more items
-    return items
+        try:
+            feed = feedparser.parse(URL, agent='MatterBot RSS Automation 1.0')
+            count = 0
+            stripchars = '`\\[\\]\'\"'
+            regex = re.compile('[%s]' % stripchars)
+            while count < settings.ENTRIES:
+                try:
+                    title = feed.entries[count].title
+                    link = feed.entries[count].link
+                    content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if len(feed.entries[count].description):
+                        description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
+                        if len(description) > 400:
+                            description = description[:396] + ' ...'
+                        content += '\n>'+ description +'\n'
+                    for channel in settings.CHANNELS:
+                        items.append([channel, content])
+                    count += 1
+                except IndexError:
+                    break # No more items
+        except Exception as e:
+            errors.append((URL, str(e)))
+            continue
+    return feedutils.result(items, errors)
 
 if __name__ == "__main__":
     print(query())


### PR DESCRIPTION
## What

Phase 2 of the partial-error work (Phase 1 = the `FeedResult` contract in #264). Migrates the multi-source feed modules to report per-source failures instead of dying on the first bad source.

## Why

A multi-source module loops over `settings.URLS`. Before this, if one source was unreachable/blocked or raised mid-parse, the **whole module died** and dropped the items already collected from the other sources. Worse, the inner `except IndexError: return items` returned from the *entire function* on the first short/empty feed, silently skipping every remaining URL.

## Change (per module)

- Wrap each source's processing in `try/except` — a failing source records `(source, message)` and the loop continues.
- Change the inner `except IndexError: return items` → `break` — a short feed ends only that source, not the whole run.
- `return feedutils.result(items, errors)` — `callModule` normalises it and logs partials centrally (`Partial : <module> …`).

Legacy behaviour otherwise identical; a source that succeeds produces exactly the same items as before.

## Scope — 16 modules

`aquasec broadcom checkpoint fortinet googlecloud microsoft paloalto silobreaker specterops watchtowr certau certca certeu certfi bluesky mastodon`

**Structure preserved exactly:** fortinet's FILTER/CVSS block, paloalto's critical/unit42 filtering, and **bluesky/mastodon's SSRF-guarded `_safe_fetch`** media handling are untouched. For the two dict-valued-`URLS` modules (bluesky/mastodon) the error label uses the stable source key (`title`) rather than the loop variable, which gets reassigned to a media URL during upload handling.

**Deliberately excluded:** `certes` and `certat/de/dk/hu/certtr` (in flight in other PRs — avoids conflicts), and single-source modules (partial-error reporting adds little; several already `log.exception` and carry `shelve` dedup logic that's risky to disturb).

## Testing

- All 16 byte-compile.
- Structural checks across all 16: one wrapped source loop, `IndexError`→`break`, single `feedutils.result(items, errors)` return, no stray `return items`.
- Diff-reviewed the non-uniform shapes (fortinet, paloalto, bluesky, mastodon) by hand.
- Runtime smoke on a representative (aquasec): with one source patched to raise and one to yield entries, `query()` returns a `FeedResult` whose `items` come from the healthy source and whose `errors` records `('bad://src', 'connection refused')` — i.e. one bad source no longer drops the rest.

## Depends on

#264 (FeedResult contract) — merged — and the #265 hotfix that makes `feedutils` importable at `callModule` time (also merged). Rebased on top of both.