### PR TITLE
Stop feed modules putting modules/ ahead of the stdlib on sys.path

### DIFF
--- a/modules/abb/feed.py
+++ b/modules/abb/feed.py
@@ -20,7 +20,7 @@ import feedparser
 try:
     from feedutils import clean_description, load_settings
 except ImportError:
-    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
     from feedutils import clean_description, load_settings
 
 

--- a/modules/akamai/feed.py
+++ b/modules/akamai/feed.py
@@ -20,7 +20,7 @@ import feedparser
 try:
     from feedutils import clean_description, load_settings
 except ImportError:
-    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
     from feedutils import clean_description, load_settings
 
 

--- a/modules/fortinet/feed.py
+++ b/modules/fortinet/feed.py
@@ -25,7 +25,7 @@ def importScore():
     running = os.path.abspath(__file__)
     cwd = os.path.abspath(os.path.join(os.path.dirname(running), '..'))
     if cwd not in sys.path:
-        sys.path.insert(0, cwd)
+        sys.path.append(cwd)
     from opencve.defaults import ADVISORYTHRESHOLD # Import threshold score from opencve module
     return ADVISORYTHRESHOLD
 

--- a/modules/siemens/feed.py
+++ b/modules/siemens/feed.py
@@ -21,7 +21,7 @@ def importScore():
     running = os.path.abspath(__file__)
     cwd = os.path.abspath(os.path.join(os.path.dirname(running), '..'))
     if cwd not in sys.path:
-        sys.path.insert(0, cwd)
+        sys.path.append(cwd)
     from opencve.defaults import ADVISORYTHRESHOLD # Import threshold score from opencve module
     return ADVISORYTHRESHOLD
 

--- a/modules/sonicwall/feed.py
+++ b/modules/sonicwall/feed.py
@@ -24,7 +24,7 @@ def importScore():
     running = os.path.abspath(__file__)
     cwd = os.path.abspath(os.path.join(os.path.dirname(running), '..'))
     if cwd not in sys.path:
-        sys.path.insert(0, cwd)
+        sys.path.append(cwd)
     from opencve.defaults import ADVISORYTHRESHOLD # Import threshold score from opencve module
     return ADVISORYTHRESHOLD
 

--- a/modules/sploitus/feed.py
+++ b/modules/sploitus/feed.py
@@ -22,7 +22,7 @@ def importScore():
     running = os.path.abspath(__file__)
     cwd = os.path.abspath(os.path.join(os.path.dirname(running), '..'))
     if cwd not in sys.path:
-        sys.path.insert(0, cwd)
+        sys.path.append(cwd)
     from opencve.defaults import ADVISORYTHRESHOLD # Import threshold score from opencve module
     return ADVISORYTHRESHOLD
 

--- a/modules/veeam/feed.py
+++ b/modules/veeam/feed.py
@@ -23,7 +23,7 @@ def importScore():
     running = os.path.abspath(__file__)
     cwd = os.path.abspath(os.path.join(os.path.dirname(running), '..'))
     if cwd not in sys.path:
-        sys.path.insert(0, cwd)
+        sys.path.append(cwd)
     from opencve.defaults import ADVISORYTHRESHOLD # Import threshold score from opencve module
     return ADVISORYTHRESHOLD
 

--- a/modules/zerodayinitiative/feed.py
+++ b/modules/zerodayinitiative/feed.py
@@ -23,7 +23,7 @@ def importScore():
     running = os.path.abspath(__file__)
     cwd = os.path.abspath(os.path.join(os.path.dirname(running), '..'))
     if cwd not in sys.path:
-        sys.path.insert(0, cwd)
+        sys.path.append(cwd)
     from opencve.defaults import ADVISORYTHRESHOLD # Import threshold score from opencve module
     return ADVISORYTHRESHOLD
 

--- a/tests/test_import_path_safety.py
+++ b/tests/test_import_path_safety.py
@@ -1,0 +1,100 @@
+"""Guard tests for how modules put their own directory on sys.path (issue #282).
+
+`modules/socket/` has an `__init__.py`, which makes it a *regular package* --
+not a namespace portion. A regular package wins the import scan outright, so it
+shadows the stdlib `socket` for any `sys.path` entry that precedes the stdlib:
+
+    >>> sys.path.insert(0, 'modules'); import socket
+    >>> socket.__file__
+    '.../modules/socket/__init__.py'
+    >>> hasattr(socket, 'socket')
+    False
+
+Anything importing `socket` fresh after that dies -- `multiprocessing.reduction`
+does exactly that, on `socket.socket`.
+
+Feed modules legitimately need `modules/` on the path (for `feedutils`, and for
+`from opencve.defaults import ...`). Appending finds those just as well while
+leaving the stdlib ahead of `modules/`, so the collision cannot happen. Placing
+it at position 0 is what arms the bug.
+
+These checks are static (AST only), so they need none of the feeds' third-party
+dependencies.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO_ROOT / "modules"
+
+
+def _sys_path_inserts_at_front(source, filename="<unknown>"):
+    """Yield lineno for every `sys.path.insert(0, ...)` call in `source`."""
+    tree = ast.parse(source, filename=filename)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # match sys.path.insert(...)
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr == "insert"
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "path"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "sys"
+        ):
+            continue
+        if not node.args:
+            continue
+        index = node.args[0]
+        if isinstance(index, ast.Constant) and index.value == 0:
+            yield node.lineno
+
+
+class ImportPathSafetyTests(unittest.TestCase):
+    def test_the_shadowing_hazard_is_real(self):
+        # If this ever fails, modules/socket stopped being a regular package and
+        # the guard below is no longer load-bearing -- worth knowing either way.
+        self.assertTrue(
+            (MODULES_DIR / "socket" / "__init__.py").exists(),
+            "modules/socket/__init__.py is gone; re-evaluate test_no_module_puts_itself_ahead_of_the_stdlib",
+        )
+
+    def test_no_module_puts_itself_ahead_of_the_stdlib(self):
+        offenders = []
+        for path in sorted(MODULES_DIR.rglob("*.py")):
+            source = path.read_text(encoding="utf-8", errors="replace")
+            for lineno in _sys_path_inserts_at_front(source):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
+        self.assertEqual(
+            [],
+            offenders,
+            "sys.path.insert(0, ...) puts modules/ ahead of the stdlib, where "
+            "modules/socket shadows the stdlib socket. Use sys.path.append(...) "
+            "instead -- it finds feedutils/opencve just as well. Offenders: "
+            + ", ".join(offenders),
+        )
+
+
+class DetectorTests(unittest.TestCase):
+    """The guard is only worth having if it actually detects the pattern."""
+
+    def test_detects_insert_at_zero(self):
+        src = "import sys\nsys.path.insert(0, 'modules')\n"
+        self.assertEqual([2], list(_sys_path_inserts_at_front(src, "<test>")))
+
+    def test_ignores_append(self):
+        src = "import sys\nsys.path.append('modules')\n"
+        self.assertEqual([], list(_sys_path_inserts_at_front(src, "<test>")))
+
+    def test_ignores_insert_at_a_later_index(self):
+        # Only position 0 puts the dir ahead of the stdlib entries.
+        src = "import sys\nsys.path.insert(1, 'modules')\n"
+        self.assertEqual([], list(_sys_path_inserts_at_front(src, "<test>")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #282. Found while working on #274.

### The bug

`modules/socket/` has an `__init__.py`, making it a **regular package**, not a namespace portion. A regular package wins the import scan outright — so it shadows the stdlib `socket` for any `sys.path` entry that precedes the stdlib:

```console
$ python3 -c "import sys; sys.path.insert(0, 'modules'); import socket; print(socket.__file__, hasattr(socket,'socket'))"
/Users/.../MatterBot/modules/socket/__init__.py False
```

Anything importing `socket` fresh after that dies. `multiprocessing.reduction` does exactly that — which is how I found it, for real:

```
File ".../multiprocessing/reduction.py", line 248, in <module>
    register(socket.socket, _reduce_socket)
AttributeError: module 'socket' has no attribute 'socket'
```

Eight feed modules call `sys.path.insert(0, <modules dir>)` — including `fortinet`'s `importScore()`, which runs **inside the feeder at runtime**.

### Why it hasn't bitten you yet

`socket` is already in `sys.modules` from matterfeed's startup imports, and cached imports never re-scan `sys.path`; forked workers inherit that cache. The hazard is armed but not triggered.

Two things suppress it, both by accident:
- `callModule`'s `sys.path.append(module_path)` puts that same absolute path in `sys.path`, so `importScore()`'s `if cwd not in sys.path` guard **skips its insert(0)**.
- Nothing imports `socket` late.

That first one matters: **#274 removes that append**, which re-arms this. Hence this lands first.

### The fix

`sys.path.insert(0, ...)` → `sys.path.append(...)` in the 8 offenders. They need `modules/` on the path for `feedutils` and `from opencve.defaults import ...`; appending finds both just as well, while leaving the stdlib ahead of `modules/`. Position 0 is the only thing that arms the collision.

`matterbot.py:89` is left alone — it inserts the *repo root* (parent of `commands/`) for package-prefixed imports, which is deliberate and collides with nothing.

### Verification

Simulating the new `append` behaviour:

```
opencve import via append   : OK (ADVISORYTHRESHOLD=7.0)
feedutils import via append : OK (feedutils.py)
socket resolves to          : .../lib/python3.9/socket.py
socket.socket present       : True
SHADOWED BY modules/socket  : False
multiprocessing.reduction   : imported cleanly     # the thing that crashed before
```

A static AST guard (`tests/test_import_path_safety.py`) asserts no module places its directory at `sys.path[0]`. Against the old tree it names all eight:

```
Offenders: modules/abb/feed.py:23, modules/akamai/feed.py:23, modules/fortinet/feed.py:28,
modules/siemens/feed.py:24, modules/sonicwall/feed.py:27, modules/sploitus/feed.py:25,
modules/veeam/feed.py:26, modules/zerodayinitiative/feed.py:26
```

The detector has its own tests (catches `insert(0, ...)`, ignores `append` and `insert(1, ...)`) — a guard that cannot fail is not a guard. Full suite: 71 tests, OK.

### Considered and rejected

Deleting `modules/socket/__init__.py` to demote it to a namespace portion. All 210 modules carry one uniformly, and they are load-bearing (`from opencve.defaults import ...` is a real package import). Fixing the path *order* is the smaller, more general fix — it protects against any future stdlib-colliding module name, not just `socket`.