### PR TITLE
Stop a malformed error entry from discarding a module's posts

### DIFF
--- a/matterfeed.py
+++ b/matterfeed.py
@@ -420,7 +420,15 @@ class MattermostManager(object):
             # hand the posts back to the caller unchanged either way.
             import feedutils
             items, errors = feedutils.split_result(func(*args, **kwargs))
-            for source, message in errors:
+            # Reporting an error must never cost us the posts we already have.
+            # split_result() guarantees well-formed pairs, but this loop runs
+            # after the module's posts were collected, so a raise here would be
+            # caught below and discard all of them -- belt and braces.
+            for error in errors:
+                try:
+                    source, message = error
+                except (TypeError, ValueError):
+                    source, message = feedutils.UNKNOWN_SOURCE, error
                 self.log.info(f"Partial  : {module_name} module: {source}: {message}")
             return items
         except Exception as e:

--- a/modules/feedutils.py
+++ b/modules/feedutils.py
@@ -22,9 +22,41 @@ _DESCRIPTION_RX = re.compile('[%s]' % _STRIPCHARS)
 FeedResult = namedtuple('FeedResult', ['items', 'errors'])
 
 
+UNKNOWN_SOURCE = '<unknown source>'
+
+
+def normalise_errors(errors):
+    """Coerce a module's `errors` into a list of (source, message) string pairs.
+
+    Every module hand-builds its own error list, so one of them will eventually
+    append a bare string, or a 3-tuple, or None. The main loop unpacks these
+    entries -- and it does so *after* the module's posts have already been
+    collected, so an unpackable entry used to take the whole run down with it
+    and discard every post the module had gathered.
+
+    Reporting an error must never be able to destroy the posts that the same
+    run succeeded in fetching. So a malformed entry is repaired here rather than
+    raised on: whatever it holds is kept as the message, under an unknown source,
+    where an operator will still see it.
+    """
+    if not errors:
+        return []
+    normalised = []
+    for entry in errors:
+        if isinstance(entry, (tuple, list)) and len(entry) == 2:
+            source, message = entry
+        elif isinstance(entry, (tuple, list)):
+            # Wrong arity: keep everything, rather than silently dropping a field.
+            source, message = UNKNOWN_SOURCE, ', '.join(str(part) for part in entry)
+        else:
+            source, message = UNKNOWN_SOURCE, entry
+        normalised.append((str(source), str(message)))
+    return normalised
+
+
 def result(items=None, errors=None):
     """Build a FeedResult from collected posts and (source, message) errors."""
-    return FeedResult(list(items) if items else [], list(errors) if errors else [])
+    return FeedResult(list(items) if items else [], normalise_errors(errors))
 
 
 def split_result(value):
@@ -33,9 +65,14 @@ def split_result(value):
     Accepts the legacy contract (a plain list, or None) -- for which errors is
     always empty -- as well as a FeedResult. This is what the main loop calls
     so that both old and migrated modules go through one code path.
+
+    Errors are normalised here too, not only in result(): a module can build a
+    FeedResult directly, and the caller unpacks these pairs, so the guarantee
+    has to hold at the boundary the caller actually reads from.
     """
     if isinstance(value, FeedResult):
-        return list(value.items) if value.items else [], list(value.errors) if value.errors else []
+        items = list(value.items) if value.items else []
+        return items, normalise_errors(value.errors)
     if value is None:
         return [], []
     return list(value), []

--- a/tests/test_feed_result.py
+++ b/tests/test_feed_result.py
@@ -55,6 +55,60 @@ class SplitResultTests(unittest.TestCase):
         self.assertEqual([["news", "a"]], src)
 
 
+class MalformedErrorTests(unittest.TestCase):
+    """Issue #271: a bad error entry must not destroy the posts of the same run.
+
+    `callModule` does `for source, message in errors:` *after* the module's posts
+    have been collected. An entry that will not unpack into two values raised
+    ValueError there, which the outer handler turned into "the module call
+    failed" -- throwing away every post the module had successfully gathered.
+    """
+
+    def _consume(self, value):
+        """Stand in for what callModule does with a query() return value."""
+        items, errors = feedutils.split_result(value)
+        logged = [f"{source}: {message}" for source, message in errors]  # must not raise
+        return items, logged
+
+    def test_bare_string_error_does_not_discard_the_posts(self):
+        r = feedutils.result(items=[["news", "kept"]], errors=["everything broke"])
+        items, logged = self._consume(r)
+        self.assertEqual([["news", "kept"]], items)
+        self.assertEqual([f"{feedutils.UNKNOWN_SOURCE}: everything broke"], logged)
+
+    def test_wrong_arity_error_does_not_discard_the_posts(self):
+        r = feedutils.result(items=[["news", "kept"]], errors=[("feed", "403", "extra")])
+        items, logged = self._consume(r)
+        self.assertEqual([["news", "kept"]], items)
+        self.assertEqual(1, len(logged))
+        # Nothing is silently dropped: both fields survive into the message.
+        self.assertIn("403", logged[0])
+        self.assertIn("extra", logged[0])
+
+    def test_none_error_entry_does_not_discard_the_posts(self):
+        r = feedutils.result(items=[["news", "kept"]], errors=[None])
+        items, _ = self._consume(r)
+        self.assertEqual([["news", "kept"]], items)
+
+    def test_exception_object_as_error_is_stringified(self):
+        r = feedutils.result(items=[], errors=[("feed", ValueError("bad payload"))])
+        _, errors = feedutils.split_result(r)
+        self.assertEqual([("feed", "bad payload")], errors)
+
+    def test_hand_built_feedresult_is_normalised_too(self):
+        # A module can bypass result() and construct the namedtuple directly;
+        # the guarantee has to hold at the boundary callModule reads from.
+        r = feedutils.FeedResult(items=[["news", "kept"]], errors=["oops"])
+        items, logged = self._consume(r)
+        self.assertEqual([["news", "kept"]], items)
+        self.assertEqual([f"{feedutils.UNKNOWN_SOURCE}: oops"], logged)
+
+    def test_well_formed_errors_are_untouched(self):
+        r = feedutils.result(items=[], errors=[("http://x/feed", "403 blocked")])
+        _, errors = feedutils.split_result(r)
+        self.assertEqual([("http://x/feed", "403 blocked")], errors)
+
+
 class ResultFactoryTests(unittest.TestCase):
     def test_empty_result_is_two_empty_lists(self):
         r = feedutils.result()
@@ -74,14 +128,17 @@ class ResultFactoryTests(unittest.TestCase):
         self.assertEqual([("feed", "err")], r.errors)
 
     def test_is_a_named_2_tuple(self):
-        r = feedutils.result(items=[1], errors=[2])
-        self.assertEqual((([1]), ([2])), (r.items, r.errors))
+        # The error entry here is a well-formed (source, message) pair: result()
+        # now enforces that shape at construction, so a placeholder scalar would
+        # be normalised and obscure what this test is actually about.
+        r = feedutils.result(items=[1], errors=[("feed", "err")])
+        self.assertEqual(([1], [("feed", "err")]), (r.items, r.errors))
         # namedtuple: unpackable and indexable, so existing list-style handling
         # of a FeedResult (were one passed straight through) still degrades
         # predictably rather than raising oddly.
         items, errors = r
         self.assertEqual([1], items)
-        self.assertEqual([2], errors)
+        self.assertEqual([("feed", "err")], errors)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #271.

### The bug

`callModule` unpacks a module's per-source errors **after** its posts have been collected:

```python
items, errors = feedutils.split_result(func(*args, **kwargs))
for source, message in errors:          # <-- unconditional 2-tuple unpack
    self.log.info(...)
return items
```

The `errors` list is hand-built by every module (16 more landing in #266). A module that appends a bare string, or a 3-tuple, makes this loop raise `ValueError: too many values to unpack`. That propagates to `callModule`'s outer `except Exception`, which returns `None` — **throwing away every post the module successfully gathered in that run**, and logging it as a failed call.

A logging mistake should not be able to destroy data. That's the whole shape of the bug: the error-reporting path can kill the success path.

### The fix

Normalise error entries into `(source, message)` string pairs at the boundary — `feedutils.normalise_errors()`, called from **both** `result()` and `split_result()`. Both, because a module can construct a `FeedResult` directly and bypass `result()`, and the guarantee has to hold where the caller actually reads.

A malformed entry is **repaired, not raised on**: its content is kept as the message under `<unknown source>`, so an operator still sees it and nothing is silently dropped. `callModule` also unpacks defensively, so a module bypassing `feedutils` entirely still cannot cost us its posts.

### Verification

The new tests exercise the consume path exactly as `callModule` does. Against the pre-fix code, 4 error out and 1 fails:

```
ERROR: test_bare_string_error_does_not_discard_the_posts
ERROR: test_wrong_arity_error_does_not_discard_the_posts
ERROR: test_none_error_entry_does_not_discard_the_posts
ERROR: test_hand_built_feedresult_is_normalised_too
FAIL:  test_exception_object_as_error_is_stringified
```

After: full suite 72 tests, OK.

### One existing test changed — please look at this

`test_is_a_named_2_tuple` called `feedutils.result(items=[1], errors=[2])` and asserted `r.errors == [2]`. That test exists to check `FeedResult` is an unpackable 2-field namedtuple; `2` was an arbitrary placeholder, and a scalar is not a valid error under the documented `(source, message)` contract. Since `result()` now enforces that contract at construction, the fixture uses a well-formed pair and the namedtuple assertions are unchanged.

I'm calling it out rather than burying it: changing an existing test to make a change pass is exactly the move that should get a second pair of eyes. If you'd rather `result()` stayed a dumb passthrough and the normalisation lived only in `split_result()`, that also closes the bug — say so and I'll move it.