### PR TITLE
fortinet: repair query() mangled by a bad merge (syntax error on main)

### DIFF
--- a/modules/fortinet/feed.py
+++ b/modules/fortinet/feed.py
@@ -71,27 +71,6 @@ def query(settings=None):
     items = []
     errors = []
     for URL in settings.URLS:
-        feed = feedparser.parse(str(URL), agent='MatterBot RSS Automation 1.0')
-        count = 0
-        stripchars = '`\\[\\]\'\"'
-        regex = re.compile('[%s]' % stripchars)
-        while count < settings.ENTRIES:
-            try:
-                title = feed.entries[count].title
-                link = feed.entries[count].link
-                content = None
-                if settings.FILTER:
-                    THRESHOLD = importScore()
-                    matches = checkPage(link)
-                    filtered = False
-                    if not matches:
-                        cvss = False
-                        filtered = True
-                    else:
-                        if isinstance(matches, tuple): # Filter for return values from checkPage()
-                            cvss = matches[1]
-                            if float(cvss) >= THRESHOLD:
-                                filtered = True
         try:
             feed = feedparser.parse(str(URL), agent='MatterBot RSS Automation 1.0')
             count = 0
@@ -101,6 +80,7 @@ def query(settings=None):
                 try:
                     title = feed.entries[count].title
                     link = feed.entries[count].link
+                    content = None
                     if settings.FILTER:
                         THRESHOLD = importScore()
                         matches = checkPage(link)
@@ -113,27 +93,6 @@ def query(settings=None):
                                 cvss = matches[1]
                                 if float(cvss) >= THRESHOLD:
                                     filtered = True
-                    if filtered:
-                        content = settings.NAME + ': [' + title
-                        if cvss:
-                            content += f' - CVSS: `{cvss}`'
-                        content += '](' + link + ')'
-                else:
-                    content = settings.NAME + ': [' + title + '](' + link + ')'
-                if content is None: # Entry did not pass the filter: skip it. Never fall through -- content
-                    count+=1        # still holds the *previous* entry, which would be posted a second time.
-                    continue
-                if len(feed.entries[count].description):
-                    description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
-                    if len(description)>400:
-                        description = description[:396]+' ...'
-                    content += '\n>'+description+'\n'
-                for channel in settings.CHANNELS:
-                    items.append([channel, content])
-                count+=1
-            except IndexError:
-                return items # No more items
-    return items
                             else:
                                 for score in matches:
                                     if float(score.text.strip()) >= THRESHOLD: # Check if CVSS score meets threshold
@@ -146,6 +105,9 @@ def query(settings=None):
                             content += '](' + link + ')'
                     else:
                         content = settings.NAME + ': [' + title + '](' + link + ')'
+                    if content is None: # Entry did not pass the filter: skip it. Never fall through -- content
+                        count+=1        # still holds the *previous* entry, which would be posted a second time.
+                        continue
                     if len(feed.entries[count].description):
                         description = regex.sub('',bs4.BeautifulSoup(feed.entries[count].description,'lxml').get_text("\n")).strip().replace('\n','. ')
                         if len(description)>400:


### PR DESCRIPTION
## Problem

`modules/fortinet/feed.py` does not parse on `main` — a `try:` at line 95 has no matching `except`/`finally`:

```
File ".../modules/fortinet/feed.py", line 95
    try:
SyntaxError: expected 'except' or 'finally' block
```

Merge `c89c607` ("Merge branch 'main' into fix/268-fortinet-unfiltered-content") stacked **three overlapping copies** of the `query()` loop body on top of each other. The file has not parsed since, so `test_feed_contracts`, `test_module_contracts` and every test importing the module fail — the **`stdlib unittest` check is red on every PR against `main`**, not just one.

## Fix

Reconstructed from the last revision that parsed (`c76c439`) by re-applying **only** the intended FeedResult error-contract changes, matching the sibling multi-source modules migrated in `c7acb1a`:

- `import feedutils`; collect per-source errors in `errors`
- wrap each URL in `try/except` → `errors.append((URL, str(e))); continue`
- `content = None` guard so an entry that fails the CVSS filter is skipped, not posted with the *previous* entry's content
- `break` (not `return`) on `IndexError`, so the remaining URLs are still processed
- `return feedutils.result(items, errors)`

The diff against `c76c439` is exactly those changes and nothing else.

## Testing

`python -m unittest tests.test_feed_contracts tests.test_module_contracts tests.test_import_path_safety` → **21/21 pass** (were erroring on the parse failure). File byte-compiles.