### PR TITLE
tests: consume fortinet query() as a FeedResult (fix red main)

### DIFF
--- a/tests/test_fortinet_filter.py
+++ b/tests/test_fortinet_filter.py
@@ -41,6 +41,13 @@ def _load_fortinet():
         Session=lambda *a, **kw: None,
         exceptions=types.SimpleNamespace(RequestException=Exception),
     )
+    # feed.py imports its sibling `feedutils` (a real module, not stubbed), so
+    # modules/ must be importable. Add it here rather than relying on an earlier
+    # test in the discovery order having put it on the path -- this test must run
+    # in isolation too.
+    modules_dir = str(FEED_PY.parent.parent)
+    if modules_dir not in sys.path:
+        sys.path.insert(0, modules_dir)
     spec = importlib.util.spec_from_file_location("fortinet_feed_under_test", FEED_PY)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -79,10 +86,18 @@ class FortinetFilterTests(unittest.TestCase):
         }
 
     def _run(self, entries, scores):
-        """Run query() over `entries`, with checkPage() returning scores[link]."""
+        """Run query() over `entries`, with checkPage() returning scores[link].
+
+        fortinet is a multi-source module, so query() returns a FeedResult
+        (posts + per-source errors), not a bare list. Unwrap to the posts the
+        assertions below read -- via the same split_result() the main loop uses.
+        """
         self.fortinet.feedparser.parse = lambda *a, **kw: _Feed(entries)
         self.fortinet.checkPage = lambda link: scores[link]
-        return self.fortinet.query(dict(self.settings))
+        items, _errors = self.fortinet.feedutils.split_result(
+            self.fortinet.query(dict(self.settings))
+        )
+        return items
 
     def test_below_threshold_entry_is_not_posted(self):
         entries = [_Entry("Low severity", "https://example.invalid/low")]


### PR DESCRIPTION
## Problem

`main` is currently **red** on the `stdlib unittest` check — `test_fortinet_filter` fails:

```
AssertionError: 1 != 2 : expected only the high-CVSS entry, got
  FeedResult(items=[['news', 'Fortinet: [Critical bug - CVSS: `9.8`]...']], errors=[])
```

Two latent problems, both surfaced once #290 made `modules/fortinet/feed.py` parse again (the tests couldn't run at all before, so this was never caught):

1. **FeedResult return.** The FeedResult migration (`c7acb1a`) converted fortinet's `query()` to return `feedutils.result(items, errors)` but never updated this test, which still consumed the return value as a bare list. `len()` on the `FeedResult` namedtuple counts its two fields (`items`, `errors`) → `2`, not the number of posts, so every assertion was off.
2. **Test isolation.** `feed.py` imports its sibling `feedutils`; the test exec-loads `feed.py` by file path, so `modules/` is only importable if an earlier test in the discovery order happened to put it on `sys.path`. Run alone, it errored with `ModuleNotFoundError: feedutils`.

## Fix

Test-only:
- Unwrap the return via `feedutils.split_result()` — the same boundary the main loop uses.
- Add `modules/` to `sys.path` in `_load_fortinet()` so the test runs standalone as well as under discovery.

**No production code change.** fortinet returning a `FeedResult` is correct — it's one of the 16 multi-source modules migrated in `c7acb1a`; the test had simply never been run against that contract.

## Testing

`python -m unittest tests.test_fortinet_filter` → **4/4 pass** in isolation; `tests.test_fortinet_filter tests.test_feed_contracts tests.test_module_contracts` → **20/20**.

Follow-up to #290.