### PR TITLE
Read the fortinet CVSS threshold once per run, not once per entry

### DIFF
--- a/modules/fortinet/feed.py
+++ b/modules/fortinet/feed.py
@@ -87,18 +87,20 @@ def query(settings=None):
         except ImportError:
             pass
     items = []
+    # The threshold is a constant for the whole run: read it once, not once per
+    # entry. importScore() re-runs a sys.path insert and an import every call.
+    THRESHOLD = importScore() if settings.FILTER else None
+    stripchars = '`\\[\\]\'\"'
+    regex = re.compile('[%s]' % stripchars)
     for URL in settings.URLS:
         feed = feedparser.parse(str(URL), agent='MatterBot RSS Automation 1.0')
         count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
         while count < settings.ENTRIES:
             try:
                 title = feed.entries[count].title
                 link = feed.entries[count].link
                 content = None
                 if settings.FILTER:
-                    THRESHOLD = importScore()
                     # FILTER means "only post advisories that meet the threshold", so an
                     # advisory whose severity we cannot establish -- no CVSS on the page,
                     # or the page did not load -- is skipped. It is not evidence of a

--- a/tests/test_fortinet_filter.py
+++ b/tests/test_fortinet_filter.py
@@ -188,5 +188,42 @@ class FortinetFilterPolarityTests(FortinetFilterTests):
         self.assertIn("CVSS: `8.2`", items[0][1])
 
 
+class FortinetThresholdHoistTests(FortinetFilterTests):
+    """Issue #275: the threshold is a constant, but was re-read for every entry."""
+
+    def test_threshold_is_read_once_per_run_not_once_per_entry(self):
+        calls = []
+
+        def counting_importScore():
+            calls.append(1)
+            return 7.0
+
+        self.fortinet.importScore = counting_importScore
+        self.settings["URLS"] = ["https://example.invalid/a", "https://example.invalid/b"]
+        entries = [
+            _Entry("One", "https://example.invalid/1"),
+            _Entry("Two", "https://example.invalid/2"),
+            _Entry("Three", "https://example.invalid/3"),
+        ]
+        scores = {e.link: ("cvss", "9.8") for e in entries}
+        items = self._run(entries, scores)
+
+        # 2 URLs x 3 entries = 6 posts, but importScore() re-runs a sys.path
+        # insert and an import on every call, so it must run exactly once.
+        self.assertEqual(6, len(items))
+        self.assertEqual(1, len(calls), f"importScore() called {len(calls)}x, expected 1")
+
+    def test_threshold_is_not_read_at_all_when_filtering_is_off(self):
+        def exploding_importScore():
+            raise AssertionError("importScore() must not run when FILTER is off")
+
+        self.fortinet.importScore = exploding_importScore
+        self.settings["FILTER"] = False
+        entries = [_Entry("Anything", "https://example.invalid/x")]
+        items = self._run(entries, {})
+        self.assertEqual(1, len(items))
+        self.assertIn("Fortinet: [Anything](https://example.invalid/x)", items[0][1])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #275.

> **Stacked on #278 → #277** (all three touch `modules/fortinet/feed.py::query`). Review #277 and #278 first; this retargets to `main` as they merge.

### The waste

```python
while count < settings.ENTRIES:
    if settings.FILTER:
        THRESHOLD = importScore()      # <-- per entry
        ...
```

`importScore()` re-runs a `sys.path` insert and re-imports `opencve.defaults` on **every call**, to fetch a constant that cannot change during the run. With `ENTRIES=10` across N feed URLs that is 10×N redundant imports.

### The fix

Hoist `THRESHOLD` above the URL loop, and skip it entirely when `FILTER` is off. The `stripchars` regex — rebuilt once per URL — comes with it.

### Verification

The test asserts `importScore()` runs exactly once across 2 URLs × 3 entries. Against the old code:

```
AssertionError: 1 != 6 : importScore() called 6x, expected 1
```

Full suite: 86 tests, OK.

### Not fixed here

`checkPage(link)` still issues one blocking, sequential HTTP GET per entry, so the module's runtime remains `entries × urls × page-latency`. That is inherent to needing each advisory's page, and parallelising it is a larger change than this PR wants to be — noted in #275 as follow-up.