### PR TITLE
Stop botscout/proxycheck/mwdb leaking the API key into the channel on error

### DIFF
--- a/commands/botscout/command.py
+++ b/commands/botscout/command.py
@@ -72,8 +72,12 @@ def process(command, channel, username, params, files, conn):
                     messages.append({'text': message})
                 else:
                     messages.append({'text': 'An error occurred querying the BotScout API:\nError: `%s`' % (response.content,)})
-        except Exception as e:
+        except Exception:
+            # Never interpolate str(e) into a channel message: for this module the
+            # API key is in the request URL, and an HTTP error's string carries that
+            # URL, so str(e) leaks the key into the channel. The traceback is logged
+            # server-side above; the channel gets a flat, credential-free line.
             log.exception("botscout module error")
-            messages.append({'text': 'An error occurred in the BotScout module:\nError: `%s`' % (str(e),)})
+            messages.append({'text': 'The BotScout lookup failed; see the bot log for details.'})
         finally:
             return {'messages': messages}

--- a/commands/mwdb/command.py
+++ b/commands/mwdb/command.py
@@ -350,8 +350,12 @@ def process(command, channel, username, params, files, conn):
                     messages.append({'text': message})
                 if len(downloads):
                     messages.append({'text': "**MWDB**: *Sample download(s)*", 'uploads': downloads})
-        except Exception as e:
+        except Exception:
+            # Never interpolate str(e) into a channel message: for this module the
+            # API key is in the request URL, and an HTTP error's string carries that
+            # URL, so str(e) leaks the key into the channel. The traceback is logged
+            # server-side above; the channel gets a flat, credential-free line.
             log.exception("mwdb module error")
-            messages.append({'text': 'A Python error occurred searching the MWDB API: `%s`' % (str(e))})
+            messages.append({'text': 'The MWDB lookup failed; see the bot log for details.'})
         finally:
             return {'messages': messages}

--- a/commands/proxycheck/command.py
+++ b/commands/proxycheck/command.py
@@ -152,8 +152,12 @@ def process(command, channel, username, params, files, conn):
                                 message += "\n\n"
                             if len(message):
                                 messages.append({'text': message})
-        except Exception as e:
+        except Exception:
+            # Never interpolate str(e) into a channel message: for this module the
+            # API key is in the request URL, and an HTTP error's string carries that
+            # URL, so str(e) leaks the key into the channel. The traceback is logged
+            # server-side above; the channel gets a flat, credential-free line.
             log.exception("proxycheck module error")
-            messages.append({'text': 'An error occurred in the ProxyCheck module:\nError: `%s`' % (str(e),)})
+            messages.append({'text': 'The ProxyCheck lookup failed; see the bot log for details.'})
         finally:
             return {'messages': messages}

--- a/tests/test_command_error_disclosure.py
+++ b/tests/test_command_error_disclosure.py
@@ -1,0 +1,110 @@
+"""Guard against command modules leaking secrets through error messages.
+
+Some command modules build their request URL with the API key in the query
+string (e.g. `...?key=<APIKEY>`). A `requests` HTTPError stringifies to include
+the offending URL, so interpolating `str(e)` of such an error into a channel
+message posts the API key into Mattermost -- a credential leak into a widely
+readable, long-lived chat log. The single most common trigger is a wrong or
+expired key, which returns 401.
+
+These modules put the key in the URL *and* used to post `str(e)`:
+botscout, proxycheck, mwdb. This test pins them shut: their exception handler
+must not interpolate the caught exception into a `messages.append(...)`.
+
+The check is static (AST only), so it needs none of the modules' third-party
+dependencies.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Modules that place the API key in the request URL: for these, any exception
+# string reaching the channel is a credential leak. Regression-locked here.
+KEY_IN_URL_MODULES = ("botscout", "proxycheck", "mwdb")
+
+
+def _names_bound_to_caught_exceptions(tree):
+    """Return the set of identifiers bound as `except ... as <name>`."""
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler) and node.name:
+            names.add(node.name)
+    return names
+
+
+def _messages_append_calls(tree):
+    """Yield ast.Call nodes that look like `<something>.append(...)`."""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "append"
+        ):
+            yield node
+
+
+def _references_any_name(node, names):
+    return any(
+        isinstance(child, ast.Name) and child.id in names
+        for child in ast.walk(node)
+    )
+
+
+class CommandErrorDisclosureTests(unittest.TestCase):
+    def test_key_in_url_modules_do_not_post_exception_text(self):
+        offenders = []
+        for module in KEY_IN_URL_MODULES:
+            path = REPO_ROOT / "commands" / module / "command.py"
+            self.assertTrue(path.exists(), f"missing {path}")
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            caught = _names_bound_to_caught_exceptions(tree)
+            if not caught:
+                continue
+            for call in _messages_append_calls(tree):
+                if _references_any_name(call, caught):
+                    offenders.append(f"{module}/command.py:{call.lineno}")
+        self.assertEqual(
+            [],
+            offenders,
+            "A caught exception is interpolated into a channel message. For these "
+            "modules the API key is in the request URL, so the exception string "
+            "leaks it into the channel. Log it instead and post a flat, "
+            "credential-free line. Offenders: " + ", ".join(offenders),
+        )
+
+
+class DetectorTests(unittest.TestCase):
+    """The guard is only worth having if it detects the pattern it targets."""
+
+    def test_detects_exception_in_append(self):
+        src = (
+            "msgs = []\n"
+            "try:\n"
+            "    pass\n"
+            "except Exception as e:\n"
+            "    msgs.append({'text': 'boom %s' % str(e)})\n"
+        )
+        tree = ast.parse(src)
+        caught = _names_bound_to_caught_exceptions(tree)
+        hits = [c for c in _messages_append_calls(tree) if _references_any_name(c, caught)]
+        self.assertEqual(1, len(hits))
+
+    def test_ignores_flat_message(self):
+        src = (
+            "msgs = []\n"
+            "try:\n"
+            "    pass\n"
+            "except Exception:\n"
+            "    msgs.append({'text': 'the lookup failed'})\n"
+        )
+        tree = ast.parse(src)
+        caught = _names_bound_to_caught_exceptions(tree)
+        hits = [c for c in _messages_append_calls(tree) if _references_any_name(c, caught)]
+        self.assertEqual([], hits)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #285 (the credential-leak subset; see note at the bottom on the rest).

### The leak

`botscout`, `proxycheck` and `mwdb` build their request URL with the API key in the query string:

```python
apiurl += f"?key={settings.APIURL['proxycheck']['key']}"      # proxycheck
url    += f"&key={settings.APIURL['botscout']['key']}"        # botscout
```

…then on failure posted the exception straight into the channel:

```python
messages.append({'text': 'An error occurred in the ProxyCheck module:\nError: `%s`' % (str(e),)})
```

A `requests` `HTTPError` stringifies to include the URL — key and all. Proven with the module's exact line and its most common failure mode, a 401 from a wrong/expired key:

```
MESSAGE POSTED TO THE MATTERMOST CHANNEL:
------------------------------------------------------------
An error occurred in the ProxyCheck module:
Error: `401 Client Error: Unauthorized for url: https://proxycheck.io/v2/8.8.8.8?key=sk_live_REAL_API_KEY_9f3a2b`
------------------------------------------------------------
API key present in the channel message: True
```

Mattermost channels are widely readable and long-lived; this puts a live credential into that log.

### The fix

All three already call `log.exception(...)` on the line **above** the leak, so the full traceback is captured server-side no matter what. So the channel line was pure redundancy on top of a disclosure — drop the `str(e)` interpolation, post a flat credential-free line, keep the operator detail in the log:

```python
except Exception:
    log.exception("proxycheck module error")
    messages.append({'text': 'The ProxyCheck lookup failed; see the bot log for details.'})
```

Re-running the 401 harness against the new line: `key present: False`.

### Guard

`tests/test_command_error_disclosure.py` — a static AST check pinning these key-in-URL modules shut: their exception handler must not interpolate the caught exception into a `messages.append(...)`. Against the pre-fix tree it names all three (`botscout:77`, `proxycheck:157`, `mwdb:355`); the detector has its own tests. Full suite: 74 tests, OK.

### Scope — deliberately the leak only

~45 command modules interpolate `str(e)` into channel messages (the general noise problem in #285). This PR fixes the **3** where key-in-URL turns that noise into a *credential leak* — the urgent subset. The broader sweep (route error detail to the log across the rest, and the type-routing fix in #284 that stops most of these modules being called on the wrong input at all) is follow-up, not squeezed in here.