### PR TITLE
Stop reporting a module with every source dead as a successful run

### DIFF
--- a/matterfeed.py
+++ b/matterfeed.py
@@ -376,6 +376,10 @@ class MattermostManager(object):
                 self.log.error(f"Error   : {module_name} ...\nTraceback: {traceback.format_exc()}")
             else:
                 self.log.error(f"Error   : {module_name} module failed: {str(e)}")
+            # Re-raise: runModules() counts a module as successful unless its
+            # future raises, so swallowing here reported every failure -- a dead
+            # feed, a crashing module -- as "ran successfully".
+            raise
         finally:
             if history:
                 history.sync()
@@ -415,22 +419,9 @@ class MattermostManager(object):
 
             # Run the module and normalise its return. A module may return the
             # legacy plain list of posts, or a feedutils.FeedResult carrying
-            # both posts and per-source errors. Log any partial errors here,
-            # centrally, so a module never has to swallow them silently, and
-            # hand the posts back to the caller unchanged either way.
+            # both posts and per-source errors.
             import feedutils
             items, errors = feedutils.split_result(func(*args, **kwargs))
-            # Reporting an error must never cost us the posts we already have.
-            # split_result() guarantees well-formed pairs, but this loop runs
-            # after the module's posts were collected, so a raise here would be
-            # caught below and discard all of them -- belt and braces.
-            for error in errors:
-                try:
-                    source, message = error
-                except (TypeError, ValueError):
-                    source, message = feedutils.UNKNOWN_SOURCE, error
-                self.log.info(f"Partial  : {module_name} module: {source}: {message}")
-            return items
         except Exception as e:
             if options.debug:
                 self.log.error(f"Error   :{str(e)}\nTraceback: {traceback.format_exc()}")
@@ -442,6 +433,34 @@ class MattermostManager(object):
                 del sys.modules[spec.name]
                 if options.debug:
                     self.log.info(f"Unloaded : {module_name} ({spec.name}) module ...")
+        # Deliberately outside the handler above: a module whose every source
+        # failed is reported by raising, and that catch-all would swallow the
+        # very signal meant to report it.
+        return self.reportSources(module_name, items, errors)
+
+    def reportSources(self, module_name, items, errors):
+        '''
+        Log a module's per-source errors and decide what its run amounted to.
+        Errors alongside posts is a partial failure; errors with no posts at all
+        means the module is dark, which must not be counted as a successful run.
+        '''
+        import feedutils
+        verdict = feedutils.classify(items, errors)
+        for error in errors:
+            # Reporting an error must never cost us the posts we already have:
+            # split_result() guarantees well-formed pairs, but this runs after
+            # the module's posts were collected, so it stays defensive.
+            try:
+                source, message = error
+            except (TypeError, ValueError):
+                source, message = feedutils.UNKNOWN_SOURCE, error
+            if verdict == feedutils.FAILED:
+                self.log.error(f"Failed   : {module_name} module: {source}: {message}")
+            else:
+                self.log.warning(f"Partial  : {module_name} module: {source}: {message}")
+        if verdict == feedutils.FAILED:
+            raise feedutils.AllSourcesFailed(f"{module_name}: all {len(errors)} source(s) failed, no posts collected")
+        return items
 
 
 def main(log):

--- a/modules/feedutils.py
+++ b/modules/feedutils.py
@@ -24,6 +24,34 @@ FeedResult = namedtuple('FeedResult', ['items', 'errors'])
 
 UNKNOWN_SOURCE = '<unknown source>'
 
+# How a module's run turned out, given what it returned.
+OK = 'ok'            # nothing went wrong
+PARTIAL = 'partial'  # some sources failed, but posts were still collected
+FAILED = 'failed'    # every source failed and nothing was collected
+
+
+class AllSourcesFailed(Exception):
+    """Raised when a module reported errors and collected nothing at all.
+
+    A module that returns FeedResult([], errors) has not "run successfully with
+    no news" -- it is dark. Without this, the empty list is indistinguishable
+    from a quiet feed, the run is counted as a success, and a module whose every
+    source is 403ing reports "16/16 modules ran successfully" indefinitely.
+    """
+
+
+def classify(items, errors):
+    """Decide whether a module's run was OK, PARTIAL, or FAILED.
+
+    The distinction that matters: errors *with* posts is a partial failure worth
+    a warning, errors *without* any posts is a dead module worth an error and a
+    failed count. No errors at all is fine, however few posts came back -- a
+    quiet feed is not a broken one.
+    """
+    if not errors:
+        return OK
+    return PARTIAL if items else FAILED
+
 
 def normalise_errors(errors):
     """Coerce a module's `errors` into a list of (source, message) string pairs.

--- a/tests/test_feed_result.py
+++ b/tests/test_feed_result.py
@@ -109,6 +109,43 @@ class MalformedErrorTests(unittest.TestCase):
         self.assertEqual([("http://x/feed", "403 blocked")], errors)
 
 
+class ClassifyTests(unittest.TestCase):
+    """Issue #270: a module whose every source failed was counted as a success.
+
+    callModule returned FeedResult([], errors).items -- an empty list -- which is
+    indistinguishable from a quiet feed. Nothing raised, so runModules counted it
+    as successful and printed "N/N modules ran successfully" while the module was
+    completely dark.
+    """
+
+    def test_no_errors_is_ok(self):
+        self.assertEqual(feedutils.OK, feedutils.classify([["news", "a"]], []))
+
+    def test_a_quiet_feed_is_not_a_broken_one(self):
+        # No posts and no errors: the feed simply had nothing new. Not a failure.
+        self.assertEqual(feedutils.OK, feedutils.classify([], []))
+
+    def test_errors_alongside_posts_is_partial(self):
+        verdict = feedutils.classify([["news", "a"]], [("feed-2", "timeout")])
+        self.assertEqual(feedutils.PARTIAL, verdict)
+
+    def test_errors_with_no_posts_is_a_failure(self):
+        # The case the issue is about: every source 403s, nothing collected.
+        verdict = feedutils.classify([], [("feed-1", "403"), ("feed-2", "403")])
+        self.assertEqual(feedutils.FAILED, verdict)
+
+    def test_failed_is_distinguishable_from_ok_on_an_empty_item_list(self):
+        # Both return zero posts; only the errors tell them apart. This is
+        # precisely the distinction the old `if items:` check could not make.
+        self.assertNotEqual(
+            feedutils.classify([], [("feed", "403")]),
+            feedutils.classify([], []),
+        )
+
+    def test_all_sources_failed_is_an_exception_the_caller_can_raise(self):
+        self.assertTrue(issubclass(feedutils.AllSourcesFailed, Exception))
+
+
 class ResultFactoryTests(unittest.TestCase):
     def test_empty_result_is_two_empty_lists(self):
         r = feedutils.result()


### PR DESCRIPTION
Fixes #270.

> **Stacked on #280** (both touch `callModule`'s return handling). Retargets to `main` once #280 merges.

### The bug

A module whose sources all failed returns `FeedResult([], errors)`. `callModule` handed back the empty item list, nothing raised, `runModule`'s `if items:` simply skipped — so `runModules` counted it a success:

```
Finished : 16/16 modules ran successfully, sleeping N seconds ...
```

…while the module had been completely dark for days. The only trace was a `log.info` line labelled `Partial`, at the same level as routine posting chatter — and "Partial" is plainly wrong when *nothing* succeeded.

The root of it: **an empty item list means two different things** — a quiet feed and a dead one — and `if items:` cannot tell them apart. Only the errors can.

### It's worse than I filed

`runModule` catches `Exception`, logs, and **does not re-raise**. `runModules` only counts a module failed if its future raises. So today *every* module failure short of a timeout — including a hard crash inside `callModule` — is already counted as a success. The FeedResult case is one instance of a broader hole.

### The fix

- **`feedutils.classify()`** names the three outcomes: `OK` (no errors — however few posts; *a quiet feed is not a broken one*), `PARTIAL` (errors alongside posts), `FAILED` (errors and nothing collected).
- **`callModule.reportSources()`**: partial errors log at `WARNING` and keep their posts; a total failure logs at `ERROR` per source and raises `feedutils.AllSourcesFailed`. The triage sits **outside** `callModule`'s catch-all on purpose — inside, that handler would swallow the very signal meant to report the failure.
- **`runModule` re-raises** instead of swallowing, so `runModules` actually counts it.

### Verification

Driving `reportSources` against the real code, all five cases:

```
1. clean run (posts, no errors)          -> returned [['news', 'a']]
2. quiet feed (no posts, no errors)      -> returned []                    # not a failure
3. partial (posts + one dead source)     -> returned [['news', 'a']]
   log[WARN]  Partial  : acme module: http://x/feed: 403 blocked
4. TOTAL FAILURE (every source dead)     -> RAISED AllSourcesFailed: acme: all 2 source(s) failed
   log[ERROR] Failed   : acme module: http://x/feed: 403
   log[ERROR] Failed   : acme module: http://y/feed: timeout
5. malformed error entry                 -> returned [['news', 'a']]       # posts survive (#271)
```

Unit tests for `classify()` cover the boundary that matters — `classify([], [error])` and `classify([], [])` must not be equal. Full suite: 78 tests, OK.

### Behaviour change to be aware of

The "N/N modules ran successfully" line will start reporting failures it previously hid. That is the point, but on a feeder with a few chronically broken sources the first run after this will look alarming. It is showing you something that was always true.