### PR TITLE
Fix inverted FILTER polarity in fortinet

### DIFF
--- a/modules/fortinet/feed.py
+++ b/modules/fortinet/feed.py
@@ -53,6 +53,25 @@ def checkPage(link):
     except NameError:
         return matches
 
+def pageScore(matches):
+    # checkPage() has three possible return shapes: False (the page did not load),
+    # a (selection, tableScore) tuple, or a bare list of score elements. Collapse
+    # them into "the highest CVSS score found on the page, or None if there is
+    # none" so the caller has a single thing to compare against the threshold.
+    if not matches:
+        return None
+    if isinstance(matches, tuple):
+        candidates = [matches[1]]
+    else:
+        candidates = [score.text for score in matches]
+    scores = []
+    for candidate in candidates:
+        try:
+            scores.append(float(str(candidate).strip()))
+        except (TypeError, ValueError): # Not a score: e.g. a table header cell
+            continue
+    return max(scores) if scores else None
+
 def query(settings=None):
     if settings:
         try:
@@ -80,25 +99,14 @@ def query(settings=None):
                 content = None
                 if settings.FILTER:
                     THRESHOLD = importScore()
-                    matches = checkPage(link)
-                    filtered = False
-                    if not matches:
-                        cvss = False
-                        filtered = True
-                    else:
-                        if isinstance(matches, tuple): # Filter for return values from checkPage()
-                            cvss = matches[1]
-                            if float(cvss) >= THRESHOLD:
-                                filtered = True
-                        else:
-                            for score in matches:
-                                if float(score.text.strip()) >= THRESHOLD: # Check if CVSS score meets threshold
-                                    cvss = float(score.text.strip())
-                                    filtered = True
-                    if filtered:
+                    # FILTER means "only post advisories that meet the threshold", so an
+                    # advisory whose severity we cannot establish -- no CVSS on the page,
+                    # or the page did not load -- is skipped. It is not evidence of a
+                    # severe advisory, and posting it defeats the setting.
+                    cvss = pageScore(checkPage(link))
+                    if cvss is not None and cvss >= THRESHOLD:
                         content = settings.NAME + ': [' + title
-                        if cvss:
-                            content += f' - CVSS: `{cvss}`'
+                        content += f' - CVSS: `{cvss}`'
                         content += '](' + link + ')'
                 else:
                     content = settings.NAME + ': [' + title + '](' + link + ')'

--- a/tests/test_fortinet_filter.py
+++ b/tests/test_fortinet_filter.py
@@ -61,6 +61,13 @@ class _Feed:
         self.entries = entries
 
 
+class _Score:
+    """Stand-in for a bs4 element selected as a CVSS score cell."""
+
+    def __init__(self, text):
+        self.text = text
+
+
 class FortinetFilterTests(unittest.TestCase):
     def setUp(self):
         self.fortinet = _load_fortinet()
@@ -133,6 +140,52 @@ class FortinetFilterTests(unittest.TestCase):
         self.assertEqual(1, len(items))
         self.assertIn("Fortinet: [Critical bug - CVSS: `9.8`]", items[0][1])
         self.assertIn("https://example.invalid/high", items[0][1])
+
+
+class FortinetFilterPolarityTests(FortinetFilterTests):
+    """Issue #269: FILTER used to *post* advisories whose severity was unknown."""
+
+    def test_entry_with_no_cvss_on_the_page_is_not_posted(self):
+        # checkPage() finds no score elements -> severity unknown -> must not post.
+        entries = [_Entry("Unscored advisory", "https://example.invalid/none")]
+        items = self._run(entries, {"https://example.invalid/none": []})
+        self.assertEqual([], items)
+
+    def test_entry_whose_page_failed_to_load_is_not_posted(self):
+        # checkPage() returns False when the request raised -> severity unknown.
+        entries = [_Entry("Unreachable advisory", "https://example.invalid/dead")]
+        items = self._run(entries, {"https://example.invalid/dead": False})
+        self.assertEqual([], items)
+
+    def test_score_exactly_at_threshold_is_posted(self):
+        entries = [_Entry("Borderline", "https://example.invalid/edge")]
+        items = self._run(entries, {"https://example.invalid/edge": ("cvss", "7.0")})
+        self.assertEqual(1, len(items))
+        self.assertIn("CVSS: `7.0`", items[0][1])
+
+    def test_zero_score_is_a_score_not_an_absent_one(self):
+        # `if cvss:` used to treat a legitimate CVSS of 0.0 as "no score".
+        self.fortinet.importScore = lambda: 0.0
+        entries = [_Entry("Informational", "https://example.invalid/zero")]
+        items = self._run(entries, {"https://example.invalid/zero": ("cvss", "0.0")})
+        self.assertEqual(1, len(items))
+        self.assertIn("CVSS: `0.0`", items[0][1])
+
+    def test_highest_score_on_the_page_is_the_one_compared(self):
+        # A page listing several CVEs must be judged on its most severe score.
+        scores = [_Score("3.1"), _Score("9.1"), _Score("5.0")]
+        entries = [_Entry("Multi-CVE advisory", "https://example.invalid/multi")]
+        items = self._run(entries, {"https://example.invalid/multi": scores})
+        self.assertEqual(1, len(items))
+        self.assertIn("CVSS: `9.1`", items[0][1])
+
+    def test_unparseable_score_cells_are_ignored(self):
+        # Header/label cells swept up by the selector must not raise.
+        scores = [_Score("CVSS Rating"), _Score("8.2")]
+        entries = [_Entry("Advisory", "https://example.invalid/hdr")]
+        items = self._run(entries, {"https://example.invalid/hdr": scores})
+        self.assertEqual(1, len(items))
+        self.assertIn("CVSS: `8.2`", items[0][1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #269.

> **Stacked on #277** (same function — `modules/fortinet/feed.py::query`). Base is `fix/268-...`; it will retarget to `main` automatically once #277 merges. Review #277 first.

### The bug

`FILTER` was backwards. With it on, `query()` **posted** advisories whose severity it could not establish, and skipped ones it could:

```python
if not matches:
    cvss = False
    filtered = True      # <-- no CVSS data found => POST IT
```

`checkPage()` returns falsy in *two* different situations — the page carries no CVSS score, **and** the request raised (`except requests.exceptions.RequestException: matches = False`). Both were treated as "post it". Meanwhile an advisory that *did* carry a score, just below `THRESHOLD`, left `filtered` False and was skipped — the only part behaving as the setting intends.

Net: with `FILTER` on, unscored and unreachable advisories got through, and the flag `filtered = True` actually meant *keep*.

### The fix

`FILTER` means "only post advisories that meet the threshold". An advisory whose score is unknown is not evidence of a severe advisory, so it is now skipped.

⚠️ **Deliberate behaviour change:** unscored and unreachable advisories are no longer posted when `FILTER` is on. That is the point of the flag, but it will make some feeds quieter — calling it out explicitly rather than burying it.

A new `pageScore()` helper collapses `checkPage()`'s three return shapes (`False` / `(selection, tableScore)` / list of score elements) into "the highest CVSS score on the page, or `None`". One value to compare against the threshold, which also fixes two latent bugs:

- a legitimate CVSS of **0.0** was treated as "no score" by `if cvss:`;
- a **ValueError** when the selector swept up a non-numeric cell (e.g. the `CVSS Rating` table header).

Using the *highest* score means a multi-CVE advisory is judged on its most severe entry.

### Verification

Against the pre-fix code the new tests show the bug directly:

```
FAIL: test_entry_whose_page_failed_to_load_is_not_posted
  [] != [['news', 'Fortinet: [Unreachable advisory](https://example.invalid/dead)']]
FAIL: test_entry_with_no_cvss_on_the_page_is_not_posted
  [] != [['news', 'Fortinet: [Unscored advisory](https://example.invalid/none)']]
ERROR: test_unparseable_score_cells_are_ignored  (ValueError)
```

After: 14 fortinet tests pass, full suite 80 tests OK.

### Follow-up, not done here

`checkPage()` still cannot distinguish "no CVSS on the page" from "the page did not load" — both collapse to falsy. Once #266 lands, a fetch failure should surface as a `FeedResult` error rather than a silent skip. Tracked in #267.