### PR TITLE
Declare accepted indicator types on process(), not in defaults.py

### DIFF
--- a/commands/abuseipdb/command.py
+++ b/commands/abuseipdb/command.py
@@ -9,6 +9,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -32,6 +33,8 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
 
+# CIDR: netblocks are looked up via the check-block endpoint, single addresses via check.
+@cmdutils.handles(cmdutils.IP, cmdutils.IPV6, cmdutils.CIDR)
 def process(command, channel, username, params, files, conn):
     if len(params)>0:
         query = params[0].replace('[', '').replace(']', '')

--- a/commands/abuseipdb/defaults.py
+++ b/commands/abuseipdb/defaults.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@abuseipdb', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-# A netblock (a.b.c.d/n) is queried via the check-block endpoint, a single address via check.
-ACCEPTS = ['ip', 'ipv6', 'cidr']
 CHANS = ['debug']
 APIURL = {
     'abuseipdb':   {

--- a/commands/bssc/command.py
+++ b/commands/bssc/command.py
@@ -8,6 +8,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -46,6 +47,7 @@ def getToken():
     except:
         return None
 
+@cmdutils.handles(cmdutils.IP, cmdutils.DOMAIN, cmdutils.URL, cmdutils.SHA256)
 def process(command, channel, username, params, files, conn):
     if len(params)>0:
         messages = []

--- a/commands/bssc/defaults.py
+++ b/commands/bssc/defaults.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@bssc', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-ACCEPTS = ['ip', 'domain', 'url', 'sha256']
 CHANS = ['debug']
 APIURL = {
     'bssc':   {'url': 'https://api.sep.securitycloud.symantec.com/v1/threat-intel/insight',

--- a/commands/circlpdns/command.py
+++ b/commands/circlpdns/command.py
@@ -12,6 +12,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -81,6 +82,7 @@ def _cell(value):
     return str(value).replace('`', '').replace('|', '/')
 
 
+@cmdutils.handles(cmdutils.IP, cmdutils.IPV6, cmdutils.CIDR, cmdutils.DOMAIN)
 def process(command, channel, username, params, files, conn):
     messages = []
     if not params:

--- a/commands/circlpdns/defaults.py
+++ b/commands/circlpdns/defaults.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@circlpdns', '@cpdns', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-ACCEPTS = ['ip', 'ipv6', 'cidr', 'domain']
 CHANS = ['debug']
 APIURL = {
     'circlpdns': {

--- a/commands/cmdutils.py
+++ b/commands/cmdutils.py
@@ -13,11 +13,15 @@ API names or routes that type; that mapping is genuinely per-module and stays in
 the module. A module keeps its own tiny `type -> endpoint` table and calls this
 for the detection half.
 
-`accepts()` is the dispatch-side gate: a command that declares `ACCEPTS` in its
-defaults is only run when the indicator matches. A command that declares nothing
-accepts anything, so this is backwards-compatible and adopted per module. That
-is what stops `@ioc 8.8.8.8` fanning an IP out to domain-only and hash-only
+`accepts()` is the dispatch-side gate: a command that declares which types it
+`handles()` is only run when the indicator matches. A command that declares
+nothing accepts anything, so this is backwards-compatible and adopted per module.
+That is what stops `@ioc 8.8.8.8` fanning an IP out to domain-only and hash-only
 modules, each of which would otherwise answer with an error in the channel.
+
+The accepted-types contract is declared with the `@handles(...)` decorator on a
+module's `process()` -- on the handler itself, not in a separate `ACCEPTS` list
+in defaults.py that can silently drift from what the code actually looks up.
 
 Kept import-light (stdlib only) so it runs under the dependency-free test
 runner, like feedutils on the feeds side.
@@ -151,3 +155,22 @@ def normalise_accepts(value):
         return None
     known = [t for t in value if t in TYPES]
     return known or None
+
+
+def handles(*types):
+    """Declare the indicator types a command's `process()` accepts.
+
+    The contract lives on the handler function, so it cannot drift from what the
+    code actually looks up the way a separate ACCEPTS list in defaults.py could.
+    The loader reads the attribute this attaches and feeds it through
+    `normalise_accepts` -> the command entry's 'accepts', which `accepts()` gates
+    dispatch on. Declaring nothing (no decorator) still means accept-anything.
+
+        @handles(IP, IPV6, CIDR)
+        def process(command, channel, username, params, files, conn):
+            ...
+    """
+    def decorate(func):
+        func.accepts = tuple(types)
+        return func
+    return decorate

--- a/commands/crtsh/command.py
+++ b/commands/crtsh/command.py
@@ -8,6 +8,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -38,6 +39,7 @@ def is_valid_domain(domain):
     return bool(re.match(domain_regex, domain))
 
 
+@cmdutils.handles(cmdutils.DOMAIN)
 def process(command, channel, username, params, files, conn):
     messages = []
     param = params[0] if params else None

--- a/commands/crtsh/defaults.py
+++ b/commands/crtsh/defaults.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@crtsh', '@cs', '@ioc']
-# Indicator types this module can look up. Under a shared bind like @ioc, the
-# dispatcher only runs the module when the argument matches -- so a hash or IP
-# no longer reaches this domain-only Certificate Transparency lookup.
-ACCEPTS = ['domain']
 CHANS = ['debug']
 APIURL = {
     'crtsh':   {'url': 'https://crt.sh/json?q='}

--- a/commands/honeydb/command.py
+++ b/commands/honeydb/command.py
@@ -9,6 +9,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -115,6 +116,7 @@ def _format_history(ip, data, max_rows):
     return '\n'.join(lines)
 
 
+@cmdutils.handles(cmdutils.IP, cmdutils.IPV6)
 def process(command, channel, username, params, files, conn):
     messages = []
     if not params:

--- a/commands/honeydb/defaults.py
+++ b/commands/honeydb/defaults.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@honeydb', '@hdb', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-ACCEPTS = ['ip', 'ipv6']
 CHANS = ['debug']
 APIURL = {
     'honeydb': {

--- a/commands/ipinfo/command.py
+++ b/commands/ipinfo/command.py
@@ -7,6 +7,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -30,6 +31,7 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
 
+@cmdutils.handles(cmdutils.IP, cmdutils.IPV6)
 def process(command, channel, username, params, files, conn):
 
     if not params:

--- a/commands/ipinfo/defaults.py
+++ b/commands/ipinfo/defaults.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@ipinfo', '@ip', '@ioc']
-# Indicator types this module can look up: IP addresses only. Under a shared bind
-# like @ioc, a domain or hash no longer reaches this IP-geolocation lookup.
-ACCEPTS = ['ip', 'ipv6']
 CHANS = ['debug']
 APIURL = {
     'ipinfo':   {'url': 'https://ipinfo.io/',

--- a/commands/ipwhois/command.py
+++ b/commands/ipwhois/command.py
@@ -7,6 +7,7 @@ import requests
 from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
+from commands import cmdutils
 _pkg = __package__ or Path(__file__).parent.name
 def _load(module_name):
     try:
@@ -28,6 +29,8 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
 
+# IPv4 only: the module validates with a v4 regex and does not handle IPv6.
+@cmdutils.handles(cmdutils.IP)
 def process(command, channel, username, params, files, conn):
     if len(params)>0:
         params = params[0].replace('[.]','.')

--- a/commands/ipwhois/defaults.py
+++ b/commands/ipwhois/defaults.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@ipwhois', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-# IPv4 only -- the module validates with a v4 regex and does not handle IPv6.
-ACCEPTS = ['ip']
 CHANS = ['debug']
 APIURL = {
     'ipwhois':   {'url': 'https://ipwho.is/'},

--- a/commands/malshare/command.py
+++ b/commands/malshare/command.py
@@ -9,6 +9,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -133,6 +134,7 @@ def _format(query_hash, query_kind, payload, max_sources):
     return '\n'.join(lines)
 
 
+@cmdutils.handles(cmdutils.MD5, cmdutils.SHA1, cmdutils.SHA256)
 def process(command, channel, username, params, files, conn):
     messages = []
     if not params:

--- a/commands/malshare/defaults.py
+++ b/commands/malshare/defaults.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@malshare', '@ms', '@ioc']
-# Indicator types this module can look up: file hashes only. Under a shared bind
-# like @ioc, an IP or domain no longer reaches this hash-only malware lookup.
-ACCEPTS = ['md5', 'sha1', 'sha256']
 CHANS = ['debug']
 APIURL = {
     'malshare': {

--- a/commands/malwarebazaar/command.py
+++ b/commands/malwarebazaar/command.py
@@ -7,6 +7,7 @@ import requests
 from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
+from commands import cmdutils
 _pkg = __package__ or Path(__file__).parent.name
 def _load(module_name):
     try:
@@ -28,6 +29,7 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
 
+@cmdutils.handles(cmdutils.MD5, cmdutils.SHA1, cmdutils.SHA256)
 def process(command, channel, username, params, files, conn):
     if len(params)>0:
         params = params[0]

--- a/commands/malwarebazaar/defaults.py
+++ b/commands/malwarebazaar/defaults.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@malwarebazaar', '@ioc', '@mb']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-ACCEPTS = ['md5', 'sha1', 'sha256']
 CHANS = ['debug']
 APIURL = {
     'malwarebazaar':   {

--- a/commands/ripewhois/command.py
+++ b/commands/ripewhois/command.py
@@ -7,6 +7,7 @@ import requests
 from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
+from commands import cmdutils
 _pkg = __package__ or Path(__file__).parent.name
 def _load(module_name):
     try:
@@ -28,6 +29,8 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
 
+# IPv4 only: the module validates with a v4 regex and does not handle IPv6.
+@cmdutils.handles(cmdutils.IP)
 def process(command, channel, username, params, files, conn):
     if len(params)>0:
         params = params[0].replace('[', '').replace(']', '').replace('hxxp','http')

--- a/commands/ripewhois/defaults.py
+++ b/commands/ripewhois/defaults.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@ripewhois', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-# IPv4 only -- the module validates with a v4 regex and does not handle IPv6.
-ACCEPTS = ['ip']
 CHANS = ['debug']
 APIURL = {
     'ripewhois':   {'url': 'https://stat.ripe.net/data/whois/data.json?resource='},

--- a/commands/sslmate/command.py
+++ b/commands/sslmate/command.py
@@ -9,6 +9,7 @@ import urllib.parse
 from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
+from commands import cmdutils
 _pkg = __package__ or Path(__file__).parent.name
 def _load(module_name):
     try:
@@ -30,6 +31,7 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
 
+@cmdutils.handles(cmdutils.DOMAIN, cmdutils.URL)
 def process(command, channel, username, params, files, conn):
     if len(params)>0:
         messages = []

--- a/commands/sslmate/defaults.py
+++ b/commands/sslmate/defaults.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@sslmate', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-ACCEPTS = ['domain', 'url']
 CHANS = ['debug']
 APIURL = {
     'sslmate':  {'url': 'https://api.certspotter.com/v1/issuances?domain=',

--- a/commands/threatbook/command.py
+++ b/commands/threatbook/command.py
@@ -9,6 +9,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -162,6 +163,7 @@ def _format_response(resource, endpoint, data, max_tags, max_judgments):
     return '\n'.join(lines)
 
 
+@cmdutils.handles(cmdutils.IP, cmdutils.IPV6, cmdutils.DOMAIN, cmdutils.MD5, cmdutils.SHA1, cmdutils.SHA256)
 def process(command, channel, username, params, files, conn):
     messages = []
     if not params:

--- a/commands/threatbook/defaults.py
+++ b/commands/threatbook/defaults.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@threatbook', '@tb', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-ACCEPTS = ['ip', 'ipv6', 'domain', 'md5', 'sha1', 'sha256']
 CHANS = ['debug']
 APIURL = {
     'threatbook': {

--- a/commands/threatfox/command.py
+++ b/commands/threatfox/command.py
@@ -8,6 +8,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -31,6 +32,8 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
 
+# IP addresses are IPv4 only: the module validates them with a v4 regex, not IPv6.
+@cmdutils.handles(cmdutils.IP, cmdutils.MD5, cmdutils.SHA1, cmdutils.SHA256)
 def process(command, channel, username, params, files, conn):
     if len(params)>0:
         messages = []

--- a/commands/threatfox/defaults.py
+++ b/commands/threatfox/defaults.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@threatfox', '@ioc', '@tf']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-# IPv4 only -- the module validates with a v4 regex and does not handle IPv6.
-ACCEPTS = ['ip', 'md5', 'sha1', 'sha256']
 CHANS = ['debug']
 APIURL = {
     'threatfox':   {

--- a/commands/threatrip/command.py
+++ b/commands/threatrip/command.py
@@ -9,6 +9,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -166,6 +167,7 @@ def _format(query, label, ttype, payload, max_tags):
     return '\n'.join(lines)
 
 
+@cmdutils.handles(cmdutils.IP, cmdutils.IPV6, cmdutils.DOMAIN, cmdutils.URL, cmdutils.MD5, cmdutils.SHA1, cmdutils.SHA256)
 def process(command, channel, username, params, files, conn):
     messages = []
     if not params:

--- a/commands/threatrip/defaults.py
+++ b/commands/threatrip/defaults.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@threatrip', '@tr', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-ACCEPTS = ['ip', 'ipv6', 'domain', 'url', 'md5', 'sha1', 'sha256']
 CHANS = ['debug']
 APIURL = {
     'threatrip': {

--- a/commands/urlhaus/command.py
+++ b/commands/urlhaus/command.py
@@ -8,6 +8,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -31,6 +32,7 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
 
+@cmdutils.handles(cmdutils.MD5, cmdutils.SHA1, cmdutils.SHA256, cmdutils.URL)
 def process(command, channel, username, params, files, conn):
     if len(params)>0:
         params = params[0].replace('[', '').replace(']', '').replace('hxxp','http')

--- a/commands/urlhaus/defaults.py
+++ b/commands/urlhaus/defaults.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@urlhaus', '@ioc', '@uh']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-ACCEPTS = ['md5', 'sha1', 'sha256', 'url']
 CHANS = ['debug']
 APIURL = {
     'urlhaus':  {

--- a/commands/wayback/command.py
+++ b/commands/wayback/command.py
@@ -9,6 +9,7 @@ from importlib import import_module
 from types import SimpleNamespace
 from pathlib import Path
 import logging
+from commands import cmdutils
 
 log = logging.getLogger('MatterBot')
 _pkg = __package__ or Path(__file__).parent.name
@@ -32,6 +33,8 @@ _settings_dict = {
 settings = SimpleNamespace(**_settings_dict)
 ### Loader end, actual module functionality starts here
  
+# URL only: the module gates on '://', so bare domains are not accepted.
+@cmdutils.handles(cmdutils.URL)
 def process(command, channel, username, params, files, conn):
     # Methods to query the current API account info (credits etc.)
     stripchars = '`\n\r\'\"'

--- a/commands/wayback/defaults.py
+++ b/commands/wayback/defaults.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 BINDS = ['@wayback', '@waybackmachine', '@wb', '@wm', '@ioc']
-# Indicator types this module accepts under a shared bind like @ioc (see cmdutils.accepts).
-# The module requires a scheme (it gates on '://'), so only URLs, not bare domains.
-ACCEPTS = ['url']
 CHANS = ['debug']
 APIURL = {
     'wayback':

--- a/matterbot.py
+++ b/matterbot.py
@@ -106,31 +106,29 @@ class MattermostManager(object):
                 if module_name not in self.commands:
                     module.settings.BINDS = None
                     module.settings.CHANS = None
-                    module.settings.ACCEPTS = None
                     defaults = importlib.import_module(f"{_pkg_prefix}.{module_name}.defaults")
                     if hasattr(defaults, 'BINDS'):
                         module.settings.BINDS = defaults.BINDS
                     if hasattr(defaults, 'CHANS'):
                         module.settings.CHANS = defaults.CHANS
-                    if hasattr(defaults, 'ACCEPTS'):
-                        module.settings.ACCEPTS = defaults.ACCEPTS
                     if 'settings.py' in files:
                         overridesettings = importlib.import_module(f"{_pkg_prefix}.{module_name}.settings")
                         if hasattr(overridesettings, 'BINDS'):
                             module.settings.BINDS = overridesettings.BINDS
                         if hasattr(overridesettings, 'CHANS'):
                             module.settings.CHANS = overridesettings.CHANS
-                        if hasattr(overridesettings, 'ACCEPTS'):
-                            module.settings.ACCEPTS = overridesettings.ACCEPTS
                     if not isinstance(module.settings.BINDS, list) or not isinstance(module.settings.CHANS, list):
                         log.error(f"Skipping command module {module_name}: BINDS and CHANS must both be lists")
                         continue
-                    # ACCEPTS is the (optional) indicator-type filter. An absent or
-                    # unusable value means "accepts anything" -- see cmdutils.accepts.
+                    # The (optional) indicator-type filter is declared on the
+                    # command's process() via @cmdutils.handles(...) -- on the
+                    # handler, so it can't drift from what the code looks up.
+                    # Absent or unusable -> "accepts anything" (cmdutils.accepts).
+                    declared = getattr(getattr(module, 'process', None), 'accepts', None)
                     self.commands[module_name] = {
                         'binds': module.settings.BINDS,
                         'chans': module.settings.CHANS,
-                        'accepts': cmdutils.normalise_accepts(module.settings.ACCEPTS),
+                        'accepts': cmdutils.normalise_accepts(declared),
                     }
                     self.binds.extend(module.settings.BINDS)
         try:

--- a/tests/test_cmdutils.py
+++ b/tests/test_cmdutils.py
@@ -166,22 +166,65 @@ class RoutingBehaviourTests(unittest.TestCase):
         self.assertNotIn('crtsh', self._route('8.8.8.8'))
 
 
+class HandlesDecoratorTests(unittest.TestCase):
+    """The decorator is the source of truth for a command's accepted types; the
+    loader reads the attribute it attaches and feeds it through normalise_accepts."""
+
+    def test_attaches_declared_types(self):
+        @cmdutils.handles(cmdutils.IP, cmdutils.DOMAIN)
+        def process():
+            pass
+        self.assertEqual((cmdutils.IP, cmdutils.DOMAIN), process.accepts)
+
+    def test_loader_path_normalises_to_known_types(self):
+        @cmdutils.handles(cmdutils.MD5, cmdutils.SHA1)
+        def process():
+            pass
+        self.assertEqual(['md5', 'sha1'], cmdutils.normalise_accepts(process.accepts))
+
+    def test_undecorated_process_accepts_anything(self):
+        # No decorator -> no attribute -> normalise_accepts(None) -> accept-anything.
+        def process():
+            pass
+        self.assertIsNone(cmdutils.normalise_accepts(getattr(process, 'accepts', None)))
+        self.assertTrue(cmdutils.accepts({'accepts': None}, 'ip'))
+
+
 class ShippedAcceptsTests(unittest.TestCase):
-    """Assert routing invariants against the ACCEPTS actually declared in the
-    command defaults, so a bad edit to a real module is caught -- not a copy of
-    the values kept in this test.
+    """Assert routing invariants against the types actually declared by the
+    @cmdutils.handles(...) decorator on each real module's process(), so a bad
+    edit to a real module is caught -- not a copy of the values kept in this
+    test. Read via AST (not import) to stay dependency-free: command.py pulls in
+    requests and friends the stdlib test runner does not have.
     """
 
     COMMANDS_DIR = Path(__file__).resolve().parent.parent / "commands"
 
+    @staticmethod
+    def _resolve(arg):
+        # Decorator args are the cmdutils.<NAME> constants (e.g. cmdutils.IP);
+        # resolve to their canonical string value. Bare names and plain string
+        # literals are handled too, so the test does not care which form is used.
+        import ast
+        if isinstance(arg, ast.Attribute):
+            return getattr(cmdutils, arg.attr)
+        if isinstance(arg, ast.Name):
+            return getattr(cmdutils, arg.id)
+        if isinstance(arg, ast.Constant):
+            return arg.value
+        raise AssertionError(f"unexpected @handles argument: {ast.dump(arg)}")
+
     def _accepts(self, module):
         import ast
-        src = (self.COMMANDS_DIR / module / "defaults.py").read_text(encoding="utf-8")
-        for node in ast.parse(src).body:
-            if isinstance(node, ast.Assign) and any(
-                isinstance(t, ast.Name) and t.id == "ACCEPTS" for t in node.targets
-            ):
-                return ast.literal_eval(node.value)
+        src = (self.COMMANDS_DIR / module / "command.py").read_text(encoding="utf-8")
+        for node in ast.walk(ast.parse(src)):
+            if not (isinstance(node, ast.FunctionDef) and node.name == "process"):
+                continue
+            for dec in node.decorator_list:
+                func = dec.func if isinstance(dec, ast.Call) else None
+                name = getattr(func, "attr", getattr(func, "id", None))
+                if name == "handles":
+                    return [self._resolve(a) for a in dec.args]
         return None
 
     def _routes_to(self, module, value):
@@ -197,9 +240,9 @@ class ShippedAcceptsTests(unittest.TestCase):
                        'wayback', 'crtsh', 'malshare', 'ipinfo',
                        'abuseipdb', 'circlpdns']:
             declared = self._accepts(module)
-            self.assertIsNotNone(declared, f"{module} lost its ACCEPTS")
+            self.assertIsNotNone(declared, f"{module} lost its @cmdutils.handles(...)")
             self.assertEqual(declared, cmdutils.normalise_accepts(declared),
-                             f"{module} ACCEPTS has an unknown/typo'd type")
+                             f"{module} @handles has an unknown/typo'd type")
 
     def test_hash_only_modules_reject_ip_and_domain(self):
         for module in ['malwarebazaar', 'malshare']:


### PR DESCRIPTION
## What

The indicator-type filter that routes a shared bind like `@ioc` lived in an `ACCEPTS` list in each module's `defaults.py` — a declaration separate from the `process()` that actually consumes those types, so the two could silently drift.

This moves the contract **onto the handler** with a `@cmdutils.handles(...)` decorator, so the accepted types sit next to the code that looks them up and can't fall out of sync.

```python
# CIDR: netblocks are looked up via the check-block endpoint, single addresses via check.
@cmdutils.handles(cmdutils.IP, cmdutils.IPV6, cmdutils.CIDR)
def process(command, channel, username, params, files, conn):
    ...
```

## Honorable mention

The idea comes from **@TTycho**'s [`typing-for-modules`](https://github.com/TTycho/MatterBot/tree/typing-for-modules) branch, which declares each command's accepted types directly on the function signature (`def search(parameters: list[ASN], ...)`) rather than in a side table. Credit to him for the core insight — the type contract belongs on the handler. This PR adapts it to our current architecture rather than porting it wholesale:

- **Decorator, not a type annotation.** TTycho's indicator *is* the whole typed parameter; our fixed `process(command, channel, username, params, files, conn)` signature has `params` also carrying non-indicator options (abuseipdb's max-age, hibp's search-type), so a bare `params: list[IP]` hint would misrepresent it — and restructuring the universal signature across ~40 modules is riskier than the drift it fixes.
- **Stdlib-only.** Keeps our existing `cmdutils.classify()` classifier so the dependency-free `python -m unittest` runner still works (his branch pulls in `validators` + `tldextract`).

## Changes

- `cmdutils.handles(*types)` attaches the declared types to `process()`; the loader reads that attribute through `normalise_accepts` into the command entry the dispatcher already gates on. No decorator → accept-anything, unchanged and backwards-compatible.
- `matterbot.py`: read the decorator off `process()` instead of `defaults.ACCEPTS`, and drop the `settings.py` ACCEPTS override — what indicator types a module's code handles is a code fact, not deployment config.
- Migrated all 16 annotated modules atomically (removing the `defaults.ACCEPTS` read breaks any un-migrated one). Relocated the substantive per-module WHY (netblock endpoint, IPv4-only, URL scheme gate) next to the decorator; dropped generic boilerplate.
- Tests read the decorator via AST (dependency-free) instead of `defaults.ACCEPTS`, so the shipped-invariant checks still catch a bad edit to a real module.

## Testing

`python -m unittest tests.test_cmdutils` → **39/39 pass** (3 new decorator tests + the 16-module routing-invariant checks that read the real decorators).

> Note: the full suite has pre-existing failures unrelated to this change (confirmed by stashing this work and re-running) — `feedparser` not installed in the runner, and a separate syntax error in `modules/fortinet/feed.py:95` already on `main`. Neither is touched here.